### PR TITLE
Small tweaks to Junction tests

### DIFF
--- a/pages/junction/api_academics_roster_page.rb
+++ b/pages/junction/api_academics_roster_page.rb
@@ -44,6 +44,10 @@ class ApiAcademicsRosterPage
     names.sort
   end
 
+  def all_student_uids
+    (enrolled_students + waitlisted_students).map { |student| student['id'] }
+  end
+
   def student_ids(students)
     students.map { |student| student['student_id'] }
   end

--- a/spec/junction/canvas_lti_course_site_creation_spec.rb
+++ b/spec/junction/canvas_lti_course_site_creation_spec.rb
@@ -237,7 +237,14 @@ describe 'bCourses course site creation' do
                                       {:role => 'Teacher', :count => expected_teacher_count}, {:role => 'Lead TA', :count => expected_lead_ta_count},
                                       {:role => 'TA', :count => expected_ta_count}]
         actual_enrollment_counts = @canvas_page.wait_for_enrollment_import(site[:course], ['Student', 'Waitlist Student', 'Teacher', 'Lead TA', 'TA'])
-        it("results in the right course site membership for #{site[:course].term} #{site[:course].code} site ID #{site[:course].site_id}") { expect(actual_enrollment_counts).to eql(expected_enrollment_counts) }
+
+        actual_student_uids = @canvas_page.get_students(site[:course]).map(&:uid).sort
+        expected_student_uids = site[:roster_data].all_student_uids.sort
+        logger.warn "Student UIDs expected but not present: #{expected_student_uids - actual_student_uids}"
+        logger.warn "Student UIDs present but not expected: #{actual_student_uids - expected_student_uids}"
+
+        it("results in the right course site membership counts for #{site[:course].term} #{site[:course].code} site ID #{site[:course].site_id}") { expect(actual_enrollment_counts).to eql(expected_enrollment_counts) }
+        it("results in the right student enrollments for #{site[:course].term} #{site[:course].code} site ID #{site[:course].site_id}") { expect(actual_student_uids).to eql(expected_student_uids) }
 
         # ROSTER PHOTOS - check that roster photos tool shows the right sections
 

--- a/spec/junction/canvas_lti_e_grades_api_spec.rb
+++ b/spec/junction/canvas_lti_e_grades_api_spec.rb
@@ -9,6 +9,9 @@ describe 'bCourses E-Grades Export' do
     test_courses_data = JunctionUtils.load_junction_test_course_data.select { |course| course['tests']['e_grades_api'] }
     courses = test_courses_data.map { |c| Course.new c }
 
+    # If using Chrome, use a new Chrome profile
+    Utils.config['webdriver']['chrome_profile'] = false
+
     @driver = Utils.launch_browser
     @cal_net = Page::CalNetPage.new @driver
     @canvas = Page::CanvasGradesPage.new @driver


### PR DESCRIPTION
- If course site student enrollment doesn't match expectations, log the mismatching UIDs
- Use a new Chrome profile for E-Grades tests, since the E-Grades Export button won't appear without a hard refresh if Canvas/Junction environments have been switched around