### PR TITLE
BOAC-2180, service-announcement textarea converted to ckEditor textbox

### DIFF
--- a/pages/boac/boac_admin_page.rb
+++ b/pages/boac/boac_admin_page.rb
@@ -12,7 +12,7 @@ class BOACAdminPage
   h2(:status_heading, :id => 'system-status-header')
   h2(:dept_users_section, :id => 'dept-users-section')
   h2(:edit_service_announcement, :id => 'edit-service-announcement')
-  text_area(:update_service_announcement_input, id: 'textarea-update-service-announcement')
+  elements(:update_service_announcement, :text_area, xpath: '//div[@role="textbox"]')
   button(:update_service_announcement_button, id: 'button-update-service-announcement')
   span(:service_announcement_banner, id: 'service-announcement-banner')
   span(:service_announcement_checkbox_label, id: 'checkbox-service-announcement-label')
@@ -59,8 +59,8 @@ class BOACAdminPage
   # Updates service announcement without touching the 'Post' checkbox
   # @param announcement [String]
   def update_service_announcement(announcement)
-    wait_for_element_and_type(update_service_announcement_input_element, '')
-    wait_for_element_and_type(update_service_announcement_input_element, announcement)
+    service_announcement_textbox = update_service_announcement_elements[0]
+    wait_for_textbox_and_type(service_announcement_textbox, announcement, 200)
     wait_for_update_and_click update_service_announcement_button_element
   end
 

--- a/pages/page.rb
+++ b/pages/page.rb
@@ -126,6 +126,20 @@ module Page
     element.send_keys text
   end
 
+  # Awaits a textbox element, clicks it, removes existing text, and sends new text.
+  # @param element [PageObject::Elements::Element]
+  # @param text [String]
+  def wait_for_textbox_and_type(element, text, max_input_length)
+    wait_for_update_and_click element
+    sleep Utils.click_wait
+    count = 0
+    begin
+      element.clear
+      count += 1
+    end while element.text.length > 0 && count < max_input_length
+    element.send_keys text
+  end
+
   # Awaits an element for a short time, clicks it using JavaScript, removes existing text, and sends new text. Intended for placing text
   # in input or textarea elements.
   # @param element [PageObject::Elements::Element]

--- a/spec/boac/boac_user_role_admin_spec.rb
+++ b/spec/boac/boac_user_role_admin_spec.rb
@@ -135,8 +135,13 @@ describe 'An admin using BOAC' do
       @admin_page.load_page
       @admin_page.unpost_service_announcement
       expect(@admin_page.is_service_announcement_posted?).to be false
-
-      announcement = "Sentimental gentle wind, blowing through my life again (#{test.id})"
+      lyrics = [
+          'We are all of us in the gutter but some of us are looking at the stars',
+          'Sentimental gentle wind, blowing through my life again',
+          'For this is the season of catching the vapors',
+          'Your hair is beautiful. Tonight, make it magnificent!'
+      ]
+      announcement = "#{lyrics[rand(0..3)]} (#{test.id})"
       @admin_page.update_service_announcement(announcement)
 
       # Verify announcement has not been posted


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2180

This can be merged after https://github.com/ets-berkeley-edu/boac/pull/1552 is merged.

The textbox was tricky to 'clear'.