### PR TITLE
QA workaround for Chrome 75 issue

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -7,6 +7,7 @@ webdriver:
   headless: false
   chrome_profile: true
   chrome_optional_profile: false
+  w3c: false
 
 timeouts:
   click_wait: 0.5

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -62,6 +62,8 @@ class Utils
           profile_dir = (profile ? profile : File.join(@config_dir, 'chrome-profile'))
           options.add_argument("user-data-dir=#{profile_dir}")
         end
+        # Works around Chrome 75 'UnknownCommandError' issue.
+        options.add_option('w3c', @config['webdriver']['w3c'])
         options.add_argument 'headless' if headless?
         prefs = {
             :prompt_for_download => false,


### PR DESCRIPTION
https://stackoverflow.com/questions/56111529/cannot-call-non-w3c-standard-command-while-in-w3c-mode-seleniumwebdrivererr