### PR TITLE
BOAC-2287 / BOAC-2275, verify student count when batch note create

### DIFF
--- a/pages/boac/boac_student_page_advising_note.rb
+++ b/pages/boac/boac_student_page_advising_note.rb
@@ -100,7 +100,7 @@ module BOACStudentPageAdvisingNote
   # @param note_subject [String]
   def expand_note_by_subject(note_subject)
     note_el = span_element(xpath: "//span[text()=\"#{note_subject}\"]/..")
-    wait_for_update_and_click_js note_el
+    wait_for_update_and_click note_el
   end
 
   # Collapses a note unless it's already collapsed
@@ -343,7 +343,9 @@ module BOACStudentPageAdvisingNote
     new_note_subject_input_element.when_not_visible Utils.short_wait
     id = ''
     start_time = Time.now
-    wait_until(15) { (id = BOACUtils.get_note_id_by_subject note) }
+    wait_until(15) do
+      id, note.id = BOACUtils.get_note_ids_by_subject(note.subject).first
+    end
     logger.debug "Note ID is #{id}"
     logger.warn "Note was created in #{Time.now - start_time} seconds"
     note.created_date = note.updated_date = Time.now
@@ -408,6 +410,15 @@ module BOACStudentPageAdvisingNote
   end
 
   #### CREATE NOTE, STUDENT PROFILE ####
+
+  button(:new_note_button, id: 'new-note-button')
+  button(:new_note_minimize_button, id: 'minimize-new-note-modal')
+
+  # Clicks the new note button
+  def click_create_new_note
+    logger.debug 'Clicking the New Note button'
+    wait_for_update_and_click new_note_button_element
+  end
 
   # Combines methods to create a note with subject, body, attachments, topics, ID, and created/updated dates
   # @param note [Note]

--- a/settings.yml
+++ b/settings.yml
@@ -67,6 +67,9 @@ boac:
   legacy_notes_max_users: 5
   no_activity_alert_threshold: 14
   notes_search_word_count: 7
+  notes_batch_curated_group_count: 2
+  notes_batch_students_count: 3
+  notes_batch_students_per_group_count: 3
   sis_data_max_users: 100
   search_max_users: 20
   service_announcement: 'A service announcement'

--- a/util/boac_utils.rb
+++ b/util/boac_utils.rb
@@ -328,11 +328,11 @@ class BOACUtils < Utils
   end
 
   # Given a note subject, sets and returns the first matching note ID. The subject must be unique for this to be useful.
-  # @param note [Note]
-  # @return [Integer]
-  def self.get_note_id_by_subject(note)
-    query = "SELECT * FROM notes WHERE subject = '#{note.subject}';"
-    note.id = Utils.query_pg_db_field(boac_db_credentials, query, 'id').first
+  # @param note_subject [String]
+  # @return [Array<Integer>]
+  def self.get_note_ids_by_subject(note_subject)
+    query = "SELECT id FROM notes WHERE subject = '#{note_subject}';"
+    Utils.query_pg_db_field(boac_db_credentials, query, 'id')
   end
 
   # Sets and returns the deleted date for a given note


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2287
https://jira.ets.berkeley.edu/jira/browse/BOAC-2286

Includes:
* new configs to control scale of batch-note creation:  `notes_batch_curated_group_count`, `notes_batch_students_count`, `notes_batch_students_per_group_count`
* verification of `unique_students_in_batch`

