### PR TITLE
Expand student population and fix filter tests

### DIFF
--- a/models/boac/boac_test_config.rb
+++ b/models/boac/boac_test_config.rb
@@ -201,7 +201,7 @@ class BOACTestConfig < TestConfig
 
   # Config for filtered cohort testing
   def filtered_cohorts
-    set_global_configs
+    set_global_configs BOACDepartments::ADMIN
     set_search_cohorts
 
     # Set a default cohort with all possible filters to exercise editing and removing filters
@@ -214,35 +214,27 @@ class BOACTestConfig < TestConfig
                 ['Letters & Sci Undeclared UG']
             end
     filters = {
-      :gpa => ['3.00 - 3.49'],
-      :level => ['Senior (90+ Units)'],
-      :units_completed => ['90 - 119'],
-      :major => major,
-      :transfer_student => true,
-      :expected_grad_terms => [CONFIG['term_code']],
-      :gender => ['Male'],
-      :last_name => 'A Z',
+        :gpa => ['3.00 - 3.49'],
+        :level => ['Senior (90+ Units)'],
+        :units_completed => ['90 - 119'],
+        :major => major,
+        :transfer_student => true,
+        :expected_grad_terms => [CONFIG['term_code']],
+        :gender => ['Male'],
+        :last_name => 'A Z',
+        :underrepresented_minority => true,
+        :ethnicity => ['Puerto Rican'],
+        :asc_inactive => true,
+        :asc_intensive => true,
+        :asc_team => [Squad::MCR],
+        :coe_advisor => [BOACUtils.get_dept_advisors(BOACDepartments::COE).first.uid.to_s],
+        :coe_ethnicity => ['Chinese / Chinese-American'],
+        :coe_gender => ['Female'],
+        :coe_underrepresented_minority => true,
+        :coe_prep => ['PREP'],
+        :coe_inactive => true,
+        :coe_probation => true
     }
-
-    if [BOACDepartments::ASC, BOACDepartments::ADMIN].include? @dept
-      filters.merge!({
-                         :asc_inactive => true,
-                         :asc_intensive => true,
-                         :asc_team => [Squad::MCR]
-                    })
-    end
-
-    if [BOACDepartments::COE, BOACDepartments::ADMIN].include? @dept
-      filters.merge!({
-                         :coe_advisor => [BOACUtils.get_dept_advisors(BOACDepartments::COE).first.uid.to_s],
-                         :coe_ethnicity => ['Chinese / Chinese-American'],
-                         :coe_gender => ['Female'],
-                         :coe_underrepresented_minority => true,
-                         :coe_prep => ['PREP'],
-                         :coe_inactive => true,
-                         :coe_probation => true
-                     })
-    end
 
     advisor_plans = NessieUtils.get_academic_plans(@advisor)
     if advisor_plans.any?

--- a/models/boac/cohort_filter.rb
+++ b/models/boac/cohort_filter.rb
@@ -46,18 +46,18 @@ class CohortFilter
     @cohort_owner_academic_plans = (test_data['cohort_owner_academic_plans'] && test_data['cohort_owner_academic_plans'].map { |t| t['plan'] })
 
     # CoE
-    @coe_advisor = (test_data['advisors'] && test_data['advisors'].map { |a| a['advisor'] })
-    @coe_ethnicity = (test_data['coe_ethnicities'] && test_data['coe_ethnicities'].map { |e| coe_ethnicity_per_code e['coe_ethnicity'] })
-    @coe_gender = (test_data['coe_genders'] && test_data['coe_genders'].map { |g| g['coe_gender'] })
+    @coe_advisor = (test_data['coe_advisors'] && test_data['coe_advisors'].map { |a| a['advisor'] })
+    @coe_ethnicity = (test_data['coe_ethnicities'] && test_data['coe_ethnicities'].map { |e| coe_ethnicity_per_code e['ethnicity'] })
+    @coe_gender = (test_data['coe_genders'] && test_data['coe_genders'].map { |g| g['gender'] })
+    @coe_inactive = test_data['coe_inactive']
+    @coe_prep = (test_data['coe_preps'] && test_data['coe_preps'].map { |p| p['prep'] })
+    @coe_probation = test_data['coe_probation']
     @coe_underrepresented_minority = test_data['coe_underrepresented_minority']
-    @coe_prep = (test_data['preps'] && test_data['preps'].map { |p| p['prep'] })
-    @coe_inactive = test_data['inactive_coe']
-    @coe_probation = test_data['probation_coe']
 
     # ASC
-    @asc_inactive = test_data['inactive_asc']
-    @asc_intensive = test_data['intensive_asc']
-    @asc_team = (test_data['teams'] && test_data['teams'].map { |t| Squad::SQUADS.find { |s| s.name == t['squad'] } })
+    @asc_inactive = test_data['asc_inactive']
+    @asc_intensive = test_data['asc_intensive']
+    @asc_team = (test_data['asc_teams'] && test_data['asc_teams'].map { |t| Squad::SQUADS.find { |s| s.name == t['squad'] } })
 
     # Remove filters that are not available to the department
     unless [BOACDepartments::ADMIN, BOACDepartments::COE].include? dept

--- a/pages/boac/boac_cohort_pages.rb
+++ b/pages/boac/boac_cohort_pages.rb
@@ -53,7 +53,7 @@ module BOACCohortPages
 
   # Clicks the Export List button and parses the resulting file
   # @param cohort [Cohort]
-  # @return [Array<Array>]
+  # @return [CSV::Table]
   def export_student_list(cohort)
     logger.info "Exporting student list for #{cohort.instance_of?(FilteredCohort) ? 'cohort' : 'group'} ID '#{cohort.id}'"
     Utils.prepare_download_dir
@@ -75,9 +75,7 @@ module BOACCohortPages
           parsed_csv.find do |r|
             (r.dig(:first_name) == stu.first_name) &&
                 (r.dig(:last_name) == stu.last_name) &&
-                (r.dig(:sid) == stu.sis_id.to_i) &&
-                (r.dig(:email)) &&
-                (r.dig(:phone))
+                (r.dig(:sid) == stu.sis_id.to_i)
           end
         end
       end
@@ -88,13 +86,18 @@ module BOACCohortPages
           parsed_csv.find do |r|
             (r.dig(:first_name) == stu[:first_name]) &&
                 (r.dig(:last_name) == stu[:last_name]) &&
-                (r.dig(:sid) == stu[:sid].to_i) &&
-                (r.dig(:email)) &&
-                (r.dig(:phone))
+                (r.dig(:sid) == stu[:sid].to_i)
           end
         end
       end
     end
+    # Make sure there's some phone / email data
+    wait_until(1) do
+      parsed_csv.by_col!
+      parsed_csv.dig(:email).compact.any?
+      parsed_csv.dig(:phone).compact.any?
+    end
+
   end
 
   # LIST VIEW - shared by filtered cohorts and curated groups

--- a/pages/boac/boac_filtered_cohort_page_results.rb
+++ b/pages/boac/boac_filtered_cohort_page_results.rb
@@ -132,7 +132,7 @@ module BOACFilteredCohortPageResults
   def matching_ethnicity_students(test, search_criteria)
     students = []
     (search_criteria.ethnicity&.any?) ?
-        (students << test.searchable_data.select { |u| (u[:ethnicity] & search_criteria.ethnicity).any? }) :
+        (students << test.searchable_data.select { |u| (u[:ethnicity] & search_criteria.ethnicity).any? if u[:ethnicity] }) :
         (students = test.searchable_data)
     students.uniq.flatten.compact
   end
@@ -311,6 +311,7 @@ module BOACFilteredCohortPageResults
                matching_gender_students(test, search_criteria),
                matching_minority_students(test, search_criteria),
                matching_acad_plan_students(test, search_criteria),
+               matching_last_name_students(test, search_criteria),
                matching_coe_advisor_students(test, search_criteria),
                matching_coe_ethnicity_students(test, search_criteria),
                matching_coe_gender_students(test, search_criteria),

--- a/spec/boac/boac_filtered_cohort_spec.rb
+++ b/spec/boac/boac_filtered_cohort_spec.rb
@@ -375,165 +375,130 @@ describe 'BOAC', order: :defined do
     end
 
     it 'allows the advisor to edit a Major filter' do
-      if test.default_cohort.search_criteria.major.any?
-        test.default_cohort.search_criteria.major = ['Bioengineering BS']
-        @cohort_page.edit_filter_and_confirm('Major', test.default_cohort.search_criteria.major.first)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing majors since there is nothing to edit'
-      end
+      test.default_cohort.search_criteria.major = ['Bioengineering BS']
+      @cohort_page.edit_filter_and_confirm('Major', test.default_cohort.search_criteria.major.first)
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to remove a Major filter' do
-      if test.default_cohort.search_criteria.major.any?
-        test.default_cohort.search_criteria.major = []
-        @cohort_page.remove_filter_of_type 'Major'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing majors since there is nothing to remove'
-      end
+      test.default_cohort.search_criteria.major = []
+      @cohort_page.remove_filter_of_type 'Major'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the the advisor to remove a Transfer Student filter' do
-      if test.default_cohort.search_criteria.transfer_student
-        test.default_cohort.search_criteria.transfer_student = false
-        @cohort_page.remove_filter_of_type 'Transfer Student'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing transfer student filter since there is nothing to remove'
-      end
+    it 'allows the advisor to remove a Transfer Student filter' do
+      test.default_cohort.search_criteria.transfer_student = false
+      @cohort_page.remove_filter_of_type 'Transfer Student'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to edit an Expected Graduation Term filter' do
-      if test.default_cohort.search_criteria.expected_grad_terms.any?
-        new_term_id = (test.default_cohort.search_criteria.expected_grad_terms.first.to_i + 10).to_s
-        test.default_cohort.search_criteria.expected_grad_terms = [new_term_id]
-        @cohort_page.edit_filter_and_confirm('Expected Graduation Term', test.default_cohort.search_criteria.expected_grad_terms.first)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing expected grad terms since there is nothing to edit'
-      end
+      new_term_id = (test.default_cohort.search_criteria.expected_grad_terms.first.to_i + 10).to_s
+      test.default_cohort.search_criteria.expected_grad_terms = [new_term_id]
+      @cohort_page.edit_filter_and_confirm('Expected Graduation Term', test.default_cohort.search_criteria.expected_grad_terms.first)
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to remove an Expected Graduation Term filter' do
-      if test.default_cohort.search_criteria.expected_grad_terms.any?
-        test.default_cohort.search_criteria.expected_grad_terms = []
-        @cohort_page.remove_filter_of_type 'Expected Graduation Term'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing expected grad terms since there is nothing to remove'
-      end
+      test.default_cohort.search_criteria.expected_grad_terms = []
+      @cohort_page.remove_filter_of_type 'Expected Graduation Term'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to edit an \'Ethnicity (COE)\' filter' do
-      if test.default_cohort.search_criteria.coe_ethnicity
-        test.default_cohort.search_criteria.coe_ethnicity = ['Mexican / Mexican-American / Chicano']
-        @cohort_page.edit_filter_and_confirm('Ethnicity (COE)', test.default_cohort.search_criteria.coe_ethnicity.first)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing \'Ethnicity (COE)\' since the filter is not available to the user'
-      end
+    it 'allows the advisor to remove an Unrepresented Minority filter' do
+      test.default_cohort.search_criteria.underrepresented_minority = false
+      @cohort_page.remove_filter_of_type 'Underrepresented Minority'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to remove an \'Ethnicity (COE)\' filter' do
-      if test.default_cohort.search_criteria.coe_ethnicity
-        test.default_cohort.search_criteria.coe_ethnicity = []
-        @cohort_page.remove_filter_of_type 'Ethnicity (COE)'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing \'Ethnicity (COE)\' since the filter is not available to the user'
-      end
+    it 'allows the advisor to edit an Ethnicity filter' do
+      test.default_cohort.search_criteria.ethnicity = ['Thai']
+      @cohort_page.edit_filter_and_confirm('Ethnicity', test.default_cohort.search_criteria.ethnicity.first)
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to edit a \'Gender (COE)\' filter' do
-      if test.default_cohort.search_criteria.coe_gender
-        test.default_cohort.search_criteria.coe_gender = ['Male']
-        @cohort_page.edit_filter_and_confirm('Gender (COE)', test.default_cohort.search_criteria.coe_gender.first)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing \'Gender (COE)\' since the filter is not available to the user'
-      end
+    it 'allows the advisor to remove an Ethnicity filter' do
+      test.default_cohort.search_criteria.ethnicity = []
+      @cohort_page.remove_filter_of_type 'Ethnicity'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to remove a \'Gender (COE)\' filter' do
-      if test.default_cohort.search_criteria.coe_gender
-        test.default_cohort.search_criteria.coe_gender = []
-        @cohort_page.remove_filter_of_type 'Gender (COE)'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing \'Gender (COE)\' since the filter is not available to the user'
-      end
+    it 'allows the advisor to edit a Gender filter' do
+      test.default_cohort.search_criteria.gender = ['Female']
+      @cohort_page.edit_filter_and_confirm('Gender', test.default_cohort.search_criteria.gender.first)
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to remove an Underrepresented Minority filter' do
-      if test.default_cohort.search_criteria.coe_underrepresented_minority
-        test.default_cohort.search_criteria.coe_underrepresented_minority = false
-        @cohort_page.remove_filter_of_type 'Underrepresented Minority'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing underrepresented minority since the filter is not available to the user'
-      end
+    it 'allows the advisor to remove a Gender filter' do
+      test.default_cohort.search_criteria.gender = []
+      @cohort_page.remove_filter_of_type 'Gender'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to remove an Inactive ASC filter' do
-      if test.default_cohort.search_criteria.asc_inactive
-        test.default_cohort.search_criteria.asc_inactive = false
-        label = (test.dept == BOACDepartments::ADMIN) ? 'Inactive (ASC)' : 'Inactive'
-        @cohort_page.remove_filter_of_type label
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing inactive ASC since the filter is not available to the user'
-      end
+    it 'allows the advisor to edit an Ethnicity (COE) filter' do
+      test.default_cohort.search_criteria.coe_ethnicity = ['Mexican / Mexican-American / Chicano']
+      @cohort_page.edit_filter_and_confirm('Ethnicity (COE)', test.default_cohort.search_criteria.coe_ethnicity.first)
+      @cohort_page.verify_filters_present test.default_cohort
+    end
+
+    it 'allows the advisor to remove an Ethnicity (COE) filter' do
+      test.default_cohort.search_criteria.coe_ethnicity = []
+      @cohort_page.remove_filter_of_type 'Ethnicity (COE)'
+      @cohort_page.verify_filters_present test.default_cohort
+    end
+
+    it 'allows the advisor to edit a Gender (COE) filter' do
+      test.default_cohort.search_criteria.coe_gender = ['Male']
+      @cohort_page.edit_filter_and_confirm('Gender (COE)', test.default_cohort.search_criteria.coe_gender.first)
+      @cohort_page.verify_filters_present test.default_cohort
+    end
+
+    it 'allows the advisor to remove a Gender (COE) filter' do
+      test.default_cohort.search_criteria.coe_gender = []
+      @cohort_page.remove_filter_of_type 'Gender (COE)'
+      @cohort_page.verify_filters_present test.default_cohort
+    end
+
+    it 'allows the advisor to remove an Underrepresented Minority (COE) filter' do
+      test.default_cohort.search_criteria.coe_underrepresented_minority = false
+      @cohort_page.remove_filter_of_type 'Underrepresented Minority (COE)'
+      @cohort_page.verify_filters_present test.default_cohort
+    end
+
+    it 'allows the advisor to remove an Inactive (ASC) filter' do
+      test.default_cohort.search_criteria.asc_inactive = false
+      @cohort_page.remove_filter_of_type 'Inactive (ASC)'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to remove an Intensive filter' do
-      if test.default_cohort.search_criteria.asc_intensive
-        test.default_cohort.search_criteria.asc_intensive = false
-        @cohort_page.remove_filter_of_type 'Intensive'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing intensive since the filter is not available to the user'
-      end
+      test.default_cohort.search_criteria.asc_intensive = false
+      @cohort_page.remove_filter_of_type 'Intensive'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to edit a Team filter' do
-      if test.default_cohort.search_criteria.asc_team && test.default_cohort.search_criteria.asc_team.any?
-        test.default_cohort.search_criteria.asc_team = [Squad::WCR]
-        @cohort_page.edit_filter_and_confirm('Team', test.default_cohort.search_criteria.asc_team.first.name)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing teams since the filter is not available to the user or there is nothing to edit'
-      end
+      test.default_cohort.search_criteria.asc_team = [Squad::WCR]
+      @cohort_page.edit_filter_and_confirm('Team', test.default_cohort.search_criteria.asc_team.first.name)
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to remove a Team filter' do
-      if test.default_cohort.search_criteria.asc_team && test.default_cohort.search_criteria.asc_team.any?
-        test.default_cohort.search_criteria.asc_team = []
-        @cohort_page.remove_filter_of_type 'Team'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing teams since the filter is not available to the user or there is nothing to edit'
-      end
+      test.default_cohort.search_criteria.asc_team = []
+      @cohort_page.remove_filter_of_type 'Team'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to edit a PREP filter' do
-      if test.default_cohort.search_criteria.coe_prep
-        test.default_cohort.search_criteria.coe_prep = ['T-PREP']
-        @cohort_page.edit_filter_and_confirm('PREP', test.default_cohort.search_criteria.coe_prep.first)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing PREPs since the filter is not available to the user'
-      end
+      test.default_cohort.search_criteria.coe_prep = ['T-PREP']
+      @cohort_page.edit_filter_and_confirm('PREP', test.default_cohort.search_criteria.coe_prep.first)
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to remove a PREP filter' do
-      if test.default_cohort.search_criteria.coe_prep
-        test.default_cohort.search_criteria.coe_prep = []
-        @cohort_page.remove_filter_of_type 'PREP'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing PREPs since the filter is not available to the user'
-      end
+      test.default_cohort.search_criteria.coe_prep = []
+      @cohort_page.remove_filter_of_type 'PREP'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to edit a Last Name filter' do
@@ -549,56 +514,47 @@ describe 'BOAC', order: :defined do
     end
 
     it 'allows the advisor to edit a My Students filter' do
-      test.default_cohort.search_criteria.cohort_owner_academic_plans = ['*']
-      @cohort_page.edit_filter_and_confirm('My Students', '*')
-      @cohort_page.verify_filters_present test.default_cohort
+      if test.default_cohort.search_criteria.cohort_owner_academic_plans
+        test.default_cohort.search_criteria.cohort_owner_academic_plans = ['*']
+        @cohort_page.edit_filter_and_confirm('My Students', '*')
+        @cohort_page.verify_filters_present test.default_cohort
+      else
+        logger.warn 'Skipping test for editing My Students since the filter is not available to the user'
+      end
     end
 
     it 'allows the advisor to remove a My Students filter' do
-      test.default_cohort.search_criteria.cohort_owner_academic_plans = []
-      @cohort_page.remove_filter_of_type 'My Students'
+      if test.default_cohort.search_criteria.cohort_owner_academic_plans
+        test.default_cohort.search_criteria.cohort_owner_academic_plans = []
+        @cohort_page.remove_filter_of_type 'My Students'
+        @cohort_page.verify_filters_present test.default_cohort
+      else
+        logger.warn 'Skipping test for removing My Students since the filter is not available to the user'
+      end
+    end
+
+    it 'allows the advisor to edit an Advisor (COE) filter' do
+      test.default_cohort.search_criteria.coe_advisor = [BOACUtils.get_dept_advisors(BOACDepartments::COE).last.uid.to_s]
+      @cohort_page.edit_filter_and_confirm('Advisor (COE)', test.default_cohort.search_criteria.coe_advisor.first)
       @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to edit an Advisor filter' do
-      if test.default_cohort.search_criteria.coe_advisor
-        test.default_cohort.search_criteria.coe_advisor = [BOACUtils.get_dept_advisors(BOACDepartments::COE).last.uid.to_s]
-        @cohort_page.edit_filter_and_confirm('Advisor (COE)', test.default_cohort.search_criteria.coe_advisor.first)
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing advisors since the filter is not available to the user'
-      end
+    it 'allows the advisor to remove an Advisor (COE) filter' do
+      test.default_cohort.search_criteria.coe_advisor = []
+      @cohort_page.remove_filter_of_type 'Advisor (COE)'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
-    it 'allows the advisor to remove an Advisor filter' do
-      if test.default_cohort.search_criteria.coe_advisor
-        test.default_cohort.search_criteria.coe_advisor = []
-        @cohort_page.remove_filter_of_type 'Advisor (COE)'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing advisors since the filter is not available to the user'
-      end
-    end
-
-    it 'allows the advisor to remove an Inactive CoE filter' do
-      if test.default_cohort.search_criteria.coe_inactive
-        test.default_cohort.search_criteria.coe_inactive = false
-        label = (test.dept == BOACDepartments::ADMIN) ? 'Inactive (COE)' : 'Inactive'
-        @cohort_page.remove_filter_of_type label
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing inactive CoE since the filter is not available to the user'
-      end
+    it 'allows the advisor to remove an Inactive (CoE) filter' do
+      test.default_cohort.search_criteria.coe_inactive = false
+      @cohort_page.remove_filter_of_type 'Inactive (COE)'
+      @cohort_page.verify_filters_present test.default_cohort
     end
 
     it 'allows the advisor to remove a Probation filter' do
-      if test.default_cohort.search_criteria.coe_probation
-        test.default_cohort.search_criteria.coe_probation = false
-        @cohort_page.remove_filter_of_type 'Probation'
-        @cohort_page.verify_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing probation since the filter is not available to the user'
-      end
+      test.default_cohort.search_criteria.coe_probation = false
+      @cohort_page.remove_filter_of_type 'Probation'
+      @cohort_page.verify_filters_present test.default_cohort
     end
   end
 

--- a/test_data/test-data-boac.json
+++ b/test_data/test-data-boac.json
@@ -1,425 +1,75 @@
 {
     "filters": [
         {
-            "gpa_ranges": [
-                {"gpa_range": "3.00 - 3.49"}
-            ],
-            "levels": null,
-            "units": null,
-            "majors": [
-                {"major": "Geography BA"},
-                {"major": "Geology BA"}
-            ],
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": "C K",
-            "genders": [
-                {"gender": "Female"},
-                {"gender": "Male"}
-            ],
-            "advisors": null
+            "asc_inactive": true,
+            "asc_teams": [
+                {"squad": "Men's Crew"},
+                {"squad": "Women's Crew"}
+            ]
         },
         {
-            "gpa_ranges": [
-                {"gpa_range": "3.50 - 4.00"}
+            "asc_intensive": true
+        },
+        {
+            "coe_advisors": [
+                {"advisor": "2322"}
             ],
+            "coe_ethnicities": [
+                {"ethnicity": "E"}
+            ]
+        },
+        {
+            "coe_genders": [
+                {"gender": "Female"}
+            ],
+            "coe_inactive": true
+        },
+        {
+            "coe_preps": [
+                {"prep": "PREP"},
+                {"prep": "T-PREP"},
+                {"prep": "PREP eligible"},
+                {"prep": "T-PREP eligible"}
+            ],
+            "coe_probation": true,
+            "coe_underrepresented_minority": true
+        },
+        {
             "levels": [
-                {"level": "Senior (90+ Units"}
+                {"level": "Junior (60-89 Units)"},
+                {"level": "Senior (90+ Units)"}
             ],
-            "units": null,
-            "majors": [
-                {"major": "Letters & Sci Undeclared UG"}
+            "ethnicities": [
+                {"ethnicity": "Puerto Rican"}
             ],
-            "transfer_student": "true",
+            "genders": [
+                {"gender": "Male"}
+            ]
+        },
+        {
             "expected_grad_terms": [
                 {"expected_grad_term": "2198"},
                 {"expected_grad_term": "2202"}
             ],
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": null,
-            "genders": null,
-            "advisors": null
-        },
-        {
             "gpa_ranges": [
-                {"gpa_range": "3.50 - 4.00"}
+                {"gpa_range": "3.50 - 4.00"},
+                {"gpa_range": "3.00 - 3.49"}
             ],
-            "levels": null,
-            "units": null,
             "majors": [
-                {"major": "Physics BA"},
-                {"major": "Nuclear Engineering BS"}
-            ],
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": [
-                {"coe_gender": "Female"}
-            ],
-            "coe_underrepresented_minority": true,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": null,
-            "genders": null,
-            "advisors": null
-        },
-        {
-            "gpa_ranges": null,
-            "levels": [
-                {"level": "Senior (90+ Units)"},
-                {"level": "Junior (60-89 Units)"}
+                {"major": "Chemistry BS"},
+                {"major": "History BA"}
             ],
             "units": [
                 {"unit": "120 +"}
-            ],
-            "majors": null,
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": true,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": [
-                {"prep": "PREP"},
-                {"prep": "T-PREP"}
-            ],
-            "probation_coe": null,
-            "last_initials": "A B",
-            "genders": [
-                {"gender": "Male"}
-            ],
-            "advisors": null
-        },
-        {
-            "gpa_ranges": null,
-            "levels": [
-                {"level": "Senior (90+ Units)"},
-                {"level": "Junior (60-89 Units)"}
-            ],
-            "units": null,
-            "majors": null,
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": [
-                {"prep": "T-PREP"}
-            ],
-            "probation_coe": null,
-            "last_initials": null,
-            "genders": [
-                {"gender": "Decline to State"}
-            ],
-            "advisors": null
-        },
-        {
-            "gpa_ranges": [
-                {"gpa_range": "2.00 - 2.49"},
-                {"gpa_range": "Below 2.0"}
-            ],
-            "levels": null,
-            "units": [
-                {"unit": "120 +"}
-            ],
-            "majors": null,
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": true,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": true,
-            "last_initials": null,
-            "genders": null,
-            "advisors": [
-                {"advisor": "1015251"}
             ]
         },
         {
-            "gpa_ranges": null,
-            "levels": [
-                {"level": "Senior (90+ Units)"}
-            ],
-            "units": [
-                {"unit": "120 +"}
-            ],
             "majors": [
-                {"major": "Business Administration BS"},
-                {"major": "Economics BA"},
-                {"major": "Education MA"}
+                {"major": "Letters & Sci Undeclared UG"}
             ],
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": [
-                {"coe_ethnicity": "F"}
-            ],
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": [
-                {"squad": "Women's Crew"},
-                {"squad": "Men's Crew"}
-            ],
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": "A L",
-            "genders": null,
-            "advisors": null
-        },
-        {
-            "gpa_ranges": [
-                {"gpa_range": "2.50 - 2.99"}
-            ],
-            "levels": [
-                {"level": "Freshman (0-29 Units)"},
-                {"level": "Sophomore (30-59 Units)"}
-            ],
-            "units": [
-                {"unit": "0 - 29"}
-            ],
-            "majors": null,
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": [
-                {"coe_ethnicity": "G"}
-            ],
-            "coe_genders": [
-                {"coe_gender": "Male"},
-                {"coe_gender": "Female"}
-            ],
-            "coe_underrepresented_minority": null,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": true,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": null,
-            "genders": null,
-            "advisors": null
-        },
-        {
-            "gpa_ranges": null,
-            "levels": [
-                {"level": "Senior (90+ Units)"}
-            ],
-            "units": null,
-            "majors": [
-                {"major": "Integrative Biology BA"},
-                {"major": "Nut Sci-Physio & Metabol BS"},
-                {"major": "Public Health BA"},
-                {"major": "Physics"},
-                {"major": "Industrial Eng & Ops Rsch MEng"},
-                {"major": "Industrial Eng & Ops Rsch MS"}
-            ],
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": false,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": "B G",
-            "genders": null,
-            "advisors": null
-        },
-        {
-            "gpa_ranges": [
-                {"gpa_range": "3.50 - 4.00"}
-            ],
-            "levels": null,
-            "units": null,
-            "majors": [
-                {"major": "Business Administration BS"},
-                {"major": "Political Economy BA"},
-                {"major": "Nuclear Engineering BS"}
-            ],
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": [
-                {"coe_gender": "Female"}
-            ],
-            "coe_underrepresented_minority": true,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": null,
-            "genders": [
-                {"gender": "Female"}
-            ],
-            "advisors": null
-        },
-        {
-            "gpa_ranges": null,
-            "levels": [
-                {"level": "Junior (60-89 Units)"}
-            ],
-            "units": null,
-            "majors": [
-                {"major": "Legal Studies BA"},
-                {"major": "Economics BA"},
-                {"major": "Electrical Eng & Comp Sci BS"},
-                {"major": "Physics BA"}
-            ],
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": [
-                {"prep": "PREP"},
-                {"prep": "T-PREP"}
-            ],
-            "probation_coe": null,
-            "last_initials": "A J",
-            "genders": null,
-            "advisors": null
-        },
-        {
-            "gpa_ranges": null,
-            "levels": [
-                {"level": "Senior (90+ Units)"}
-            ],
-            "units": [
-                {"unit": "120 +"}
-            ],
-            "majors": null,
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": null,
-            "coe_genders": null,
-            "coe_underrepresented_minority": true,
-            "underrepresented_minority": null,
-            "inactive_asc": true,
-            "intensive_asc": null,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": null,
-            "last_initials": "P R",
-            "genders": [
-                {"gender": "Male"}
-            ],
-            "advisors": null
-        },
-        {
-            "gpa_ranges": [
-                {"gpa_range": "Below 2.0"},
-                {"gpa_range": "2.50 - 2.99"}
-            ],
-            "levels": [
-                {"level": "Freshman (0-29 Units)"},
-                {"level": "Sophomore (30-59 Units)"}
-            ],
-            "units": null,
-            "majors": null,
-            "transfer_student": null,
-            "expected_grad_terms": null,
-            "coe_ethnicities": [
-                {"coe_ethnicity": "H"}
-            ],
-            "coe_genders": null,
-            "coe_underrepresented_minority": null,
-            "underrepresented_minority": null,
-            "inactive_asc": null,
-            "intensive_asc": true,
-            "teams": null,
-            "inactive_coe": null,
-            "preps": null,
-            "probation_coe": true,
-            "last_initials": null,
-            "genders": null,
-            "advisors": [
-                {"advisor": "1015251"},
-                {"advisor": "18767"}
-            ]
-        },
-        {
-            "teams": null,
-            "levels": [
-                {"level": "Freshman (0-29 Units)"}
-            ],
-            "majors": null,
-            "gpa_ranges": null,
-            "advisors": null,
-            "cohort_owner_academic_plans": [
-                {"plan": "*"}
-            ],
-            "coe_ethnicities": null,
-            "underrepresented_minority": null,
-            "coe_genders": null,
-            "preps": null,
-            "probation_coe": null,
-            "inactive_asc": null,
-            "intensive_asc": true
-        },
-        {
+            "transfer_student": true,
             "underrepresented_minority": true,
-            "levels": [
-                {"level":  "Freshman (0-29 Units)"}
-            ],
-            "genders": [
-                {"gender": "Female"}
-            ]
-        },
-        {
-            "ethnicities": [
-                {"ethnicity":  "Puerto Rican"},
-                {"ethnicity":  "Pacific Islander"}
-            ]
+            "last_initials": "B C"
         }
     ]
 }


### PR DESCRIPTION
- Replaces l_and_s students with undergrads
- Converts the cohort test script to an admin-only script to exercise all filters
- Updates the test data file, and cuts the cohort test script run time in half
- Standardizes naming conventions for filters