### PR TITLE
Fix Junction add-user tests

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -83,7 +83,7 @@ canvas:
   uc_berkeley_sub_account: secret
   official_courses_sub_account: secret
   qa_sub_account: secret
-  enrollment_retries: 20
+  enrollment_retries: 25
   create_site_tool: secret
   course_add_user_tool: secret
   course_captures_tool: secret

--- a/spec/junction/canvas_lti_course_add_user_spec.rb
+++ b/spec/junction/canvas_lti_course_add_user_spec.rb
@@ -130,25 +130,18 @@ describe 'bCourses Find a Person to Add', order: :defined do
     before(:all) do
       @section_to_test = sections_for_site.first
       @canvas.masquerade_as(@driver, teacher_1, course)
-    end
-
-    before(:each) do
       @canvas.load_users_page course
       @canvas.click_find_person_to_add @driver
-    end
-
-    [teacher_2, lead_ta, ta, designer, reader, student, waitlist, observer].each do |user|
-
-      it "allows a course Teacher to add a #{user.role} to a course site with any type of role" do
+      [teacher_2, lead_ta, ta, designer, reader, student, waitlist, observer].each do |user|
         @course_add_user_page.search(user.uid, 'CalNet UID')
         @course_add_user_page.add_user_by_uid(user, @section_to_test)
       end
+      @canvas.load_users_page course
+      @canvas.load_all_students course
     end
 
     [teacher_2, lead_ta, ta, designer, reader, student, waitlist, observer].each do |user|
-
       it "shows an added #{user.role} user in the course site roster" do
-        @canvas.load_users_page course
         @canvas.search_user_by_canvas_id user
         @canvas.wait_until(Utils.medium_wait) { @canvas.roster_user? user.canvas_id }
         expect(@canvas.roster_user_sections(user.canvas_id)).to include("#{@section_to_test.course} #{@section_to_test.label}") unless user.role == 'Observer'


### PR DESCRIPTION
Canvas isn't reliably finding site members unless the full roster is loaded, so this change loads the whole roster before searching for users added via the add-user tool.