### PR TITLE
Revert change to site publishing workflow

### DIFF
--- a/pages/canvas/canvas_page.rb
+++ b/pages/canvas/canvas_page.rb
@@ -251,6 +251,8 @@ module Page
     button(:save_and_publish_button, class: 'save_and_publish')
     button(:published_button, class: 'btn-published')
     form(:published_status, id: 'course_status_form')
+    radio_button(:activity_stream_radio, xpath: '//span[contains(.,"Course Activity Stream")]/ancestor::label')
+    button(:choose_and_publish_button, xpath: '//span[contains(.,"Choose and Publish")]/ancestor::button')
 
     # Publishes a course site
     # @param driver [Selenium::WebDriver]
@@ -264,6 +266,13 @@ module Page
       else
         logger.debug 'The site is unpublished, publishing'
         wait_for_update_and_click publish_button_element
+        # Junction test courses from SIS data always have a term and have the site's front page set during creation. Other
+        # test courses never have a term and need to set the site's front page while publishing.
+        if course.term.nil?
+          activity_stream_radio_element.when_visible Utils.short_wait
+          select_activity_stream_radio
+          wait_for_update_and_click choose_and_publish_button_element
+        end
         published_button_element.when_present Utils.medium_wait
       end
     end


### PR DESCRIPTION
Canvas changed its site publishing workflow in Beta, and now it's changed it back.