### PR TITLE
Teena: note.subject null check

### DIFF
--- a/spec/boac/boac_search_spec.rb
+++ b/spec/boac/boac_search_spec.rb
@@ -86,7 +86,7 @@ describe 'BOAC' do
         expected_notes = expected_notes + expected_asc_notes if expected_asc_notes
         if expected_notes.any?
           expected_notes.each do |note|
-            if note.subject.include? 'QA Test'
+            if !note.subject.nil? && (note.subject.include? 'QA Test')
               logger.warn "Skipping note search tests for UID #{student.uid} note ID #{note.id} because it is a testing artifact"
             else
               begin


### PR DESCRIPTION
Legacy notes can have null subject. A few lines after this change you'll see `generate_note_search_query()` which contains a similar null check.