### PR TITLE
Allow Junction LTI tests to be run outside Canvas

### DIFF
--- a/pages/junction/junction_pages.rb
+++ b/pages/junction/junction_pages.rb
@@ -24,11 +24,11 @@ module Page
       switch_to_canvas_iframe JunctionUtils.junction_base_url
     end
 
-    # Logs the user out if the user is logged in
+    # Logs the user out
     # @param splash_page [Page::JunctionPages::SplashPage]
     def log_out(splash_page)
       toggle_footer_link_element.when_visible Utils.medium_wait
-      wait_for_update_and_click(log_out_link_element) if title.include? 'Toolbox'
+      wait_for_update_and_click log_out_link_element unless title.include? 'Home'
       splash_page.sign_in_element.when_visible Utils.medium_wait
     end
 

--- a/spec/junction/canvas_job_refresh_canvas_recent_spec.rb
+++ b/spec/junction/canvas_job_refresh_canvas_recent_spec.rb
@@ -1,138 +1,141 @@
-require_relative '../../util/spec_helper'
+unless ENV['STANDALONE']
 
-# Prior to running, backdate last sync dates in Junction db to JunctionUtils.sis_update_date
+  require_relative '../../util/spec_helper'
 
-describe 'bCourses recent enrollment updates' do
+  # Prior to running, backdate last sync dates in Junction db to JunctionUtils.sis_update_date
 
-  include Logging
+  describe 'bCourses recent enrollment updates' do
 
-  begin
+    include Logging
 
-    @driver = Utils.launch_browser
-    @splash_page = Page::JunctionPages::SplashPage.new @driver
-    @cal_net_page = Page::CalNetPage.new @driver
-    @create_course_site_page = Page::JunctionPages::CanvasCreateCourseSitePage.new @driver
-    @canvas_page = Page::CanvasPage.new @driver
+    begin
 
-    test_data = JunctionUtils.load_junction_test_course_data.select { |course| course['tests']['recent_update'] }
-    roles = ['Teacher', 'Lead TA', 'TA', 'Student', 'Waitlist Student']
-    @admin = User.new username: Utils.super_admin_username, canvas_id: Utils.super_admin_canvas_id
-    sites_to_verify = []
+      @driver = Utils.launch_browser
+      @splash_page = Page::JunctionPages::SplashPage.new @driver
+      @cal_net_page = Page::CalNetPage.new @driver
+      @create_course_site_page = Page::JunctionPages::CanvasCreateCourseSitePage.new @driver
+      @canvas_page = Page::CanvasPage.new @driver
 
-    course_sites = test_data.map do |data|
-      course = Course.new data
-      course.sections.map! { |h| Section.new h }
-      course.teachers.map! { |h| User.new h }
-      {course: course, user_data: []}
-    end
+      test_data = JunctionUtils.load_junction_test_course_data.select { |course| course['tests']['recent_update'] }
+      roles = ['Teacher', 'Lead TA', 'TA', 'Student', 'Waitlist Student']
+      @admin = User.new username: Utils.super_admin_username, canvas_id: Utils.super_admin_canvas_id
+      sites_to_verify = []
 
-    logger.debug "There are #{course_sites.length} test courses"
-    @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
+      course_sites = test_data.map do |data|
+        course = Course.new data
+        course.sections.map! { |h| Section.new h }
+        course.teachers.map! { |h| User.new h }
+        {course: course, user_data: []}
+      end
 
-    course_sites.each do |site|
-      begin
+      logger.debug "There are #{course_sites.length} test courses"
+      @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
+
+      course_sites.each do |site|
+        begin
+          course = site[:course]
+          @create_course_site_page.provision_course_site(course, @admin, course.sections, {admin: true})
+          @canvas_page.set_course_sis_id course
+          @canvas_page.set_section_sis_ids course
+          @canvas_page.load_users_page course
+          @canvas_page.wait_for_enrollment_import(course, roles)
+          initial_users_with_sections = @canvas_page.get_users_with_sections course
+          initial_enrollment_data = initial_users_with_sections.map do |u|
+            {
+                sid: u[:user].sis_id,
+                section_id: u[:section].sis_id,
+                role: u[:user].role
+            }
+          end
+          site.merge!({enrollment: initial_enrollment_data})
+
+          student_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'student' }
+          waitlisted_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Waitlist Student' }
+          ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'ta' }
+          lead_ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Lead TA' }
+          teacher_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'teacher' }
+
+          csv = File.join(Utils.initialize_test_output_dir, "enrollments-#{course.code}.csv")
+          CSV.open(csv, 'wb') { |heading| heading << %w(course_id user_id role section_id status) }
+
+          students_to_delete = student_enrollments[0..9].map &:dup
+          waitlists_to_delete = waitlisted_enrollments[0..9].map &:dup
+          tas_to_delete = ta_enrollments[0..0].map &:dup
+          lead_tas_to_delete = lead_ta_enrollments[0..1].map &:dup
+          teachers_to_delete = teacher_enrollments[0..0].map &:dup
+          students_to_convert = student_enrollments[10..19].map &:dup
+
+          deletes = [students_to_delete + students_to_convert + waitlists_to_delete + tas_to_delete + lead_tas_to_delete + teachers_to_delete]
+          deletes.flatten!
+          logger.debug "#{deletes.map { |h| {sid: h[:user].sis_id, role: h[:user].role} }}"
+          deletes.each { |h| h[:user].status = 'deleted' }
+          deletes.each do |delete|
+            user = delete[:user]
+            section = delete[:section]
+            Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
+          end
+
+          logger.debug "#{students_to_convert}"
+          students_to_convert.each do |h|
+            h[:user].role = 'Waitlist Student'
+            h[:user].status = 'active'
+          end
+          students_to_convert.each do |converts|
+            user = converts[:user]
+            section = converts[:section]
+            Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
+          end
+
+          # For one of the deletions, add a different user role manually to ensure that the manual role persists after an enrollment update
+          if lead_tas_to_delete[0] && course.sections.length == 1
+            teacher = lead_tas_to_delete[0].dup
+            teacher[:user].role = 'Teacher'
+            @canvas_page.add_users(course, [teacher[:user]])
+            initial_enrollment_data << {sid: teacher[:user].sis_id, role: teacher[:user].role.downcase, section_id: teacher[:section].sis_id}
+          end
+
+          @canvas_page.upload_sis_imports([csv], [])
+          sites_to_verify << site
+        rescue => e
+          Utils.log_error e
+          it("hit an error in the test for #{site[:course].code}") { fail }
+        end
+      end
+
+      @canvas_page.log_out(@driver, @cal_net_page)
+      @canvas_page.load_homepage
+      @cal_net_page.prompt_for_action 'RUN EXPORT AND REFRESH SCRIPTS MANUALLY'
+      @cal_net_page.wait_for_manual_login
+
+      #########################################
+      ############  MANUAL STEPS  #############
+      #########################################
+
+      # 1. Run export_cached_csv_enrollments.sh
+      # 2. Run refresh_canvas_recent.sh
+      # 3. Log in manually to resume tests
+
+      sites_to_verify.each do |site|
         course = site[:course]
-        @create_course_site_page.provision_course_site(course, @admin, course.sections, {admin: true})
-        @canvas_page.set_course_sis_id course
-        @canvas_page.set_section_sis_ids course
-        @canvas_page.load_users_page course
-        @canvas_page.wait_for_enrollment_import(course, roles)
-        initial_users_with_sections = @canvas_page.get_users_with_sections course
-        initial_enrollment_data = initial_users_with_sections.map do |u|
+        @canvas_page.load_course_site course
+        updated_users_with_sections = @canvas_page.get_users_with_sections course
+        updated_enrollment_data = updated_users_with_sections.map do |u|
           {
               sid: u[:user].sis_id,
               section_id: u[:section].sis_id,
               role: u[:user].role
           }
         end
-        site.merge!({enrollment: initial_enrollment_data})
-
-        student_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'student' }
-        waitlisted_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Waitlist Student' }
-        ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'ta' }
-        lead_ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Lead TA' }
-        teacher_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'teacher' }
-
-        csv = File.join(Utils.initialize_test_output_dir, "enrollments-#{course.code}.csv")
-        CSV.open(csv, 'wb') { |heading| heading << %w(course_id user_id role section_id status) }
-
-        students_to_delete = student_enrollments[0..9].map &:dup
-        waitlists_to_delete = waitlisted_enrollments[0..9].map &:dup
-        tas_to_delete = ta_enrollments[0..0].map &:dup
-        lead_tas_to_delete = lead_ta_enrollments[0..1].map &:dup
-        teachers_to_delete = teacher_enrollments[0..0].map &:dup
-        students_to_convert = student_enrollments[10..19].map &:dup
-
-        deletes = [students_to_delete + students_to_convert + waitlists_to_delete + tas_to_delete + lead_tas_to_delete + teachers_to_delete]
-        deletes.flatten!
-        logger.debug "#{deletes.map { |h| {sid: h[:user].sis_id, role: h[:user].role} }}"
-        deletes.each { |h| h[:user].status = 'deleted' }
-        deletes.each do |delete|
-          user = delete[:user]
-          section = delete[:section]
-          Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
+        logger.debug "Original site membership: #{site[:enrollment]}"
+        logger.debug "Updated site membership: #{updated_enrollment_data}"
+        logger.debug "Current less original: #{updated_enrollment_data - site[:enrollment]}"
+        logger.debug "Original less current: #{site[:enrollment] - updated_enrollment_data}"
+        it("updates the enrollment for site ID #{site[:course].site_id} with no unexpected memberships") do
+          expect(updated_enrollment_data - site[:enrollment]).to be_empty
         end
-
-        logger.debug "#{students_to_convert}"
-        students_to_convert.each do |h|
-          h[:user].role = 'Waitlist Student'
-          h[:user].status = 'active'
+        it("updates the enrollment for site ID #{site[:course].site_id} with no missing memberships") do
+          expect(site[:enrollment] - updated_enrollment_data).to be_empty
         end
-        students_to_convert.each do |converts|
-          user = converts[:user]
-          section = converts[:section]
-          Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
-        end
-
-        # For one of the deletions, add a different user role manually to ensure that the manual role persists after an enrollment update
-        if lead_tas_to_delete[0] && course.sections.length == 1
-          teacher = lead_tas_to_delete[0].dup
-          teacher[:user].role = 'Teacher'
-          @canvas_page.add_users(course, [teacher[:user]])
-          initial_enrollment_data << {sid: teacher[:user].sis_id, role: teacher[:user].role.downcase, section_id: teacher[:section].sis_id}
-        end
-
-        @canvas_page.upload_sis_imports([csv], [])
-        sites_to_verify << site
-      rescue => e
-        Utils.log_error e
-        it("hit an error in the test for #{site[:course].code}") { fail }
-      end
-    end
-
-    @canvas_page.log_out(@driver, @cal_net_page)
-    @canvas_page.load_homepage
-    @cal_net_page.prompt_for_action 'RUN EXPORT AND REFRESH SCRIPTS MANUALLY'
-    @cal_net_page.wait_for_manual_login
-
-    #########################################
-    ############  MANUAL STEPS  #############
-    #########################################
-
-    # 1. Run export_cached_csv_enrollments.sh
-    # 2. Run refresh_canvas_recent.sh
-    # 3. Log in manually to resume tests
-
-    sites_to_verify.each do |site|
-      course = site[:course]
-      @canvas_page.load_course_site course
-      updated_users_with_sections = @canvas_page.get_users_with_sections course
-      updated_enrollment_data = updated_users_with_sections.map do |u|
-        {
-            sid: u[:user].sis_id,
-            section_id: u[:section].sis_id,
-            role: u[:user].role
-        }
-      end
-      logger.debug "Original site membership: #{site[:enrollment]}"
-      logger.debug "Updated site membership: #{updated_enrollment_data}"
-      logger.debug "Current less original: #{updated_enrollment_data - site[:enrollment]}"
-      logger.debug "Original less current: #{site[:enrollment] - updated_enrollment_data}"
-      it("updates the enrollment for site ID #{site[:course].site_id} with no unexpected memberships") do
-        expect(updated_enrollment_data - site[:enrollment]).to be_empty
-      end
-      it("updates the enrollment for site ID #{site[:course].site_id} with no missing memberships") do
-        expect(site[:enrollment] - updated_enrollment_data).to be_empty
       end
     end
   end

--- a/spec/junction/canvas_lti_e_grades_api_spec.rb
+++ b/spec/junction/canvas_lti_e_grades_api_spec.rb
@@ -1,185 +1,188 @@
-require_relative '../../util/spec_helper'
+unless ENV['STANDALONE']
 
-include Logging
+  require_relative '../../util/spec_helper'
 
-describe 'bCourses E-Grades Export' do
+  include Logging
 
-  begin
+  describe 'bCourses E-Grades Export' do
 
-    test = JunctionTestConfig.new
-    test.e_grades_api
-    letter_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F)
+    begin
 
-    # If using Chrome, use a new Chrome profile
-    Utils.config['webdriver']['chrome_profile'] = false
+      test = JunctionTestConfig.new
+      test.e_grades_api
+      letter_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F)
 
-    @driver = Utils.launch_browser
-    @cal_net = Page::CalNetPage.new @driver
-    @canvas = Page::CanvasGradesPage.new @driver
-    @splash_page = Page::JunctionPages::SplashPage.new @driver
-    @e_grades_export_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
-    @rosters_api = ApiAcademicsRosterPage.new @driver
+      # If using Chrome, use a new Chrome profile
+      Utils.config['webdriver']['chrome_profile'] = false
 
-    @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
+      @driver = Utils.launch_browser
+      @cal_net = Page::CalNetPage.new @driver
+      @canvas = Page::CanvasGradesPage.new @driver
+      @splash_page = Page::JunctionPages::SplashPage.new @driver
+      @e_grades_export_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
+      @rosters_api = ApiAcademicsRosterPage.new @driver
 
-    test.courses.each_with_index do |course, i|
+      @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
 
-      begin
+      test.courses.each_with_index do |course, i|
 
-        # Get SIS roster
-        test.set_sis_teacher course
-        instructor = test.set_sis_teacher course
-        primary_section = test.set_course_sections(course).first
-        @splash_page.load_page
-        @splash_page.basic_auth(instructor.uid, @cal_net)
-        rosters_api = ApiAcademicsRosterPage.new @driver
-        rosters_api.get_feed(@driver, course)
+        begin
 
-        # Disable existing grading scheme in case it is not default, then set default scheme
-        @canvas.masquerade_as(instructor, course)
+          # Get SIS roster
+          test.set_sis_teacher course
+          instructor = test.set_sis_teacher course
+          primary_section = test.set_course_sections(course).first
+          @splash_page.load_page
+          @splash_page.basic_auth(instructor.uid, @cal_net)
+          rosters_api = ApiAcademicsRosterPage.new @driver
+          rosters_api.get_feed(@driver, course)
 
-        %w(letter letter-only pnp sus).each do |scheme|
+          # Disable existing grading scheme in case it is not default, then set default scheme
+          @canvas.masquerade_as(instructor, course)
 
-          @canvas.enable_grading_scheme course
-          @canvas.set_grading_scheme({scheme: scheme})
+          %w(letter letter-only pnp sus).each do |scheme|
 
-          # Get grades in Canvas
-          students = @canvas.get_students(course, primary_section)
-          @canvas.load_gradebook course
-          grades_are_final = @canvas.grades_final?
-          logger.info "Grades are final is #{grades_are_final}"
-          @canvas.hit_escape
-          gradebook_grades = students.map do |user|
-            user.sis_id = rosters_api.sid_from_uid user.uid
-            @canvas.student_score user unless user.sis_id.nil?
-          end
-          gradebook_grades.compact!
-          logger.debug "Gradebook grades: #{gradebook_grades}"
+            @canvas.enable_grading_scheme course
+            @canvas.set_grading_scheme({scheme: scheme})
 
-          ### WITH A P/NP CUTOFF ###
+            # Get grades in Canvas
+            students = @canvas.get_students(course, primary_section)
+            @canvas.load_gradebook course
+            grades_are_final = @canvas.grades_final?
+            logger.info "Grades are final is #{grades_are_final}"
+            @canvas.hit_escape
+            gradebook_grades = students.map do |user|
+              user.sis_id = rosters_api.sid_from_uid user.uid
+              @canvas.student_score user unless user.sis_id.nil?
+            end
+            gradebook_grades.compact!
+            logger.debug "Gradebook grades: #{gradebook_grades}"
 
-          # Get grades in export CSV
-          cutoff = i.even? ? 'C-' : 'A'
-          e_grades = grades_are_final ?
-                         @e_grades_export_page.download_final_grades(course, primary_section, cutoff) :
-                         @e_grades_export_page.download_current_grades(course, primary_section, cutoff)
+            ### WITH A P/NP CUTOFF ###
 
-          if gradebook_grades.any?
-            # Match the grade for each student
-            gradebook_grades.each do |gradebook_row|
-              begin
+            # Get grades in export CSV
+            cutoff = i.even? ? 'C-' : 'A'
+            e_grades = grades_are_final ?
+                           @e_grades_export_page.download_final_grades(course, primary_section, cutoff) :
+                           @e_grades_export_page.download_current_grades(course, primary_section, cutoff)
 
-                # If an error occurred fetching a grade, then the row might cause an error in the test
-                e_grades_row = e_grades.find { |e_grade| e_grade[:id] == gradebook_row[:sis_id] if gradebook_row.instance_of? Hash }
-                if e_grades_row && gradebook_row[:grade]
+            if gradebook_grades.any?
+              # Match the grade for each student
+              gradebook_grades.each do |gradebook_row|
+                begin
 
-                  expected_grade = if %w(letter letter-only).include? scheme
-                                     if e_grades_row[:grading_basis] == 'GRD'
-                                       gradebook_row[:grade]
-                                     else
-                                       pass = letter_grades.index(gradebook_row[:grade]) <= letter_grades.index(cutoff)
-                                       if %w(ESU SUS).include? e_grades_row[:grading_basis]
-                                         pass ? 'S' : 'U'
+                  # If an error occurred fetching a grade, then the row might cause an error in the test
+                  e_grades_row = e_grades.find { |e_grade| e_grade[:id] == gradebook_row[:sis_id] if gradebook_row.instance_of? Hash }
+                  if e_grades_row && gradebook_row[:grade]
+
+                    expected_grade = if %w(letter letter-only).include? scheme
+                                       if e_grades_row[:grading_basis] == 'GRD'
+                                         gradebook_row[:grade]
                                        else
-                                         pass ? 'P' : 'NP'
+                                         pass = letter_grades.index(gradebook_row[:grade]) <= letter_grades.index(cutoff)
+                                         if %w(ESU SUS).include? e_grades_row[:grading_basis]
+                                           pass ? 'S' : 'U'
+                                         else
+                                           pass ? 'P' : 'NP'
+                                         end
                                        end
-                                     end
-                                   else
-                                     gradebook_row[:grade]
-                                   end
-
-
-                  it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
-                      site #{course.site_id} with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
-                    expect(e_grades_row[:grade]).to eql(expected_grade)
-                  end
-
-                  expected_comment = case e_grades_row[:grading_basis]
-                                     when 'GRD'
-                                       'Opted for letter grade'
-                                     when 'ESU', 'SUS'
-                                       'S/U grade'
-                                     when 'CNC'
-                                       'C/NC grade'
                                      else
-                                       ''
+                                       gradebook_row[:grade]
                                      end
-                  it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
-                      site #{course.site_id} with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
-                    expect(e_grades_row[:comments]).to eql(expected_comment)
-                  end
-                end
 
-              rescue => e
-                # Catch and report errors related to the user
-                Utils.log_error e
-                it("encountered an unexpected error with #{course.code} #{gradebook_row}") { fail }
+
+                    it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
+                        site #{course.site_id} with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
+                      expect(e_grades_row[:grade]).to eql(expected_grade)
+                    end
+
+                    expected_comment = case e_grades_row[:grading_basis]
+                                       when 'GRD'
+                                         'Opted for letter grade'
+                                       when 'ESU', 'SUS'
+                                         'S/U grade'
+                                       when 'CNC'
+                                         'C/NC grade'
+                                       else
+                                         ''
+                                       end
+                    it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
+                        site #{course.site_id} with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
+                      expect(e_grades_row[:comments]).to eql(expected_comment)
+                    end
+                  end
+
+                rescue => e
+                  # Catch and report errors related to the user
+                  Utils.log_error e
+                  it("encountered an unexpected error with #{course.code} #{gradebook_row}") { fail }
+                end
               end
+
+            else
+              it("found no Canvas grades for #{course.code}") { fail }
             end
 
-          else
-            it("found no Canvas grades for #{course.code}") { fail }
-          end
+            ### WITH NO P/NP CUTOFF
 
-          ### WITH NO P/NP CUTOFF
+            # Get grades in export CSV
+            cutoff = nil
+            e_grades = grades_are_final ?
+                           @e_grades_export_page.download_final_grades(course, primary_section, cutoff) :
+                           @e_grades_export_page.download_current_grades(course, primary_section, cutoff)
 
-          # Get grades in export CSV
-          cutoff = nil
-          e_grades = grades_are_final ?
-                         @e_grades_export_page.download_final_grades(course, primary_section, cutoff) :
-                         @e_grades_export_page.download_current_grades(course, primary_section, cutoff)
+            if gradebook_grades.any?
+              # Match the grade for each student
+              gradebook_grades.each do |gradebook_row|
+                begin
 
-          if gradebook_grades.any?
-            # Match the grade for each student
-            gradebook_grades.each do |gradebook_row|
-              begin
+                  # If an error occurred fetching a grade, then the row might cause an error in the test
+                  e_grades_row = e_grades.find { |e_grade| e_grade[:id] == gradebook_row[:sis_id] if gradebook_row.instance_of? Hash }
+                  if e_grades_row && gradebook_row[:grade]
 
-                # If an error occurred fetching a grade, then the row might cause an error in the test
-                e_grades_row = e_grades.find { |e_grade| e_grade[:id] == gradebook_row[:sis_id] if gradebook_row.instance_of? Hash }
-                if e_grades_row && gradebook_row[:grade]
+                    expected_grade = gradebook_row[:grade]
 
-                  expected_grade = gradebook_row[:grade]
+                    it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
+                        site #{course.site_id} with grading scheme #{scheme} and no P/NP cutoff" do
+                      expect(e_grades_row[:grade]).to eql(expected_grade)
+                    end
 
-                  it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
-                      site #{course.site_id} with grading scheme #{scheme} and no P/NP cutoff" do
-                    expect(e_grades_row[:grade]).to eql(expected_grade)
+                    expected_comment = case e_grades_row[:grading_basis]
+                                       when 'GRD'
+                                         'Opted for letter grade'
+                                       when 'ESU', 'SUS'
+                                         'S/U grade'
+                                       when 'CNC'
+                                         'C/NC grade'
+                                       else
+                                         ''
+                                       end
+                    it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
+                        site #{course.site_id} with grading scheme #{scheme} and no P/NP cutoff" do
+                      expect(e_grades_row[:comments]).to eql(expected_comment)
+                    end
                   end
 
-                  expected_comment = case e_grades_row[:grading_basis]
-                                     when 'GRD'
-                                       'Opted for letter grade'
-                                     when 'ESU', 'SUS'
-                                       'S/U grade'
-                                     when 'CNC'
-                                       'C/NC grade'
-                                     else
-                                       ''
-                                     end
-                  it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:uid]} in #{course.term} #{course.code}
-                      site #{course.site_id} with grading scheme #{scheme} and no P/NP cutoff" do
-                    expect(e_grades_row[:comments]).to eql(expected_comment)
-                  end
+                rescue => e
+                  # Catch and report errors related to the user
+                  Utils.log_error e
+                  it("encountered an unexpected error with #{course.code} #{gradebook_row}") { fail }
                 end
-
-              rescue => e
-                # Catch and report errors related to the user
-                Utils.log_error e
-                it("encountered an unexpected error with #{course.code} #{gradebook_row}") { fail }
               end
             end
           end
+        rescue => e
+          # Catch and report errors related to the course
+          Utils.log_error e
+          it("encountered an unexpected error with #{course.code}") { fail }
         end
-      rescue => e
-        # Catch and report errors related to the course
-        Utils.log_error e
-        it("encountered an unexpected error with #{course.code}") { fail }
       end
+    rescue => e
+      # Catch and report errors related to the whole test
+      Utils.log_error e
+      it('encountered an unexpected error') { fail }
+    ensure
+      @driver.quit
     end
-  rescue => e
-    # Catch and report errors related to the whole test
-    Utils.log_error e
-    it('encountered an unexpected error') { fail }
-  ensure
-    @driver.quit
   end
 end

--- a/spec/junction/canvas_lti_e_grades_export_spec.rb
+++ b/spec/junction/canvas_lti_e_grades_export_spec.rb
@@ -1,367 +1,370 @@
-require_relative '../../util/spec_helper'
+unless ENV['STANDALONE']
 
-describe 'bCourses E-Grades Export', order: :defined do
+  require_relative '../../util/spec_helper'
 
-  include Logging
+  describe 'bCourses E-Grades Export', order: :defined do
 
-  test = JunctionTestConfig.new
-  test.e_grades_export
+    include Logging
 
-  course = test.courses.first
-  sections = test.set_course_sections(course).select(&:include_in_site)
-  teacher = test.set_sis_teacher course
-  non_teachers = [test.lead_ta, test.ta, test.designer, test.reader, test.observer, test.students.first, test.wait_list_student]
-  primary_section = sections.first
-  secondary_section = sections.last if sections.length > 1
+    test = JunctionTestConfig.new
+    test.e_grades_export
 
-  before(:all) do
-    @driver = Utils.launch_browser
-    @cal_net = Page::CalNetPage.new @driver
-    @canvas = Page::CanvasGradesPage.new @driver
-    @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
-    @splash_page = Page::JunctionPages::SplashPage.new @driver
-    @e_grades_export_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
-    @course_add_user_page = Page::JunctionPages::CanvasCourseAddUserPage.new @driver
-    @rosters_api = ApiAcademicsRosterPage.new @driver
-    @academics_api = ApiAcademicsCourseProvisionPage.new @driver
-
-    # Get roster and section data for the site
-    @splash_page.load_page
-    @splash_page.basic_auth(teacher.uid, @cal_net)
-    @rosters_api.get_feed(@driver, course)
-    @academics_api.get_feed(@driver)
-
-    @prim_sec_sids = @rosters_api.student_ids(@rosters_api.section_students("#{primary_section.course} #{primary_section.label}"))
-    if secondary_section
-      @sec_sec_sids = @rosters_api.student_ids(@rosters_api.section_students("#{secondary_section.course} #{secondary_section.label}"))
-    end
-
-    @current_semester = @academics_api.current_semester @academics_api.all_teaching_semesters
-    @current_semester_name = @academics_api.semester_name @current_semester if @current_semester
-    @driver.manage.delete_all_cookies
-
-    @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
-    @canvas.masquerade_as teacher
-
-    # Create an ungraded assignment to use for testing manual grading policy
-    @ungraded_assignment = Assignment.new(title: Utils.get_test_id)
-    @canvas.set_grade_policy_manual course
-    @canvas_assignments_page.create_assignment(course, @ungraded_assignment)
-
-    # Ensure final grade override feature is enabled on the course for override tests
-    @canvas.enable_final_grade_override course
-  end
-
-  after(:all) do
-    @canvas.stop_masquerading
-    assignments = @canvas_assignments_page.get_list_view_assignments course
-    @canvas_assignments_page.delete_test_assignments assignments
-  ensure
-    Utils.quit_browser @driver
-  end
-
-  it 'offers an E-Grades Export button on the Gradebook' do
-    @canvas.load_gradebook course
-    @canvas.click_e_grades_export_button
-    @e_grades_export_page.wait_until(Utils.medium_wait) { @e_grades_export_page.title == 'Download E-Grades' }
-    @e_grades_export_page.wait_until(1, 'Wrong Junction environment is configured') do
-      @e_grades_export_page.i_frame_form_element? JunctionUtils.junction_base_url
-    end
-  end
-
-  context 'when no grading scheme is enabled and an assignment is un-posted' do
-
-    before(:all) { @canvas.disable_grading_scheme course }
-
-    before(:each) { @e_grades_export_page.load_embedded_tool course }
-
-    it 'offers a "Course Settings" link' do
-      @e_grades_export_page.click_course_settings_button_disabled
-      @canvas.wait_until(Utils.medium_wait) { @canvas.current_url.include? "#{Utils.canvas_base_url}/courses/#{course.site_id}/settings" }
-    end
-
-    it 'offers a "How do I post grades for an assignment?" link' do
-      title = 'How do I post grades for an assignment in the G... | Canvas LMS Community'
-      expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
-    end
-
-    it 'allows the user to Cancel' do
-      @e_grades_export_page.click_cancel
-      @canvas.wait_until(Utils.medium_wait) { @canvas.current_url == "#{Utils.canvas_base_url}/courses/#{course.site_id}/gradebook" }
-    end
-
-    it 'prevents the user continuing' do
-      @e_grades_export_page.continue_button_element.when_visible Utils.medium_wait
-      expect(@e_grades_export_page.continue_button_element.attribute('disabled')).to eql('true')
-    end
-  end
-
-  context 'when a grading scheme is enabled and an assignment is un-posted' do
-
-    before(:all) { @canvas.enable_grading_scheme course }
-
-    before(:each) { @e_grades_export_page.load_embedded_tool course }
-
-    it 'offers a "Course Settings" link' do
-      @e_grades_export_page.click_course_settings_button_enabled
-      @canvas.wait_until(Utils.medium_wait) { @canvas.current_url.include? "#{Utils.canvas_base_url}/courses/#{course.site_id}/settings" }
-    end
-
-    it 'offers a "How do I post grades for an assignment?" link' do
-      title = 'How do I mute or unmute an assignment in the Gradebook? | Canvas Instructor Guide | Canvas Guides'
-      expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
-    end
-
-    it 'allows the user to Cancel' do
-      @e_grades_export_page.click_cancel
-      @canvas.wait_until(Utils.medium_wait) { @canvas.current_url == "#{Utils.canvas_base_url}/courses/#{course.site_id}/gradebook" }
-    end
-
-    it 'allows the user to Continue' do
-      @e_grades_export_page.click_continue
-      @e_grades_export_page.download_final_grades_element.when_visible Utils.medium_wait
-    end
-  end
-
-  # Canvas and BCS test environments are on different refresh schedules, so their enrollment data can differ in the current term.
-  # Only compare their enrollment data if the term is in the past and no longer changing.
-
-  context 'when no assignment is muted and a grading scheme is enabled' do
+    course = test.courses.first
+    sections = test.set_course_sections(course).select(&:include_in_site)
+    teacher = test.set_sis_teacher course
+    non_teachers = [test.lead_ta, test.ta, test.designer, test.reader, test.observer, test.students.first, test.wait_list_student]
+    primary_section = sections.first
+    secondary_section = sections.last if sections.length > 1
 
     before(:all) do
-      @e_grades_export_page.load_embedded_tool course
-      @e_grades_export_page.click_continue
-    end
+      @driver = Utils.launch_browser
+      @cal_net = Page::CalNetPage.new @driver
+      @canvas = Page::CanvasGradesPage.new @driver
+      @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
+      @splash_page = Page::JunctionPages::SplashPage.new @driver
+      @e_grades_export_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
+      @course_add_user_page = Page::JunctionPages::CanvasCourseAddUserPage.new @driver
+      @rosters_api = ApiAcademicsRosterPage.new @driver
+      @academics_api = ApiAcademicsCourseProvisionPage.new @driver
 
-    it 'allows the user the select any section on the course site' do
-      expected_options = @rosters_api.section_names.sort
-      if expected_options.length > 1
-        expect(@e_grades_export_page.sections_select_options.sort).to eql(expected_options)
-      end
-    end
+      # Get roster and section data for the site
+      @splash_page.load_page
+      @splash_page.basic_auth(teacher.uid, @cal_net)
+      @rosters_api.get_feed(@driver, course)
+      @academics_api.get_feed(@driver)
 
-    it 'requires the user to select a pass / no pass cutoff grade' do
-      expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
-      expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
-    end
-
-    shared_examples 'CSV downloads' do |cutoff|
-
-      it 'allows the user to download current grades for a primary section' do
-        csv = @e_grades_export_page.download_current_grades(course, primary_section, cutoff)
-        if @current_semester && course.term == @current_semester_name
-          expect(csv.any?).to be true
-        else
-          expected_sids = @prim_sec_sids.sort
-          actual_sids = csv.map { |k| k[:id] }.sort
-          @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-            expected_sids == actual_sids
-          end
-        end
+      @prim_sec_sids = @rosters_api.student_ids(@rosters_api.section_students("#{primary_section.course} #{primary_section.label}"))
+      if secondary_section
+        @sec_sec_sids = @rosters_api.student_ids(@rosters_api.section_students("#{secondary_section.course} #{secondary_section.label}"))
       end
 
-      it 'allows the user to download current grades for a secondary section' do
-        if secondary_section
-          csv = @e_grades_export_page.download_current_grades(course, secondary_section, cutoff)
-          if @current_semester && course.term == @current_semester_name
-            expect(csv.any?).to be true
-          else
-            expected_sids = @sec_sec_sids.sort
-            actual_sids = csv.map { |k| k[:id] }.sort
-            @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-              expected_sids == actual_sids
-            end
-          end
-        end
-      end
+      @current_semester = @academics_api.current_semester @academics_api.all_teaching_semesters
+      @current_semester_name = @academics_api.semester_name @current_semester if @current_semester
+      @driver.manage.delete_all_cookies
 
-      it 'allows the user to download final grades for a primary section' do
-        csv = @e_grades_export_page.download_final_grades(course, primary_section, cutoff)
-        if @current_semester && course.term == @current_semester_name
-          expect(csv.any?).to be true
-        else
-          expected_sids = @prim_sec_sids.sort
-          actual_sids = csv.map { |k| k[:id] }.sort
-          @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-            expected_sids == actual_sids
-          end
-        end
-      end
+      @canvas.log_in(@cal_net, Utils.super_admin_username, Utils.super_admin_password)
+      @canvas.masquerade_as teacher
 
-      it 'allows the user to download final grades for a secondary section' do
-        if secondary_section
-          csv = @e_grades_export_page.download_final_grades(course, secondary_section, cutoff)
-          if @current_semester && course.term == @current_semester_name
-            expect(csv.any?).to be true
-          else
-            expected_sids = @sec_sec_sids.sort
-            actual_sids = csv.map { |k| k[:id] }.sort
-            @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-              expected_sids == actual_sids
-            end
-          end
-        end
-      end
+      # Create an ungraded assignment to use for testing manual grading policy
+      @ungraded_assignment = Assignment.new(title: Utils.get_test_id)
+      @canvas.set_grade_policy_manual course
+      @canvas_assignments_page.create_assignment(course, @ungraded_assignment)
+
+      # Ensure final grade override feature is enabled on the course for override tests
+      @canvas.enable_final_grade_override course
     end
 
-    context 'and the user selects a pass / no pass cutoff' do
-
-      include_examples 'CSV downloads', 'C-'
-
+    after(:all) do
+      @canvas.stop_masquerading
+      assignments = @canvas_assignments_page.get_list_view_assignments course
+      @canvas_assignments_page.delete_test_assignments assignments
+    ensure
+      Utils.quit_browser @driver
     end
 
-    context 'and the user does not select a pass / no pass cutoff' do
-
-      include_examples 'CSV downloads', nil
-
-    end
-  end
-
-  describe 'CSV export' do
-
-    before(:all) do
-      section_name = "#{primary_section.course} #{primary_section.label}"
-      @roster_students = @rosters_api.section_students section_name
-      @e_grades = @e_grades_export_page.download_final_grades(course, primary_section, 'C-')
-    end
-
-    it 'has the right column headers' do
-      expected_header = %w(id name grade grading_basis comments).map { |h| h.to_sym }
-      actual_header = (@e_grades.map { |h| h.keys }).flatten.uniq
-      logger.debug "Expecting #{expected_header} and got #{actual_header}"
-      expect(actual_header).to eql(expected_header)
-    end
-
-    it 'has the right SIDs' do
-      expected_sids = @rosters_api.student_ids(@roster_students).sort
-      actual_sids = @e_grades.map { |s| s[:id] }.sort
-      logger.debug "Expecting #{expected_sids} and got #{actual_sids}"
-      expect(actual_sids.any? &:empty?).to be false
-      @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-        expected_sids == actual_sids
-      end
-    end
-
-    it 'has the right names' do
-      # Compare last names only, since preferred names can cause mismatches
-      expected_names = @rosters_api.student_last_names(@roster_students).sort
-      actual_names = @e_grades.map { |n| n[:name].split(',')[0].strip.downcase }.sort
-      logger.debug "Expecting #{expected_names} and got #{actual_names}"
-      expect(actual_names.any? &:empty?).to be false
-      @e_grades_export_page.wait_until(1,  "Missing: #{expected_names - actual_names}. Unexpected: #{actual_names - expected_names}") do
-        expected_names == actual_names
-      end
-    end
-
-    it 'has reasonable grades' do
-      expected_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F P NP S U)
-      actual_grades = @e_grades.map { |g| g[:grade] }
-      logger.debug "Expecting #{expected_grades} and got #{actual_grades.uniq}"
-      expect(actual_grades.any? &:empty?).to be false
-      expect((actual_grades - expected_grades).any?).to be false
-    end
-
-    it 'has reasonable grading bases' do
-      expected_grading_bases = %w(DPN EPN ESU GRD)
-      actual_grading_bases = @e_grades.map { |b| b[:grading_basis] }
-      logger.debug "Expecting #{expected_grading_bases} and got #{actual_grading_bases.uniq}"
-      expect(actual_grading_bases.any? &:empty?).to be false
-      expect((actual_grading_bases - expected_grading_bases).any?).to be false
-    end
-  end
-
-  describe 'final grade' do
-
-    before(:all) do
-      students = @canvas.get_students(course, primary_section)
-      @canvas.enable_grading_scheme course
+    it 'offers an E-Grades Export button on the Gradebook' do
       @canvas.load_gradebook course
-      @grades_are_final = @canvas.grades_final?
-      logger.info "Grades are final is #{@grades_are_final}"
-      @canvas.hit_escape
-
-      # Get actual grade data for one student
-      gradebook_grade_data = students.map do |user|
-        user.sis_id = @rosters_api.sid_from_uid user.uid
-        @canvas.student_score user unless user.sis_id.nil?
+      @canvas.click_e_grades_export_button
+      @e_grades_export_page.wait_until(Utils.medium_wait) { @e_grades_export_page.title == 'Download E-Grades' }
+      @e_grades_export_page.wait_until(1, 'Wrong Junction environment is configured') do
+        @e_grades_export_page.i_frame_form_element? JunctionUtils.junction_base_url
       end
-      gradebook_grade_data.compact!
-      test_data = gradebook_grade_data.first
-      logger.debug "Test data: #{test_data}"
-
-      @test_student = BOACUser.new(uid: test_data[:uid],
-                                   sis_id: test_data[:sis_id],
-                                   canvas_id: test_data[:canvas_id])
-      @test_grade = test_data[:grade]
-      @override_grade = %w(A A- B+ B B- C+ C C- D+ D D- F).find { |g| g != @test_grade }
     end
 
-    context 'when override is enabled' do
+    context 'when no grading scheme is enabled and an assignment is un-posted' do
+
+      before(:all) { @canvas.disable_grading_scheme course }
+
+      before(:each) { @e_grades_export_page.load_embedded_tool course }
+
+      it 'offers a "Course Settings" link' do
+        @e_grades_export_page.click_course_settings_button_disabled
+        @canvas.wait_until(Utils.medium_wait) { @canvas.current_url.include? "#{Utils.canvas_base_url}/courses/#{course.site_id}/settings" }
+      end
+
+      it 'offers a "How do I post grades for an assignment?" link' do
+        title = 'How do I post grades for an assignment in the G... | Canvas LMS Community'
+        expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
+      end
+
+      it 'allows the user to Cancel' do
+        @e_grades_export_page.click_cancel
+        @canvas.wait_until(Utils.medium_wait) { @canvas.current_url == "#{Utils.canvas_base_url}/courses/#{course.site_id}/gradebook" }
+      end
+
+      it 'prevents the user continuing' do
+        @e_grades_export_page.continue_button_element.when_visible Utils.medium_wait
+        expect(@e_grades_export_page.continue_button_element.attribute('disabled')).to eql('true')
+      end
+    end
+
+    context 'when a grading scheme is enabled and an assignment is un-posted' do
+
+      before(:all) { @canvas.enable_grading_scheme course }
+
+      before(:each) { @e_grades_export_page.load_embedded_tool course }
+
+      it 'offers a "Course Settings" link' do
+        @e_grades_export_page.click_course_settings_button_enabled
+        @canvas.wait_until(Utils.medium_wait) { @canvas.current_url.include? "#{Utils.canvas_base_url}/courses/#{course.site_id}/settings" }
+      end
+
+      it 'offers a "How do I post grades for an assignment?" link' do
+        title = 'How do I mute or unmute an assignment in the Gradebook? | Canvas Instructor Guide | Canvas Guides'
+        expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
+      end
+
+      it 'allows the user to Cancel' do
+        @e_grades_export_page.click_cancel
+        @canvas.wait_until(Utils.medium_wait) { @canvas.current_url == "#{Utils.canvas_base_url}/courses/#{course.site_id}/gradebook" }
+      end
+
+      it 'allows the user to Continue' do
+        @e_grades_export_page.click_continue
+        @e_grades_export_page.download_final_grades_element.when_visible Utils.medium_wait
+      end
+    end
+
+    # Canvas and BCS test environments are on different refresh schedules, so their enrollment data can differ in the current term.
+    # Only compare their enrollment data if the term is in the past and no longer changing.
+
+    context 'when no assignment is muted and a grading scheme is enabled' do
 
       before(:all) do
-        @canvas.load_gradebook course
-        @canvas.allow_grade_override
-        @canvas.enter_override_grade(course, @test_student, @override_grade)
-      end
-
-      it 'downloads the override grade rather than the calculated grade in current grades' do
-        e_grades = @e_grades_export_page.download_current_grades(course, primary_section)
-        e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
-        expect(e_grades_row[:grade]).to eql(@override_grade)
-      end
-
-      it 'downloads the override grade rather than the calculated grade in final grades' do
-        e_grades = @e_grades_export_page.download_final_grades(course, primary_section)
-        e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
-        expect(e_grades_row[:grade]).to eql(@override_grade)
-      end
-    end
-
-    context 'when override is disabled' do
-
-      before(:all) do
-        @canvas.load_gradebook course
-        @canvas.disallow_grade_override
-      end
-
-      it 'downloads the calculated grade rather than the override grade' do
-        e_grades = if @grades_are_final
-                     @e_grades_export_page.download_final_grades(course, primary_section)
-                   else
-                     @e_grades_export_page.download_current_grades(course, primary_section)
-                   end
-
-        e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
-        expect(e_grades_row[:grade]).to eql(@test_grade)
-      end
-    end
-  end
-
-  describe 'user role restrictions' do
-
-    before(:all) do
-      non_teachers.each do |user|
-        @course_add_user_page.load_embedded_tool course
-        @course_add_user_page.search(user.uid, 'CalNet UID')
-        @course_add_user_page.add_user_by_uid(user, primary_section)
-      end
-    end
-
-    non_teachers.each do |user|
-      it "allows a course #{user.role} to access the tool if permitted to do so" do
-        @canvas.masquerade_as(user, course)
-        logger.debug "Checking a #{user.role}'s access to the tool"
         @e_grades_export_page.load_embedded_tool course
+        @e_grades_export_page.click_continue
+      end
 
-        if [test.lead_ta, test.ta, test.reader].include? user
+      it 'allows the user the select any section on the course site' do
+        expected_options = @rosters_api.section_names.sort
+        if expected_options.length > 1
+          expect(@e_grades_export_page.sections_select_options.sort).to eql(expected_options)
+        end
+      end
+
+      it 'requires the user to select a pass / no pass cutoff grade' do
+        expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
+        expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
+      end
+
+      shared_examples 'CSV downloads' do |cutoff|
+
+        it 'allows the user to download current grades for a primary section' do
+          csv = @e_grades_export_page.download_current_grades(course, primary_section, cutoff)
+          if @current_semester && course.term == @current_semester_name
+            expect(csv.any?).to be true
+          else
+            expected_sids = @prim_sec_sids.sort
+            actual_sids = csv.map { |k| k[:id] }.sort
+            @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+              expected_sids == actual_sids
+            end
+          end
+        end
+
+        it 'allows the user to download current grades for a secondary section' do
+          if secondary_section
+            csv = @e_grades_export_page.download_current_grades(course, secondary_section, cutoff)
+            if @current_semester && course.term == @current_semester_name
+              expect(csv.any?).to be true
+            else
+              expected_sids = @sec_sec_sids.sort
+              actual_sids = csv.map { |k| k[:id] }.sort
+              @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+                expected_sids == actual_sids
+              end
+            end
+          end
+        end
+
+        it 'allows the user to download final grades for a primary section' do
+          csv = @e_grades_export_page.download_final_grades(course, primary_section, cutoff)
+          if @current_semester && course.term == @current_semester_name
+            expect(csv.any?).to be true
+          else
+            expected_sids = @prim_sec_sids.sort
+            actual_sids = csv.map { |k| k[:id] }.sort
+            @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+              expected_sids == actual_sids
+            end
+          end
+        end
+
+        it 'allows the user to download final grades for a secondary section' do
+          if secondary_section
+            csv = @e_grades_export_page.download_final_grades(course, secondary_section, cutoff)
+            if @current_semester && course.term == @current_semester_name
+              expect(csv.any?).to be true
+            else
+              expected_sids = @sec_sec_sids.sort
+              actual_sids = csv.map { |k| k[:id] }.sort
+              @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+                expected_sids == actual_sids
+              end
+            end
+          end
+        end
+      end
+
+      context 'and the user selects a pass / no pass cutoff' do
+
+        include_examples 'CSV downloads', 'C-'
+
+      end
+
+      context 'and the user does not select a pass / no pass cutoff' do
+
+        include_examples 'CSV downloads', nil
+
+      end
+    end
+
+    describe 'CSV export' do
+
+      before(:all) do
+        section_name = "#{primary_section.course} #{primary_section.label}"
+        @roster_students = @rosters_api.section_students section_name
+        @e_grades = @e_grades_export_page.download_final_grades(course, primary_section, 'C-')
+      end
+
+      it 'has the right column headers' do
+        expected_header = %w(id name grade grading_basis comments).map { |h| h.to_sym }
+        actual_header = (@e_grades.map { |h| h.keys }).flatten.uniq
+        logger.debug "Expecting #{expected_header} and got #{actual_header}"
+        expect(actual_header).to eql(expected_header)
+      end
+
+      it 'has the right SIDs' do
+        expected_sids = @rosters_api.student_ids(@roster_students).sort
+        actual_sids = @e_grades.map { |s| s[:id] }.sort
+        logger.debug "Expecting #{expected_sids} and got #{actual_sids}"
+        expect(actual_sids.any? &:empty?).to be false
+        @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+          expected_sids == actual_sids
+        end
+      end
+
+      it 'has the right names' do
+        # Compare last names only, since preferred names can cause mismatches
+        expected_names = @rosters_api.student_last_names(@roster_students).sort
+        actual_names = @e_grades.map { |n| n[:name].split(',')[0].strip.downcase }.sort
+        logger.debug "Expecting #{expected_names} and got #{actual_names}"
+        expect(actual_names.any? &:empty?).to be false
+        @e_grades_export_page.wait_until(1,  "Missing: #{expected_names - actual_names}. Unexpected: #{actual_names - expected_names}") do
+          expected_names == actual_names
+        end
+      end
+
+      it 'has reasonable grades' do
+        expected_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F P NP S U)
+        actual_grades = @e_grades.map { |g| g[:grade] }
+        logger.debug "Expecting #{expected_grades} and got #{actual_grades.uniq}"
+        expect(actual_grades.any? &:empty?).to be false
+        expect((actual_grades - expected_grades).any?).to be false
+      end
+
+      it 'has reasonable grading bases' do
+        expected_grading_bases = %w(DPN EPN ESU GRD)
+        actual_grading_bases = @e_grades.map { |b| b[:grading_basis] }
+        logger.debug "Expecting #{expected_grading_bases} and got #{actual_grading_bases.uniq}"
+        expect(actual_grading_bases.any? &:empty?).to be false
+        expect((actual_grading_bases - expected_grading_bases).any?).to be false
+      end
+    end
+
+    describe 'final grade' do
+
+      before(:all) do
+        students = @canvas.get_students(course, primary_section)
+        @canvas.enable_grading_scheme course
+        @canvas.load_gradebook course
+        @grades_are_final = @canvas.grades_final?
+        logger.info "Grades are final is #{@grades_are_final}"
+        @canvas.hit_escape
+
+        # Get actual grade data for one student
+        gradebook_grade_data = students.map do |user|
+          user.sis_id = @rosters_api.sid_from_uid user.uid
+          @canvas.student_score user unless user.sis_id.nil?
+        end
+        gradebook_grade_data.compact!
+        test_data = gradebook_grade_data.first
+        logger.debug "Test data: #{test_data}"
+
+        @test_student = BOACUser.new(uid: test_data[:uid],
+                                     sis_id: test_data[:sis_id],
+                                     canvas_id: test_data[:canvas_id])
+        @test_grade = test_data[:grade]
+        @override_grade = %w(A A- B+ B B- C+ C C- D+ D D- F).find { |g| g != @test_grade }
+      end
+
+      context 'when override is enabled' do
+
+        before(:all) do
           @canvas.load_gradebook course
-          @canvas.click_e_grades_export_button
-          @e_grades_export_page.switch_to_canvas_iframe
-          @e_grades_export_page.not_auth_msg_element.when_visible Utils.medium_wait
+          @canvas.allow_grade_override
+          @canvas.enter_override_grade(course, @test_student, @override_grade)
+        end
 
-        elsif [test.designer, test.students.first, test.wait_list_student, test.observer].include? user
+        it 'downloads the override grade rather than the calculated grade in current grades' do
+          e_grades = @e_grades_export_page.download_current_grades(course, primary_section)
+          e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
+          expect(e_grades_row[:grade]).to eql(@override_grade)
+        end
+
+        it 'downloads the override grade rather than the calculated grade in final grades' do
+          e_grades = @e_grades_export_page.download_final_grades(course, primary_section)
+          e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
+          expect(e_grades_row[:grade]).to eql(@override_grade)
+        end
+      end
+
+      context 'when override is disabled' do
+
+        before(:all) do
+          @canvas.load_gradebook course
+          @canvas.disallow_grade_override
+        end
+
+        it 'downloads the calculated grade rather than the override grade' do
+          e_grades = if @grades_are_final
+                       @e_grades_export_page.download_final_grades(course, primary_section)
+                     else
+                       @e_grades_export_page.download_current_grades(course, primary_section)
+                     end
+
+          e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
+          expect(e_grades_row[:grade]).to eql(@test_grade)
+        end
+      end
+    end
+
+    describe 'user role restrictions' do
+
+      before(:all) do
+        non_teachers.each do |user|
+          @course_add_user_page.load_embedded_tool course
+          @course_add_user_page.search(user.uid, 'CalNet UID')
+          @course_add_user_page.add_user_by_uid(user, primary_section)
+        end
+      end
+
+      non_teachers.each do |user|
+        it "allows a course #{user.role} to access the tool if permitted to do so" do
+          @canvas.masquerade_as(user, course)
+          logger.debug "Checking a #{user.role}'s access to the tool"
           @e_grades_export_page.load_embedded_tool course
-          @e_grades_export_page.not_auth_msg_element.when_visible Utils.medium_wait
+
+          if [test.lead_ta, test.ta, test.reader].include? user
+            @canvas.load_gradebook course
+            @canvas.click_e_grades_export_button
+            @e_grades_export_page.switch_to_canvas_iframe
+            @e_grades_export_page.not_auth_msg_element.when_visible Utils.medium_wait
+
+          elsif [test.designer, test.students.first, test.wait_list_student, test.observer].include? user
+            @e_grades_export_page.load_embedded_tool course
+            @e_grades_export_page.not_auth_msg_element.when_visible Utils.medium_wait
+          end
         end
       end
     end

--- a/spec/junction/canvas_lti_mailing_lists_spec.rb
+++ b/spec/junction/canvas_lti_mailing_lists_spec.rb
@@ -1,221 +1,223 @@
-require_relative '../../util/spec_helper'
+unless ENV['STANDALONE']
 
-describe 'bCourses Mailgun mailing lists', order: :defined do
+  require_relative '../../util/spec_helper'
 
-  include Logging
+  describe 'bCourses Mailgun mailing lists', order: :defined do
 
-  test = JunctionTestConfig.new
-  test.mailing_lists
-  timeout = Utils.short_wait
+    include Logging
 
-  course_site_1 = Course.new({title: "QA Mailing List 1 #{test.id}", code: "QA admin #{test.id}"})
-  course_site_2 = Course.new({title: "QA Mailing List 2 #{test.id}", code: "QA admin #{test.id}"})
-  course_site_3 = Course.new({title: "QA Mailing List 3 #{test.id}", code: "QA instructor #{test.id}"})
+    test = JunctionTestConfig.new
+    test.mailing_lists
+    timeout = Utils.short_wait
 
-  users = [test.manual_teacher, test.designer, test.lead_ta, test.ta, test.observer, test.reader, test.students].flatten
+    course_site_1 = Course.new({title: "QA Mailing List 1 #{test.id}", code: "QA admin #{test.id}"})
+    course_site_2 = Course.new({title: "QA Mailing List 2 #{test.id}", code: "QA admin #{test.id}"})
+    course_site_3 = Course.new({title: "QA Mailing List 3 #{test.id}", code: "QA instructor #{test.id}"})
 
-  before(:all) do
-    @driver = Utils.launch_browser
-    @canvas_page = Page::CanvasPage.new @driver
-    @cal_net_page = Page::CalNetPage.new @driver
-    @splash_page = Page::JunctionPages::SplashPage.new @driver
-    @toolbox_page = Page::JunctionPages::MyToolboxPage.new @driver
-    @mailing_list_page = Page::JunctionPages::CanvasMailingListPage.new @driver
-    @mailing_lists_page = Page::JunctionPages::CanvasMailingListsPage.new @driver
-    @site_creation_page = Page::JunctionPages::CanvasSiteCreationPage.new @driver
-    @create_project_site_page = Page::JunctionPages::CanvasCreateProjectSitePage.new @driver
-
-    # Create three course sites in the Official Courses sub-account
-    @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
-    @canvas_page.create_generic_course_site(Utils.canvas_official_courses_sub_account, course_site_1, users, test.id)
-    @canvas_page.create_generic_course_site(Utils.canvas_official_courses_sub_account, course_site_2, [test.manual_teacher], test.id)
-    @canvas_page.create_generic_course_site(Utils.canvas_official_courses_sub_account, course_site_3, users, test.id)
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  it 'is not added to site navigation by default' do
-    @canvas_page.load_course_site course_site_1
-    @canvas_page.list_item_element(id: 'section-tabs').when_present Utils.medium_wait
-    expect(@mailing_list_page.mailing_list_link?).to be false
-  end
-
-  users.each do |user|
-    it "can be managed by a course #{user.role} if the user has permission to reach the instructor-facing tool" do
-      @canvas_page.masquerade_as(user, course_site_1)
-      @mailing_list_page.load_embedded_tool course_site_1
-      if [test.manual_teacher, test.lead_ta, test.ta, test.reader].include? user
-        logger.debug "Verifying that #{user.role} UID #{user.uid} has access to the instructor-facing mailing list tool"
-        @mailing_list_page.create_list_button_element.when_present(Utils.medium_wait)
-      else
-        logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the instructor-facing mailing list tool"
-        @canvas_page.unexpected_error_msg_element.when_visible(Utils.medium_wait)
-      end
-    end
-
-    it "cannot be managed by a course #{user.role} via the admin tool" do
-      @canvas_page.masquerade_as(user, course_site_1)
-      @mailing_lists_page.load_embedded_tool
-      @mailing_lists_page.search_for_list course_site_1.site_id
-      logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the admin mailing lists tool"
-      @canvas_page.unexpected_error_msg_element.when_visible Utils.medium_wait
-    end
-  end
-
-  describe 'admin tool' do
+    users = [test.manual_teacher, test.designer, test.lead_ta, test.ta, test.observer, test.reader, test.students].flatten
 
     before(:all) do
-      @driver.switch_to.default_content
-      @canvas_page.stop_masquerading if @canvas_page.stop_masquerading_link?
-      @mailing_lists_page.load_embedded_tool
+      @driver = Utils.launch_browser
+      @canvas_page = Page::CanvasPage.new @driver
+      @cal_net_page = Page::CalNetPage.new @driver
+      @splash_page = Page::JunctionPages::SplashPage.new @driver
+      @mailing_list_page = Page::JunctionPages::CanvasMailingListPage.new @driver
+      @mailing_lists_page = Page::JunctionPages::CanvasMailingListsPage.new @driver
+      @site_creation_page = Page::JunctionPages::CanvasSiteCreationPage.new @driver
+      @create_project_site_page = Page::JunctionPages::CanvasCreateProjectSitePage.new @driver
+
+      # Create three course sites in the Official Courses sub-account
+      @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
+      @canvas_page.create_generic_course_site(Utils.canvas_official_courses_sub_account, course_site_1, users, test.id)
+      @canvas_page.create_generic_course_site(Utils.canvas_official_courses_sub_account, course_site_2, [test.manual_teacher], test.id)
+      @canvas_page.create_generic_course_site(Utils.canvas_official_courses_sub_account, course_site_3, users, test.id)
     end
 
-    context 'when creating a list' do
+    after(:all) { Utils.quit_browser @driver }
 
-      it 'requires a numeric site ID in order to find a site' do
-        @mailing_lists_page.search_for_list 'foo'
-        @mailing_lists_page.bad_input_msg_element.when_visible timeout
+    it 'is not added to site navigation by default' do
+      @canvas_page.load_course_site course_site_1
+      @canvas_page.list_item_element(id: 'section-tabs').when_present Utils.medium_wait
+      expect(@mailing_list_page.mailing_list_link?).to be false
+    end
+
+    users.each do |user|
+      it "can be managed by a course #{user.role} if the user has permission to reach the instructor-facing tool" do
+        @canvas_page.masquerade_as(user, course_site_1)
+        @mailing_list_page.load_embedded_tool course_site_1
+        if [test.manual_teacher, test.lead_ta, test.ta, test.reader].include? user
+          logger.debug "Verifying that #{user.role} UID #{user.uid} has access to the instructor-facing mailing list tool"
+          @mailing_list_page.create_list_button_element.when_present(Utils.medium_wait)
+        else
+          logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the instructor-facing mailing list tool"
+          @canvas_page.unexpected_error_msg_element.when_visible(Utils.medium_wait)
+        end
       end
 
-      it 'requires a valid numeric site ID in order to find a site' do
-        @mailing_lists_page.search_for_list '99999999999'
-        @mailing_lists_page.not_found_msg_element.when_visible timeout
-      end
-
-      it 'retrieves a course site for a valid numeric site ID' do
+      it "cannot be managed by a course #{user.role} via the admin tool" do
+        @canvas_page.masquerade_as(user, course_site_1)
+        @mailing_lists_page.load_embedded_tool
         @mailing_lists_page.search_for_list course_site_1.site_id
-        @mailing_lists_page.register_list_button_element.when_visible timeout
-      end
-
-      it 'shows the course site code, title, and ID' do
-        expect(@mailing_lists_page.site_name).to eql(course_site_1.title)
-        expect(@mailing_lists_page.site_code).to eql(("#{course_site_1.code} #{course_site_1.term}").strip)
-        expect(@mailing_lists_page.site_id).to eql("Site ID: #{course_site_1.site_id}")
-      end
-
-      it('shows a link to the course site') { expect(@mailing_lists_page.external_link_valid?(@mailing_lists_page.view_site_link_element, course_site_1.title)).to be true }
-
-      it('shows a default mailing list name') do
-        @mailing_lists_page.switch_to_canvas_iframe unless "#{@driver.browser}" == 'firefox'
-        @mailing_lists_page.wait_until(Utils.short_wait) { @mailing_lists_page.list_name_input == @mailing_lists_page.default_list_name(course_site_1) }
-      end
-
-      it 'requires a non-default mailing list name have no spaces' do
-        @mailing_lists_page.enter_mailgun_list_name 'lousy-list name'
-        @mailing_lists_page.list_name_error_msg_element.when_visible timeout
-      end
-
-      it 'requires a non-default mailing list name have no special characters' do
-        @mailing_lists_page.enter_mailgun_list_name 'lousier-list-name?'
-        @mailing_lists_page.list_name_error_msg_element.when_visible timeout
-      end
-
-      it 'creates a mailing list with a valid, unique mailing list name' do
-        @mailing_lists_page.enter_mailgun_list_name @mailing_lists_page.default_list_name(course_site_1)
-        @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_address == "#{@mailing_lists_page.default_list_name course_site_1}@bcourses-mail.berkeley.edu" }
-      end
-
-      it 'will not create a mailing list for a course site with the same course code as an existing list' do
-        @mailing_lists_page.click_cancel
-        @mailing_lists_page.search_for_list course_site_2.site_id
-        @mailing_lists_page.enter_mailgun_list_name @mailing_lists_page.default_list_name(course_site_1)
-        @mailing_lists_page.list_name_taken_error_msg_element.when_visible timeout
+        logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the admin mailing lists tool"
+        @canvas_page.unexpected_error_msg_element.when_visible Utils.medium_wait
       end
     end
 
-    context 'when viewing a list' do
+    describe 'admin tool' do
 
       before(:all) do
+        @driver.switch_to.default_content
+        @canvas_page.stop_masquerading if @canvas_page.stop_masquerading_link?
         @mailing_lists_page.load_embedded_tool
-        @mailing_lists_page.search_for_list course_site_1.site_id
-        @mailing_lists_page.list_address_element.when_visible timeout
       end
 
-      it('shows the mailing list email address') do
-        @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_address == "#{@mailing_lists_page.default_list_name course_site_1}@bcourses-mail.berkeley.edu" }
+      context 'when creating a list' do
+
+        it 'requires a numeric site ID in order to find a site' do
+          @mailing_lists_page.search_for_list 'foo'
+          @mailing_lists_page.bad_input_msg_element.when_visible timeout
+        end
+
+        it 'requires a valid numeric site ID in order to find a site' do
+          @mailing_lists_page.search_for_list '99999999999'
+          @mailing_lists_page.not_found_msg_element.when_visible timeout
+        end
+
+        it 'retrieves a course site for a valid numeric site ID' do
+          @mailing_lists_page.search_for_list course_site_1.site_id
+          @mailing_lists_page.register_list_button_element.when_visible timeout
+        end
+
+        it 'shows the course site code, title, and ID' do
+          expect(@mailing_lists_page.site_name).to eql(course_site_1.title)
+          expect(@mailing_lists_page.site_code).to eql(("#{course_site_1.code} #{course_site_1.term}").strip)
+          expect(@mailing_lists_page.site_id).to eql("Site ID: #{course_site_1.site_id}")
+        end
+
+        it('shows a link to the course site') { expect(@mailing_lists_page.external_link_valid?(@mailing_lists_page.view_site_link_element, course_site_1.title)).to be true }
+
+        it('shows a default mailing list name') do
+          @mailing_lists_page.switch_to_canvas_iframe unless "#{@driver.browser}" == 'firefox'
+          @mailing_lists_page.wait_until(Utils.short_wait) { @mailing_lists_page.list_name_input == @mailing_lists_page.default_list_name(course_site_1) }
+        end
+
+        it 'requires a non-default mailing list name have no spaces' do
+          @mailing_lists_page.enter_mailgun_list_name 'lousy-list name'
+          @mailing_lists_page.list_name_error_msg_element.when_visible timeout
+        end
+
+        it 'requires a non-default mailing list name have no special characters' do
+          @mailing_lists_page.enter_mailgun_list_name 'lousier-list-name?'
+          @mailing_lists_page.list_name_error_msg_element.when_visible timeout
+        end
+
+        it 'creates a mailing list with a valid, unique mailing list name' do
+          @mailing_lists_page.enter_mailgun_list_name @mailing_lists_page.default_list_name(course_site_1)
+          @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_address == "#{@mailing_lists_page.default_list_name course_site_1}@bcourses-mail.berkeley.edu" }
+        end
+
+        it 'will not create a mailing list for a course site with the same course code as an existing list' do
+          @mailing_lists_page.click_cancel
+          @mailing_lists_page.search_for_list course_site_2.site_id
+          @mailing_lists_page.enter_mailgun_list_name @mailing_lists_page.default_list_name(course_site_1)
+          @mailing_lists_page.list_name_taken_error_msg_element.when_visible timeout
+        end
       end
 
-      it('shows the membership count') { expect(@mailing_lists_page.list_membership_count).to eql('No members') }
-      it('shows the most recent membership update') { expect(@mailing_lists_page.list_update_time).to eql('never') }
-      it('shows a link to the course site') { expect(@mailing_lists_page.external_link_valid?(@mailing_lists_page.list_site_link_element, course_site_1.title)).to be true }
+      context 'when viewing a list' do
 
-      it 'shows the course site code, title, and ID' do
-        @canvas_page.switch_to_canvas_iframe unless "#{@driver.browser}" == 'firefox'
-        expect(@mailing_lists_page.site_name).to eql("#{@mailing_lists_page.default_list_name course_site_1}@bcourses-mail.berkeley.edu")
-        expect(@mailing_lists_page.site_code).to eql(("#{course_site_1.code} #{course_site_1.term}").strip)
-        expect(@mailing_lists_page.site_id).to eql("Site ID: #{course_site_1.site_id}")
-      end
+        before(:all) do
+          @mailing_lists_page.load_embedded_tool
+          @mailing_lists_page.search_for_list course_site_1.site_id
+          @mailing_lists_page.list_address_element.when_visible timeout
+        end
 
-      it 'creates mailing list memberships for users who are members of the site' do
-        @mailing_lists_page.click_update_memberships
-        @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count.include? "#{users.length}" }
-        expect(@mailing_lists_page.list_update_time).to include(Time.now.strftime '%-m/%-d/%y')
-      end
+        it('shows the mailing list email address') do
+          @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_address == "#{@mailing_lists_page.default_list_name course_site_1}@bcourses-mail.berkeley.edu" }
+        end
 
-      it 'deletes mailing list memberships for users who have been removed from the site' do
-        @canvas_page.remove_users_from_course(course_site_1, [test.students[0]])
-        JunctionUtils.clear_cache(@driver, @splash_page, @toolbox_page)
-        @mailing_lists_page.load_embedded_tool
-        @mailing_lists_page.search_for_list course_site_1.site_id
-        @mailing_lists_page.click_update_memberships
-        @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count == "#{users.length - 1} members" }
-      end
+        it('shows the membership count') { expect(@mailing_lists_page.list_membership_count).to eql('No members') }
+        it('shows the most recent membership update') { expect(@mailing_lists_page.list_update_time).to eql('never') }
+        it('shows a link to the course site') { expect(@mailing_lists_page.external_link_valid?(@mailing_lists_page.list_site_link_element, course_site_1.title)).to be true }
 
-      it 'creates mailing list memberships for users who have been restored to the site' do
-        @canvas_page.add_users(course_site_1, [test.students[0]])
-        @canvas_page.masquerade_as(test.students[0], course_site_1)
-        @canvas_page.stop_masquerading
-        JunctionUtils.clear_cache(@driver, @splash_page, @toolbox_page)
-        @mailing_lists_page.load_embedded_tool
-        @mailing_lists_page.search_for_list course_site_1.site_id
-        @mailing_lists_page.click_update_memberships
-        @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count == "#{users.length} members" }
-      end
+        it 'shows the course site code, title, and ID' do
+          @canvas_page.switch_to_canvas_iframe unless "#{@driver.browser}" == 'firefox'
+          expect(@mailing_lists_page.site_name).to eql("#{@mailing_lists_page.default_list_name course_site_1}@bcourses-mail.berkeley.edu")
+          expect(@mailing_lists_page.site_code).to eql(("#{course_site_1.code} #{course_site_1.term}").strip)
+          expect(@mailing_lists_page.site_id).to eql("Site ID: #{course_site_1.site_id}")
+        end
 
-      it 'does not create mailing list memberships for site members with the same email addresses as existing mailing list members' do
-        test.students[1].email = test.students[0].email
-        @canvas_page.activate_user_and_reset_email [test.students[1]]
-        JunctionUtils.clear_cache(@driver, @splash_page, @toolbox_page)
-        @mailing_lists_page.load_embedded_tool
-        @mailing_lists_page.search_for_list course_site_1.site_id
-        @mailing_lists_page.click_update_memberships
-        @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count == "#{users.length - 1} members" }
+        it 'creates mailing list memberships for users who are members of the site' do
+          @mailing_lists_page.click_update_memberships
+          @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count.include? "#{users.length}" }
+          expect(@mailing_lists_page.list_update_time).to include(Time.now.strftime '%-m/%-d/%y')
+        end
+
+        it 'deletes mailing list memberships for users who have been removed from the site' do
+          @canvas_page.remove_users_from_course(course_site_1, [test.students[0]])
+          JunctionUtils.clear_cache(@driver, @splash_page)
+          @mailing_lists_page.load_embedded_tool
+          @mailing_lists_page.search_for_list course_site_1.site_id
+          @mailing_lists_page.click_update_memberships
+          @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count == "#{users.length - 1} members" }
+        end
+
+        it 'creates mailing list memberships for users who have been restored to the site' do
+          @canvas_page.add_users(course_site_1, [test.students[0]])
+          @canvas_page.masquerade_as(test.students[0], course_site_1)
+          @canvas_page.stop_masquerading
+          JunctionUtils.clear_cache(@driver, @splash_page)
+          @mailing_lists_page.load_embedded_tool
+          @mailing_lists_page.search_for_list course_site_1.site_id
+          @mailing_lists_page.click_update_memberships
+          @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count == "#{users.length} members" }
+        end
+
+        it 'does not create mailing list memberships for site members with the same email addresses as existing mailing list members' do
+          test.students[1].email = test.students[0].email
+          @canvas_page.activate_user_and_reset_email [test.students[1]]
+          JunctionUtils.clear_cache(@driver, @splash_page)
+          @mailing_lists_page.load_embedded_tool
+          @mailing_lists_page.search_for_list course_site_1.site_id
+          @mailing_lists_page.click_update_memberships
+          @mailing_lists_page.wait_until(timeout) { @mailing_lists_page.list_membership_count == "#{users.length - 1} members" }
+        end
       end
     end
-  end
 
-  describe 'instructor-facing tool' do
+    describe 'instructor-facing tool' do
 
-    before(:all) do
-      course_site_2.title = course_site_1.title
-      @canvas_page.edit_course_name course_site_2
-      @canvas_page.masquerade_as(test.manual_teacher, course_site_3)
-      @mailing_list_page.load_embedded_tool course_site_3
-    end
-
-    context 'when no mailing list exists' do
-
-      it('shows a "no existing list" message') { @mailing_list_page.wait_until(timeout) { @mailing_list_page.no_list_msg? } }
-
-      it 'allows the user to create a mailing list with a default list name' do
-        @mailing_list_page.create_list
-        @mailing_list_page.list_created_msg_element.when_present timeout
-        expect(@mailing_list_page.list_address).to eql("#{@mailing_lists_page.default_list_name course_site_3}@bcourses-mail.berkeley.edu")
-      end
-
-      it 'will not create a mailing list for a course site with the same course code and term as an existing list' do
-        @mailing_list_page.load_embedded_tool course_site_2
-        @mailing_list_page.list_dupe_error_msg_element.when_present timeout
-        expect(@mailing_list_page.list_dupe_email_msg).to include(@mailing_lists_page.default_list_name course_site_2)
-      end
-    end
-
-    context 'when a mailing list exists' do
-
-      it 'shows the mailing list email address' do
+      before(:all) do
+        course_site_2.title = course_site_1.title
+        @canvas_page.edit_course_name course_site_2
+        @canvas_page.masquerade_as(test.manual_teacher, course_site_3)
         @mailing_list_page.load_embedded_tool course_site_3
-        @mailing_list_page.list_address_element.when_present timeout
-        expect(@mailing_list_page.list_address).to include("#{@mailing_lists_page.default_list_name course_site_3}@bcourses-mail.berkeley.edu")
+      end
+
+      context 'when no mailing list exists' do
+
+        it('shows a "no existing list" message') { @mailing_list_page.wait_until(timeout) { @mailing_list_page.no_list_msg? } }
+
+        it 'allows the user to create a mailing list with a default list name' do
+          @mailing_list_page.create_list
+          @mailing_list_page.list_created_msg_element.when_present timeout
+          expect(@mailing_list_page.list_address).to eql("#{@mailing_lists_page.default_list_name course_site_3}@bcourses-mail.berkeley.edu")
+        end
+
+        it 'will not create a mailing list for a course site with the same course code and term as an existing list' do
+          @mailing_list_page.load_embedded_tool course_site_2
+          @mailing_list_page.list_dupe_error_msg_element.when_present timeout
+          expect(@mailing_list_page.list_dupe_email_msg).to include(@mailing_lists_page.default_list_name course_site_2)
+        end
+      end
+
+      context 'when a mailing list exists' do
+
+        it 'shows the mailing list email address' do
+          @mailing_list_page.load_embedded_tool course_site_3
+          @mailing_list_page.list_address_element.when_present timeout
+          expect(@mailing_list_page.list_address).to include("#{@mailing_lists_page.default_list_name course_site_3}@bcourses-mail.berkeley.edu")
+        end
       end
     end
   end

--- a/spec/junction/canvas_lti_user_provisioning_spec.rb
+++ b/spec/junction/canvas_lti_user_provisioning_spec.rb
@@ -4,25 +4,39 @@ test = JunctionTestConfig.new
 test.user_prov
 test_users = [test.manual_teacher, test.lead_ta, test.ta, test.designer, test.observer, test.reader, test.students.first]
 
+standalone = ENV['STANDALONE']
+
 describe 'User Provisioning' do
 
   before(:all) do
     @driver = Utils.launch_browser
     @cal_net = Page::CalNetPage.new @driver
+    @splash_page = Page::JunctionPages::SplashPage.new @driver
     @canvas = Page::CanvasPage.new @driver
     @user_prov_tool = CanvasUserProvisioningPage.new @driver
+
+    if standalone
+      @splash_page.basic_auth test.admin.uid
+    else
+      @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
+    end
   end
 
   after(:all) { Utils.quit_browser @driver }
 
+  unless standalone
+    context 'when the user is an authorized user' do
+
+      it 'can be reached from a navigation link' do
+        @canvas.load_sub_account Utils.canvas_uc_berkeley_sub_account
+        @canvas.click_user_prov
+      end
+    end
+  end
+
   context 'when the user is an authorized user' do
 
-    before(:all) do
-      @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
-      @canvas.load_sub_account Utils.canvas_uc_berkeley_sub_account
-    end
-
-    it('can be reached from a navigation link') { @canvas.click_user_prov }
+    before(:each) { standalone ? @user_prov_tool.load_standalone_tool : @user_prov_tool.load_embedded_tool }
 
     it 'provisions users via line break separated UIDs' do
       uids = test_users.map(&:uid).join("\n")
@@ -32,21 +46,18 @@ describe 'User Provisioning' do
 
     it 'provisions users via space separated UIDs' do
       uids = test_users.map(&:uid).join(' ')
-      @user_prov_tool.load_embedded_tool
       @user_prov_tool.enter_uids_and_submit uids
       @user_prov_tool.success_msg_element.when_visible Utils.long_wait
     end
 
     it 'provisions users via comma separated UIDs' do
       uids = test_users.map(&:uid).join(',')
-      @user_prov_tool.load_embedded_tool
       @user_prov_tool.enter_uids_and_submit uids
       @user_prov_tool.success_msg_element.when_visible Utils.long_wait
     end
 
     it 'rejects non-numeric input' do
       uids = 'Starchild'
-      @user_prov_tool.load_embedded_tool
       @user_prov_tool.enter_uids_and_submit uids
       @user_prov_tool.non_numeric_msg_element.when_visible Utils.short_wait
     end
@@ -54,20 +65,21 @@ describe 'User Provisioning' do
     it 'rejects more than 200 UIDs' do
       uids = test_users.map(&:uid).join(' ')
       uids = "#{uids} " * 29
-      @user_prov_tool.load_embedded_tool
       @user_prov_tool.enter_uids_and_submit uids
       @user_prov_tool.max_input_msg_element.when_visible Utils.short_wait
     end
   end
 
-  context 'when the user is not an authorized user' do
+  unless standalone
+    context 'when the user is not an authorized user' do
 
-    test_users.each do |user|
-      it "prevents the #{user.role} from reaching the tool" do
-        @canvas.masquerade_as user
-        @user_prov_tool.load_embedded_tool
-        @user_prov_tool.enter_uids_and_submit Utils.oski_uid
-        @user_prov_tool.error_msg_element.when_visible Utils.short_wait
+      test_users.each do |user|
+        it "prevents the #{user.role} from reaching the tool" do
+          @canvas.masquerade_as user
+          @user_prov_tool.load_embedded_tool
+          @user_prov_tool.enter_uids_and_submit Utils.oski_uid
+          @user_prov_tool.error_msg_element.when_visible Utils.short_wait
+        end
       end
     end
   end

--- a/spec/junction/junction_background_tasks_spec.rb
+++ b/spec/junction/junction_background_tasks_spec.rb
@@ -2,6 +2,8 @@ require_relative '../../util/spec_helper'
 
 describe 'Junction background tasks' do
 
+  standalone = ENV['STANDALONE']
+
   begin
 
     include Logging
@@ -18,7 +20,11 @@ describe 'Junction background tasks' do
     @canvas_page = Page::CanvasPage.new @driver
 
     # Log in to both Canvas and Junction
-    @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
+    if standalone
+      @canvas_page.log_in(@cal_net_page, Utils.ets_qa_username, Utils.ets_qa_password)
+    else
+      @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password)
+    end
     @splash_page.basic_auth config.admin.uid
 
     tests = courses.map do |course|

--- a/util/junction_utils.rb
+++ b/util/junction_utils.rb
@@ -76,15 +76,14 @@ class JunctionUtils < Utils
   # Authenticates in Junction as an admin and expires all cache
   # @param driver [Selenium::WebDriver]
   # @param splash_page [Page::JunctionPages::SplashPage]
-  # @param my_toolbox_page [Page::JunctionPages::MyToolboxPage]
-  def self.clear_cache(driver, splash_page, my_toolbox_page)
+  def self.clear_cache(driver, splash_page)
     splash_page.load_page
     splash_page.basic_auth @config['admin_uid']
     driver.get("#{junction_base_url}/api/cache/clear")
     sleep 3
-    my_toolbox_page.load_page
-    my_toolbox_page.toggle_footer_link_element.when_visible Utils.long_wait
-    my_toolbox_page.log_out splash_page
+    splash_page.load_page
+    splash_page.toggle_footer_link_element.when_visible Utils.long_wait
+    splash_page.log_out splash_page
   end
 
   # Creates CSV for data generated during Junction test runs


### PR DESCRIPTION
Except E-Grades and mailing list tests, which are too enmeshed in Canvas.  A significant part of the diff is indent change.