### PR TITLE
Allow BOA tests to run in separate threads

### DIFF
--- a/spec/boac/boac_appts_content_spec.rb
+++ b/spec/boac/boac_appts_content_spec.rb
@@ -1,218 +1,220 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-describe 'BOAC' do
+  include Logging
 
-  begin
-    test = BOACTestConfig.new
-    test.appts_content
-    downloadable_attachments = []
-    advisor_link_tested = false
-    max_appt_count_per_src = BOACUtils.notes_max_notes - 1
+  describe 'BOAC' do
 
-    appts_data_heading = %w(UID SID NoteId Created Updated CreatedBy Advisor AdvisorRole AdvisorDepts HasBody Topics Attachments)
-    appts_data = Utils.create_test_output_csv('boac-appts.csv', appts_data_heading)
+    begin
+      test = BOACTestConfig.new
+      test.appts_content
+      downloadable_attachments = []
+      advisor_link_tested = false
+      max_appt_count_per_src = BOACUtils.notes_max_notes - 1
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @api_notes_page = BOACApiNotesPage.new @driver
+      appts_data_heading = %w(UID SID NoteId Created Updated CreatedBy Advisor AdvisorRole AdvisorDepts HasBody Topics Attachments)
+      appts_data = Utils.create_test_output_csv('boac-appts.csv', appts_data_heading)
 
-    @homepage.dev_auth test.advisor
-    test.test_students.each do |student|
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @api_notes_page = BOACApiNotesPage.new @driver
 
-      begin
-        @student_page.load_page student
-        expected_boa_appts = BOACUtils.get_student_appts(student, test.students).delete_if &:deleted_date
-        expected_sis_appts = NessieUtils.get_sis_appts student
-        logger.warn "UID #{student.uid} has #{expected_sis_appts.length} SIS appointments and #{expected_boa_appts.length} BOA appointments"
+      @homepage.dev_auth test.advisor
+      test.test_students.each do |student|
 
-        expected_appts = expected_sis_appts + expected_boa_appts
+        begin
+          @student_page.load_page student
+          expected_boa_appts = BOACUtils.get_student_appts(student, test.students).delete_if &:deleted_date
+          expected_sis_appts = NessieUtils.get_sis_appts student
+          logger.warn "UID #{student.uid} has #{expected_sis_appts.length} SIS appointments and #{expected_boa_appts.length} BOA appointments"
 
-        @student_page.show_appts
+          expected_appts = expected_sis_appts + expected_boa_appts
 
-        visible_appt_count = @student_page.appt_msg_row_elements.length
-        it("shows the right number of appointments for UID #{student.uid}") { expect(visible_appt_count).to eql((expected_appts).length) }
+          @student_page.show_appts
 
-        expected_sort_order = (expected_appts.sort_by {|a| [a.created_date, a.id] }).reverse.map &:id
-        visible_sort_order = @student_page.visible_collapsed_appt_ids
-        it("shows the appointments in the right order for UID #{student.uid}") { expect(visible_sort_order).to eql(expected_sort_order) }
+          visible_appt_count = @student_page.appt_msg_row_elements.length
+          it("shows the right number of appointments for UID #{student.uid}") { expect(visible_appt_count).to eql((expected_appts).length) }
 
-        @student_page.expand_all_appts
-        expected_sis_appts.each do |appt|
-          appt_expanded = @student_page.item_expanded? appt
-          it("expand-all-appointments button expands appointment ID #{appt.id} for UID #{student.uid}") { expect(appt_expanded).to be true }
-        end
+          expected_sort_order = (expected_appts.sort_by { |a| [a.created_date, a.id] }).reverse.map &:id
+          visible_sort_order = @student_page.visible_collapsed_appt_ids
+          it("shows the appointments in the right order for UID #{student.uid}") { expect(visible_sort_order).to eql(expected_sort_order) }
 
-        @student_page.collapse_all_appts
-        expected_sis_appts.each do |appt|
-          appt_expanded = @student_page.item_expanded? appt
-          it("collapse-all-appointments-button collapses appointment ID #{appt.id} for UID #{student.uid}") { expect(appt_expanded).to be false }
-        end
+          @student_page.expand_all_appts
+          expected_sis_appts.each do |appt|
+            appt_expanded = @student_page.item_expanded? appt
+            it("expand-all-appointments button expands appointment ID #{appt.id} for UID #{student.uid}") { expect(appt_expanded).to be true }
+          end
 
-        # Test a representative subset of the total appts
-        test_appts = expected_sis_appts.shuffle[0..max_appt_count_per_src]
+          @student_page.collapse_all_appts
+          expected_sis_appts.each do |appt|
+            appt_expanded = @student_page.item_expanded? appt
+            it("collapse-all-appointments-button collapses appointment ID #{appt.id} for UID #{student.uid}") { expect(appt_expanded).to be false }
+          end
 
-        test_appts.each do |appt|
+          # Test a representative subset of the total appts
+          test_appts = expected_sis_appts.shuffle[0..max_appt_count_per_src]
 
-          begin
-            test_case = "appointment ID #{appt.id} for UID #{student.uid}"
-            logger.info "Checking #{test_case}"
+          test_appts.each do |appt|
 
-            # COLLAPSED APPOINTMENT
+            begin
+              test_case = "appointment ID #{appt.id} for UID #{student.uid}"
+              logger.info "Checking #{test_case}"
 
-            @student_page.show_appts
-            visible_collapsed_appt_data = @student_page.visible_collapsed_appt_data appt
+              # COLLAPSED APPOINTMENT
 
-            # Appointment date
+              @student_page.show_appts
+              visible_collapsed_appt_data = @student_page.visible_collapsed_appt_data appt
 
-            expected_date_text = "Appointment date #{@student_page.expected_item_short_date_format appt.created_date}"
-            visible_date = @student_page.visible_collapsed_item_data(appt)[:date]
-            it("shows '#{expected_date_text}' on collapsed #{test_case}") { expect(visible_date).to eql(expected_date_text) }
+              # Appointment date
 
-            # EXPANDED APPOINTMENT
+              expected_date_text = "Appointment date #{@student_page.expected_item_short_date_format appt.created_date}"
+              visible_date = @student_page.visible_collapsed_item_data(appt)[:date]
+              it("shows '#{expected_date_text}' on collapsed #{test_case}") { expect(visible_date).to eql(expected_date_text) }
 
-            @student_page.expand_item appt
-            visible_expanded_appt_data = @student_page.visible_expanded_appt_data appt
-            it("shows the detail on #{test_case}") { expect(visible_expanded_appt_data[:detail].gsub(/\W/, '')).to eql(appt.detail.gsub(/\W/, '')) }
+              # EXPANDED APPOINTMENT
 
-            # Appointment advisor
+              @student_page.expand_item appt
+              visible_expanded_appt_data = @student_page.visible_expanded_appt_data appt
+              it("shows the detail on #{test_case}") { expect(visible_expanded_appt_data[:detail].gsub(/\W/, '')).to eql(appt.detail.gsub(/\W/, '')) }
 
-            if appt.advisor.uid
-              logger.warn "No advisor shown for UID #{appt.advisor.uid} on #{test_case}" unless visible_expanded_appt_data[:advisor]
+              # Appointment advisor
 
-              if visible_expanded_appt_data[:advisor] && !advisor_link_tested
-                advisor_link_works = @student_page.external_link_valid?(@student_page.appt_advisor_el(appt), 'Campus Directory | University of California, Berkeley')
-                advisor_link_tested = true
-                it("offers a link to the Berkeley directory for advisor #{appt.advisor.uid} on #{test_case}") { expect(advisor_link_works).to be true }
-              end
+              if appt.advisor.uid
+                logger.warn "No advisor shown for UID #{appt.advisor.uid} on #{test_case}" unless visible_expanded_appt_data[:advisor]
 
-            else
-              if appt.advisor.last_name && !appt.advisor.last_name.empty?
-                it("shows an advisor on #{test_case}") { expect(visible_expanded_appt_data[:advisor]).not_to be_nil }
-              end
-            end
-
-            # Appointment topics
-
-            if appt.topics.any?
-              topics = appt.topics.map(&:upcase).uniq
-              topics.sort!
-              it("shows the right topics on #{test_case}") { expect(visible_expanded_appt_data[:topics]).to eql(topics) }
-            else
-              it("shows no topics on #{test_case}") { expect(visible_expanded_appt_data[:topics]).to be_empty }
-            end
-
-            # Appointment dates
-
-            expected_create_date_text = @student_page.expected_item_short_date_format(appt.created_date)
-            it("shows creation date #{expected_create_date_text} on expanded #{test_case}") { expect(visible_expanded_appt_data[:created_date]).to eql(expected_create_date_text) }
-
-            # Appointment attachments
-
-            if appt.attachments.any?
-              non_deleted_attachments = appt.attachments.reject &:deleted_at
-              attachment_file_names = non_deleted_attachments.map &:file_name
-              it("shows the right attachment file names on #{test_case}") { expect(visible_expanded_appt_data[:attachments].sort).to eql(attachment_file_names.sort) }
-
-              non_deleted_attachments.each do |attach|
-                if attach.sis_file_name
-                  has_delete_button = @student_page.delete_note_button(appt).exists?
-                  it("shows no delete button for imported #{test_case}") { expect(has_delete_button).to be false }
+                if visible_expanded_appt_data[:advisor] && !advisor_link_tested
+                  advisor_link_works = @student_page.external_link_valid?(@student_page.appt_advisor_el(appt), 'Campus Directory | University of California, Berkeley')
+                  advisor_link_tested = true
+                  it("offers a link to the Berkeley directory for advisor #{appt.advisor.uid} on #{test_case}") { expect(advisor_link_works).to be true }
                 end
 
-                if @student_page.item_attachment_el(appt, attach.file_name).tag_name == 'a' && "#{@driver.browser}" != 'firefox' && !Utils.headless?
-                  begin
-                    file_size = @student_page.download_attachment(appt, attach, student)
-                    if file_size
-                      attachment_downloads = file_size > 0
-                      downloadable_attachments << attach
-                      it("allows attachment ID #{attach.id} to be downloaded from #{test_case}") { expect(attachment_downloads).to be true }
-                    end
-                  rescue => e
-                    Utils.log_error e
-                    it("encountered an error downloading attachment ID #{attach.id} from #{test_case}") { fail }
+              else
+                if appt.advisor.last_name && !appt.advisor.last_name.empty?
+                  it("shows an advisor on #{test_case}") { expect(visible_expanded_appt_data[:advisor]).not_to be_nil }
+                end
+              end
 
-                    # If the download fails, the browser might no longer be on the student page so reload it.
-                    @student_page.load_page student
-                    @student_page.show_appts
+              # Appointment topics
+
+              if appt.topics.any?
+                topics = appt.topics.map(&:upcase).uniq
+                topics.sort!
+                it("shows the right topics on #{test_case}") { expect(visible_expanded_appt_data[:topics]).to eql(topics) }
+              else
+                it("shows no topics on #{test_case}") { expect(visible_expanded_appt_data[:topics]).to be_empty }
+              end
+
+              # Appointment dates
+
+              expected_create_date_text = @student_page.expected_item_short_date_format(appt.created_date)
+              it("shows creation date #{expected_create_date_text} on expanded #{test_case}") { expect(visible_expanded_appt_data[:created_date]).to eql(expected_create_date_text) }
+
+              # Appointment attachments
+
+              if appt.attachments.any?
+                non_deleted_attachments = appt.attachments.reject &:deleted_at
+                attachment_file_names = non_deleted_attachments.map &:file_name
+                it("shows the right attachment file names on #{test_case}") { expect(visible_expanded_appt_data[:attachments].sort).to eql(attachment_file_names.sort) }
+
+                non_deleted_attachments.each do |attach|
+                  if attach.sis_file_name
+                    has_delete_button = @student_page.delete_note_button(appt).exists?
+                    it("shows no delete button for imported #{test_case}") { expect(has_delete_button).to be false }
                   end
 
-                else
-                  logger.warn "Skipping download test for appointment ID #{appt.id} attachment ID #{attach.id} since it cannot be downloaded"
+                  if @student_page.item_attachment_el(appt, attach.file_name).tag_name == 'a' && "#{@driver.browser}" != 'firefox' && !Utils.headless?
+                    begin
+                      file_size = @student_page.download_attachment(appt, attach, student)
+                      if file_size
+                        attachment_downloads = file_size > 0
+                        downloadable_attachments << attach
+                        it("allows attachment ID #{attach.id} to be downloaded from #{test_case}") { expect(attachment_downloads).to be true }
+                      end
+                    rescue => e
+                      Utils.log_error e
+                      it("encountered an error downloading attachment ID #{attach.id} from #{test_case}") { fail }
+
+                      # If the download fails, the browser might no longer be on the student page so reload it.
+                      @student_page.load_page student
+                      @student_page.show_appts
+                    end
+
+                  else
+                    logger.warn "Skipping download test for appointment ID #{appt.id} attachment ID #{attach.id} since it cannot be downloaded"
+                  end
                 end
+
+              else
+                it("shows no attachment file names on #{test_case}") { expect(visible_expanded_appt_data[:attachments]).to be_empty }
               end
 
-            else
-              it("shows no attachment file names on #{test_case}") { expect(visible_expanded_appt_data[:attachments]).to be_empty }
-            end
+              # Appointment search
 
-            # Appointment search
+              query = BOACUtils.generate_appt_search_query(student, appt)
 
-            query = BOACUtils.generate_appt_search_query(student, appt)
+              if query
+                @student_page.show_appts
+                initial_msg_count = @student_page.visible_message_ids.length
+                @student_page.search_within_timeline_appts(query[:string])
+                message_ids = @student_page.visible_message_ids
 
-            if query
-              @student_page.show_appts
-              initial_msg_count = @student_page.visible_message_ids.length
-              @student_page.search_within_timeline_appts(query[:string])
-              message_ids = @student_page.visible_message_ids
+                it("searches within academic timeline for #{query[:test_case]}") do
+                  expect(message_ids.length).to be < (initial_msg_count) unless initial_msg_count == 1
+                  expect(message_ids).to include(query[:appt].id)
+                end
 
-              it("searches within academic timeline for #{query[:test_case]}") do
-                expect(message_ids.length).to be < (initial_msg_count) unless initial_msg_count == 1
-                expect(message_ids).to include(query[:appt].id)
+                @student_page.clear_timeline_appts_search
               end
-
-              @student_page.clear_timeline_appts_search
+            rescue => e
+              Utils.log_error e
+              it("hit an error with #{test_case}") { fail }
+            ensure
+              row = [student.uid, student.sis_id, appt.id, appt.created_date, appt.updated_date, appt.advisor.uid,
+                     (visible_expanded_appt_data[:advisor] if visible_expanded_appt_data),
+                     (visible_expanded_appt_data[:advisor_role] if visible_expanded_appt_data),
+                     (visible_expanded_appt_data[:advisor_depts] if visible_expanded_appt_data),
+                     !appt.body.nil?, appt.topics.length, appt.attachments.length]
+              Utils.add_csv_row(appts_data, row)
             end
-          rescue => e
-            Utils.log_error e
-            it("hit an error with #{test_case}") { fail }
-          ensure
-            row = [student.uid, student.sis_id, appt.id, appt.created_date, appt.updated_date, appt.advisor.uid,
-                   (visible_expanded_appt_data[:advisor] if visible_expanded_appt_data),
-                   (visible_expanded_appt_data[:advisor_role] if visible_expanded_appt_data),
-                   (visible_expanded_appt_data[:advisor_depts] if visible_expanded_appt_data),
-                   !appt.body.nil?, appt.topics.length, appt.attachments.length]
-            Utils.add_csv_row(appts_data, row)
           end
+
+        rescue => e
+          Utils.log_error e
+          it("hit an error with UID #{student.uid}") { fail }
+        ensure
+          # Make sure no attachment is left on the test machine
+          Utils.prepare_download_dir
         end
-
-      rescue => e
-        Utils.log_error e
-        it("hit an error with UID #{student.uid}") { fail }
-      ensure
-        # Make sure no attachment is left on the test machine
-        Utils.prepare_download_dir
       end
-    end
 
-    if downloadable_attachments.any?
+      if downloadable_attachments.any?
 
-      @homepage.load_page
-      @homepage.log_out
+        @homepage.load_page
+        @homepage.log_out
 
-      downloadable_attachments.each do |attach|
+        downloadable_attachments.each do |attach|
 
-        identifier = attach.sis_file_name || attach.id
-        Utils.prepare_download_dir
-        @api_notes_page.load_attachment_page identifier
-        no_access = @api_notes_page.verify_block { @api_notes_page.unauth_msg_element.when_visible Utils.short_wait }
-        it("blocks an anonymous user from hitting the attachment download endpoint for #{identifier}") { expect(no_access).to be true }
+          identifier = attach.sis_file_name || attach.id
+          Utils.prepare_download_dir
+          @api_notes_page.load_attachment_page identifier
+          no_access = @api_notes_page.verify_block { @api_notes_page.unauth_msg_element.when_visible Utils.short_wait }
+          it("blocks an anonymous user from hitting the attachment download endpoint for #{identifier}") { expect(no_access).to be true }
 
-        no_file = Utils.downloads_empty?
-        it("delivers no file to an anonymous user when hitting the attachment download endpoint for #{identifier}") { expect(no_file).to be true }
+          no_file = Utils.downloads_empty?
+          it("delivers no file to an anonymous user when hitting the attachment download endpoint for #{identifier}") { expect(no_file).to be true }
+        end
+      else
+        it('found no downloadable attachments') { fail } unless test.test_students.empty?
       end
-    else
-      it('found no downloadable attachments') { fail } unless test.test_students.empty?
-    end
 
-  rescue => e
-    Utils.log_error e
-    it('hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
+    rescue => e
+      Utils.log_error e
+      it('hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end
-

--- a/spec/boac/boac_appts_drop_in_spec.rb
+++ b/spec/boac/boac_appts_drop_in_spec.rb
@@ -1,1188 +1,1191 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-describe 'BOA' do
+  include Logging
 
-  before(:all) do
-    dept = BOACDepartments::DEPARTMENTS.find { |d| d.code == BOACUtils.appts_drop_in_dept }
-    @other_dept = BOACDepartments::DEPARTMENTS.find { |d| ![dept, BOACDepartments::ADMIN].include? d }
-    authorized_users = BOACUtils.get_authorized_users
-    @test = BOACTestConfig.new
-    @test.drop_in_appts(authorized_users, dept)
-
-    @students = @test.students.shuffle[0..20]
-    inactive_sid = (NessieUtils.hist_profile_sids_of_career_status('Inactive') - BOACUtils.manual_advisee_sids).first
-    @inactive_student = NessieUtils.get_hist_student inactive_sid
-    completed_sid = (NessieUtils.hist_profile_sids_of_career_status('Completed') - BOACUtils.manual_advisee_sids).first
-    @completed_student = NessieUtils.get_hist_student completed_sid
-
-    @appts = []
-    @appt_0 = Appointment.new(student: @students[0], topics: [Topic::COURSE_ADD, Topic::COURSE_DROP], detail: "Drop-in advisor appointment creation #{@test.id}")
-    @appt_1 = Appointment.new(student: @students[1], reserve_advisor: @test.drop_in_advisor, topics: [Topic::RETROACTIVE_ADD, Topic::RETROACTIVE_DROP], detail: "Drop-in appointment details #{@test.id}")
-    @appt_2 = Appointment.new(student: @students[2], topics: [Topic::PROBATION], detail: "Scheduler check-in 1 #{@test.id}")
-    @appt_3 = Appointment.new(student: @students[3], topics: [Topic::PROBATION], detail: "Drop-in advisor waiting list check-in 1 #{@test.id}")
-    @appt_4 = Appointment.new(student: @students[4], topics: [Topic::READMISSION], detail: "Scheduler cancel #{@test.id}")
-    @appt_5 = Appointment.new(student: @students[5], topics: [Topic::WITHDRAWAL], detail: "Drop-in advisor waiting list cancel #{@test.id}")
-    @appt_6 = Appointment.new(student: @students[6], topics: [Topic::OTHER], detail: "Drop-in advisor student page cancel #{@test.id}")
-    @appt_7 = Appointment.new(student: @students[7], topics: [Topic::COURSE_ADD, Topic::COURSE_DROP], detail: "Scheduler no-reservation appointment creation #{@test.id} detail")
-    @appt_8 = Appointment.new(student: @inactive_student, reserve_advisor: @test.drop_in_advisor, topics: [Topic::COURSE_ADD], detail: "Scheduler reservation appointment creation #{@test.id} detail")
-    @appt_9 = Appointment.new(student: @completed_student, detail: 'Some detail')
-    @appt_10 = Appointment.new(student: @students[8], topics: [Topic::COURSE_DROP], detail: "Reserved 1 #{@test.id}", reserve_advisor: @test.drop_in_advisor)
-    @appt_11 = Appointment.new(student: @students[9], topics: [Topic::COURSE_DROP], detail: "Reserved 2 #{@test.id}", reserve_advisor: @test.drop_in_advisor)
-    @resolved_issue = Appointment.new(student: @students[10], topics: [Topic::COURSE_ADD], detail: "A resolved issue #{@test.id}")
-
-    @driver_scheduler = Utils.launch_browser
-    @scheduler_homepage = BOACHomePage.new @driver_scheduler
-    @scheduler_intake_desk = BOACApptIntakeDeskPage.new @driver_scheduler
-    @scheduler_flight_deck = BOACFlightDeckPage.new @driver_scheduler
-
-    @driver_advisor = Utils.launch_browser
-    @pax_manifest = BOACPaxManifestPage.new @driver_advisor
-    @advisor_homepage = BOACHomePage.new @driver_advisor
-    @advisor_appt_desk = BOACApptIntakeDeskPage.new @driver_advisor
-    @advisor_student_page = BOACStudentPage.new @driver_advisor
-    @search_results_page = BOACSearchResultsPage.new @driver_advisor
-    @advisor_flight_deck = BOACFlightDeckPage.new @driver_advisor
-
-    # Configure users
-    [@test.advisor, @test.drop_in_advisor].each { |u| BOACUtils.delete_drop_in_advisor u }
-    @advisor_homepage.dev_auth
-    @pax_manifest.load_page
-    @pax_manifest.filter_mode_select_element.when_visible Utils.medium_wait
-    @pax_manifest.search_for_and_edit_user @test.advisor
-    @pax_manifest.search_for_and_edit_user @test.drop_in_advisor
-    @pax_manifest.search_for_and_edit_user @test.drop_in_scheduler
-    @pax_manifest.log_out
-
-    @drop_in_advisors = BOACUtils.get_authorized_users.select do |a|
-      a.dept_memberships.find { |r| r.dept == @test.dept && r.is_drop_in_advisor }
-    end
-  end
-
-  after(:all) do
-    Utils.quit_browser @driver_scheduler
-    Utils.quit_browser @driver_advisor
-  end
-
-  ### PERMISSIONS - SCHEDULER
-
-  context 'when the user is a scheduler' do
-
-    before(:all) { @scheduler_homepage.dev_auth @test.drop_in_scheduler }
-
-    it 'drops the user onto the drop-in intake desk at login' do
-      expect(@scheduler_homepage.title).to include('Drop-in Appointments Desk')
-      @scheduler_intake_desk.new_appt_button_element.when_visible Utils.short_wait
-    end
-
-    it 'prevents the user from accessing a drop-in intake desk belonging to another department' do
-      @scheduler_intake_desk.load_page @other_dept
-      @scheduler_intake_desk.wait_for_title 'Not Found'
-    end
-
-    it 'prevents the user from accessing a page other than the drop-in intake desk' do
-      @scheduler_intake_desk.navigate_to "#{BOACUtils.base_url}/student/#{@students.first.uid}"
-      @scheduler_intake_desk.wait_for_title 'Not Found'
-    end
-
-    # TODO user cannot get to any boa API endpoints other than drop-in endpoints
-  end
-
-  ### PERMISSIONS - DROP-IN ADVISOR
-
-  context 'when the user is a drop-in advisor' do
+  describe 'BOA' do
 
     before(:all) do
-      @advisor_homepage.dev_auth @test.drop_in_advisor
-      @advisor_flight_deck.load_advisor_page
-      @advisor_flight_deck.disable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
-      @advisor_flight_deck.enable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
-      @drop_in_advisors << @test.drop_in_advisor unless @drop_in_advisors.map(&:uid).include? @test.drop_in_advisor.uid
-    end
+      dept = BOACDepartments::DEPARTMENTS.find { |d| d.code == BOACUtils.appts_drop_in_dept }
+      @other_dept = BOACDepartments::DEPARTMENTS.find { |d| ![dept, BOACDepartments::ADMIN].include? d }
+      authorized_users = BOACUtils.get_authorized_users
+      @test = BOACTestConfig.new
+      @test.drop_in_appts(authorized_users, dept)
 
-    after(:all) { @advisor_homepage.log_out }
+      @students = @test.students.shuffle[0..20]
+      inactive_sid = (NessieUtils.hist_profile_sids_of_career_status('Inactive') - BOACUtils.manual_advisee_sids).first
+      @inactive_student = NessieUtils.get_hist_student inactive_sid
+      completed_sid = (NessieUtils.hist_profile_sids_of_career_status('Completed') - BOACUtils.manual_advisee_sids).first
+      @completed_student = NessieUtils.get_hist_student completed_sid
 
-    it 'drops the user onto the homepage at login with a waiting list' do
-      @advisor_homepage.load_page
-      expect(@advisor_homepage.title).to include('Home')
-      @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
-    end
+      @appts = []
+      @appt_0 = Appointment.new(student: @students[0], topics: [Topic::COURSE_ADD, Topic::COURSE_DROP], detail: "Drop-in advisor appointment creation #{@test.id}")
+      @appt_1 = Appointment.new(student: @students[1], reserve_advisor: @test.drop_in_advisor, topics: [Topic::RETROACTIVE_ADD, Topic::RETROACTIVE_DROP], detail: "Drop-in appointment details #{@test.id}")
+      @appt_2 = Appointment.new(student: @students[2], topics: [Topic::PROBATION], detail: "Scheduler check-in 1 #{@test.id}")
+      @appt_3 = Appointment.new(student: @students[3], topics: [Topic::PROBATION], detail: "Drop-in advisor waiting list check-in 1 #{@test.id}")
+      @appt_4 = Appointment.new(student: @students[4], topics: [Topic::READMISSION], detail: "Scheduler cancel #{@test.id}")
+      @appt_5 = Appointment.new(student: @students[5], topics: [Topic::WITHDRAWAL], detail: "Drop-in advisor waiting list cancel #{@test.id}")
+      @appt_6 = Appointment.new(student: @students[6], topics: [Topic::OTHER], detail: "Drop-in advisor student page cancel #{@test.id}")
+      @appt_7 = Appointment.new(student: @students[7], topics: [Topic::COURSE_ADD, Topic::COURSE_DROP], detail: "Scheduler no-reservation appointment creation #{@test.id} detail")
+      @appt_8 = Appointment.new(student: @inactive_student, reserve_advisor: @test.drop_in_advisor, topics: [Topic::COURSE_ADD], detail: "Scheduler reservation appointment creation #{@test.id} detail")
+      @appt_9 = Appointment.new(student: @completed_student, detail: 'Some detail')
+      @appt_10 = Appointment.new(student: @students[8], topics: [Topic::COURSE_DROP], detail: "Reserved 1 #{@test.id}", reserve_advisor: @test.drop_in_advisor)
+      @appt_11 = Appointment.new(student: @students[9], topics: [Topic::COURSE_DROP], detail: "Reserved 2 #{@test.id}", reserve_advisor: @test.drop_in_advisor)
+      @resolved_issue = Appointment.new(student: @students[10], topics: [Topic::COURSE_ADD], detail: "A resolved issue #{@test.id}")
 
-    it 'prevents the user from accessing the department drop-in intake desk' do
-      @advisor_appt_desk.load_page @test.dept
-      @advisor_appt_desk.wait_for_title 'Page not found'
-    end
+      @driver_scheduler = Utils.launch_browser
+      @scheduler_homepage = BOACHomePage.new @driver_scheduler
+      @scheduler_intake_desk = BOACApptIntakeDeskPage.new @driver_scheduler
+      @scheduler_flight_deck = BOACFlightDeckPage.new @driver_scheduler
 
-    it 'prevents the user from accessing a drop-in intake desk belonging to another department' do
-      @advisor_appt_desk.load_page @other_dept
-      @advisor_appt_desk.wait_for_title 'Page not found'
-    end
-  end
+      @driver_advisor = Utils.launch_browser
+      @pax_manifest = BOACPaxManifestPage.new @driver_advisor
+      @advisor_homepage = BOACHomePage.new @driver_advisor
+      @advisor_appt_desk = BOACApptIntakeDeskPage.new @driver_advisor
+      @advisor_student_page = BOACStudentPage.new @driver_advisor
+      @search_results_page = BOACSearchResultsPage.new @driver_advisor
+      @advisor_flight_deck = BOACFlightDeckPage.new @driver_advisor
 
-  ### PERMISSIONS - NON-DROP-IN ADVISOR
+      # Configure users
+      [@test.advisor, @test.drop_in_advisor].each { |u| BOACUtils.delete_drop_in_advisor u }
+      @advisor_homepage.dev_auth
+      @pax_manifest.load_page
+      @pax_manifest.filter_mode_select_element.when_visible Utils.medium_wait
+      @pax_manifest.search_for_and_edit_user @test.advisor
+      @pax_manifest.search_for_and_edit_user @test.drop_in_advisor
+      @pax_manifest.search_for_and_edit_user @test.drop_in_scheduler
+      @pax_manifest.log_out
 
-  context 'when the user is a non-drop-in advisor' do
-
-    before(:all) { @advisor_homepage.dev_auth @test.advisor }
-    after(:all) { @advisor_homepage.log_out }
-
-    it 'drops the user onto the homepage at login with no waiting list' do
-      expect(@advisor_homepage.title).to include('Home')
-      sleep 2
-      expect(@advisor_homepage.new_appt_button?).to be false
-    end
-
-    it 'prevents the user from accessing the department drop-in intake desk' do
-      @advisor_appt_desk.load_page @test.dept
-      @advisor_appt_desk.wait_for_title 'Page not found'
-    end
-  end
-
-  ### PERMISSIONS - ADMIN
-
-  context 'when the user is an admin' do
-
-    before(:all) { @advisor_homepage.dev_auth }
-    after(:all) { @advisor_homepage.log_out }
-
-    it 'drops the user onto the homepage at login with no waiting list' do
-      expect(@advisor_homepage.title).to include('Home')
-      sleep 2
-      expect(@advisor_homepage.new_appt_button?).to be false
-    end
-
-    it 'allows the user to access any department\'s drop-in intake desk' do
-      @advisor_appt_desk.load_page @test.dept
-      @advisor_appt_desk.wait_for_title 'Drop-in Appointments Desk'
-      @advisor_appt_desk.load_page @other_dept
-      @advisor_appt_desk.wait_for_title 'Drop-in Appointments Desk'
-    end
-  end
-
-  ### ADVISOR AVAILABILITY ###
-
-  describe 'drop-in advisor availability' do
-
-    context 'on the intake desk' do
-
-      before(:all) { @scheduler_intake_desk.load_page @test.dept }
-      after(:all) { @scheduler_intake_desk.hit_escape }
-
-      it 'is shown for only drop-in advisors' do
-        @scheduler_intake_desk.new_appt_button_element.when_visible Utils.short_wait
-        expect(@scheduler_intake_desk.drop_in_advisor_uids.sort).to eql(@drop_in_advisors.map(&:uid).sort)
-      end
-
-      it('allows a scheduler to set a drop-in advisor to "unavailable"') { @scheduler_intake_desk.set_advisor_unavailable @test.drop_in_advisor }
-
-      it 'shows no unavailable advisors when making an appointment with a reservation' do
-        @scheduler_intake_desk.click_new_appt
-        expect(@scheduler_intake_desk.available_appt_advisor_uids).not_to include(@test.drop_in_advisor.uid)
-      end
-
-      it 'allows a scheduler to set a drop-in advisor to "available"' do
-        @scheduler_intake_desk.hit_escape
-        @scheduler_intake_desk.set_advisor_available @test.drop_in_advisor
-      end
-
-      it 'shows available advisors when making an appointment with a reservation' do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.available_appt_advisor_uids.include? @test.drop_in_advisor.uid }
+      @drop_in_advisors = BOACUtils.get_authorized_users.select do |a|
+        a.dept_memberships.find { |r| r.dept == @test.dept && r.is_drop_in_advisor }
       end
     end
 
-    context 'on the waiting list' do
-
-      before(:all) { @advisor_homepage.dev_auth @test.drop_in_advisor }
-
-      it 'is shown for the logged-in drop-in advisor' do
-        @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
-        @advisor_homepage.wait_for_poller { @advisor_homepage.self_available? }
-      end
-
-      it('allows a drop-in advisor to set itself "unavailable"') { @advisor_homepage.set_self_unavailable }
-      it('allows a drop-in advisor to set itself "available"') { @advisor_homepage.set_self_available }
-
-      it 'is shown for only drop-in advisors' do
-        @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
-        expect(@advisor_homepage.visible_drop_in_advisors_and_status).to eql(BOACUtils.get_drop_in_advisors_and_status(@test.dept))
-      end
-
-      it 'does not allow a drop-in advisor to toggle another advisor\'s availability' do
-        expect(@advisor_homepage.availability_toggle_button_elements.length).to eql(1)
-      end
-    end
-  end
-
-  ### ADVISOR STATUS ###
-
-  describe 'drop-in advisor status' do
-
-    context 'on the intake desk' do
-
-      it 'cannot be set' do
-        expect(@scheduler_intake_desk.status_clear_button?).to be false
-        expect(@scheduler_intake_desk.status_save_button?).to be false
-      end
+    after(:all) do
+      Utils.quit_browser @driver_scheduler
+      Utils.quit_browser @driver_advisor
     end
 
-    context 'on the waiting list' do
-
-      it 'can be set' do
-        @advisor_homepage.create_status(@test.drop_in_advisor.dept_memberships.first, ("#{@test.id} drop-in advisor status" * 6))
-        @advisor_homepage.wait_until(2) { @advisor_homepage.status == @test.drop_in_advisor.dept_memberships.first.drop_in_status }
-      end
-
-      it 'updates the intake desk when set' do
-        @scheduler_intake_desk.wait_for_poller do
-          @scheduler_intake_desk.intake_desk_advisor_status(@test.drop_in_advisor)&.include? @test.drop_in_advisor.dept_memberships.first.drop_in_status
-        end
-      end
-
-      it 'can be cleared' do
-        @advisor_homepage.clear_status @test.drop_in_advisor.dept_memberships.first
-      end
-
-      it 'updates the intake desk when cleared' do
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.intake_desk_advisor_status(@test.advisor) == @test.advisor.dept_memberships.first.drop_in_status }
-      end
-    end
-  end
-
-  ### DROP-IN APPOINTMENT CREATION
-
-  describe 'drop-in appointment creation' do
-
-    # Scheduler
-
-    context 'on the intake desk' do
-
-      before(:all) do
-        existing_appts = BOACUtils.get_today_drop_in_appts(@test.dept, @test.students).select { |a| !a.deleted_date }
-        BOACUtils.delete_appts existing_appts
-      end
-
-      before(:each) { @scheduler_intake_desk.hit_escape }
-
-      it 'shows a No Appointments message when there are no appointments' do
-        @scheduler_intake_desk.empty_wait_list_msg_element.when_visible Utils.medium_wait
-        expect(@scheduler_intake_desk.empty_wait_list_msg.strip).to eql('No appointments yet')
-      end
-
-      it 'allows a scheduler to create but cancel a new appointment' do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.click_cancel_new_appt
-      end
-
-      it 'requires a scheduler to select a student for a new appointment' do
-        appt = Appointment.new(detail: 'Some detail')
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.add_reasons(appt, [Topic::OTHER])
-        @scheduler_intake_desk.enter_detail appt
-        expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be true
-        @scheduler_intake_desk.choose_appt_student @test.students.first
-        expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be false
-      end
-
-      it 'requires a scheduler to select a reason for a new appointment' do
-        appt = Appointment.new(detail: 'Some detail')
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.choose_appt_student @test.students.first
-        @scheduler_intake_desk.enter_detail appt
-        expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be true
-        @scheduler_intake_desk.add_reasons(appt,[Topic::OTHER])
-        @scheduler_intake_desk.wait_until(2) { !@scheduler_intake_desk.make_appt_button_element.disabled? }
-      end
-
-      it 'allows a scheduler to select an available advisor for a new reserved appointment' do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.wait_until(1) { @scheduler_intake_desk.available_appt_advisor_uids.sort.include? @test.drop_in_advisor.uid }
-      end
-
-      it 'shows a scheduler the right reasons for a new appointment' do
-        @scheduler_intake_desk.click_new_appt
-        expected_topics = Topic::TOPICS.select(&:for_appts).map &:name
-        @scheduler_intake_desk.wait_until(1, "Expected #{expected_topics}, got #{@scheduler_intake_desk.available_appt_reasons}") do
-          @scheduler_intake_desk.available_appt_reasons == expected_topics
-        end
-      end
-
-      it 'requires a scheduler to enter details for a new appointment' do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.choose_appt_student @test.students.first
-        @scheduler_intake_desk.add_reasons(@appt_9, [Topic::OTHER])
-        expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be true
-        @scheduler_intake_desk.enter_detail @appt_9
-        @scheduler_intake_desk.wait_until(3) { !@scheduler_intake_desk.make_appt_button_element.disabled? }
-      end
-
-      it 'allows a scheduler to create a new unreserved appointment' do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.create_appt @appt_7
-        expect(@appt_7.id).not_to be_nil
-      end
-
-      it 'allows a scheduler to create a new reserved apppointment' do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.create_appt @appt_8
-        expect(@appt_8.id).not_to be_nil
-        expect(@scheduler_intake_desk.visible_list_view_appt_data(@appt_8)[:reserved_by]).not_to be_nil
-      end
-
-      it 'prevents a scheduler from creating a new appointment for a student with an existing pending appointment' do
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_8.id }
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.choose_appt_student @appt_8.student
-        @scheduler_intake_desk.student_double_booking_msg_element.when_visible 3
-      end
-    end
-
-    # Drop-in Advisor
-
-    context 'on the waiting list' do
-
-      before(:all) do
-        existing_appts = BOACUtils.get_today_drop_in_appts(@test.dept, @test.students)
-        BOACUtils.delete_appts existing_appts
-      end
-
-      before(:each) { @advisor_homepage.hit_escape }
-
-      it 'shows a No Appointments message when there are no appointments' do
-        @advisor_homepage.empty_wait_list_msg_element.when_visible Utils.medium_wait
-        expect(@advisor_homepage.empty_wait_list_msg.strip).to eql('No appointments yet')
-      end
-
-      it 'updates the scheduler appointment desk with a No Appointments message when there are no appointments' do
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.empty_wait_list_msg? }
-      end
-
-      it 'allows a drop-in advisor to create but cancel a new appointment' do
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.click_cancel_new_appt
-      end
-
-      it 'requires a drop-in advisor to select a student for a new appointment' do
-        appt = Appointment.new(detail: 'Some detail')
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.add_reasons(appt,[Topic::OTHER])
-        @advisor_homepage.enter_detail appt
-        expect(@advisor_homepage.make_appt_button_element.disabled?).to be true
-        @advisor_homepage.choose_appt_student @test.students.first
-        expect(@advisor_homepage.make_appt_button_element.disabled?).to be false
-      end
-
-      it 'requires a drop-in advisor to select a reason for a new appointment' do
-        appt = Appointment.new(detail: 'Some detail')
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.choose_appt_student @test.students.first
-        @advisor_homepage.enter_detail appt
-        expect(@advisor_homepage.make_appt_button_element.disabled?).to be true
-        @advisor_homepage.add_reasons(appt, [Topic::OTHER])
-        expect(@advisor_homepage.make_appt_button_element.disabled?).to be false
-      end
-
-      it 'shows a drop-in advisor the right reasons for a new appointment' do
-        @advisor_homepage.click_new_appt
-        expected_topics = Topic::TOPICS.select(&:for_appts).map &:name
-        @advisor_homepage.wait_until(1, "Expected #{expected_topics}, got #{@advisor_homepage.available_appt_reasons}") do
-          @advisor_homepage.available_appt_reasons == expected_topics
-        end
-      end
-
-      it 'requires a drop-in advisor to enter details for a new appointment' do
-        appt = Appointment.new(detail: 'Some detail')
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.choose_appt_student @test.students.first
-        @advisor_homepage.add_reasons(appt, [Topic::OTHER])
-        expect(@advisor_homepage.make_appt_button_element.disabled?).to be true
-        @advisor_homepage.enter_detail appt
-        @advisor_homepage.wait_until(Utils.short_wait) { !@advisor_homepage.make_appt_button_element.disabled? }
-      end
-
-      it 'allows a drop-in advisor to create a new appointment' do
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.create_appt @appt_0
-        expect(@appt_0.id).not_to be_nil
-        @appts << @appt_0
-      end
-
-      it 'updates the scheduler appointment desk when a new appointment is created' do
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_0.id }
-      end
-
-      it 'prevents a drop-in advisor from creating a new appointment for a student with an existing pending appointment' do
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.choose_appt_student @appt_0.student
-        @advisor_homepage.student_double_booking_msg_element.when_visible 3
-      end
-    end
-  end
-
-  describe 'appointment search' do
-
-    before(:all) do
-      @advisor_homepage.hit_escape
-      @advisor_homepage.expand_search_options
-      @advisor_homepage.uncheck_include_students_cbx
-      @advisor_homepage.uncheck_include_classes_cbx
-    end
-
-    it 'can find a newly created appointment by its description' do
-      @advisor_homepage.type_note_appt_string_and_enter @appt_0.detail
-      @search_results_page.wait_for_appt_search_result_rows
-      expect(@search_results_page.appt_link(@appt_0).exists?).to be true
-    end
-
-    it 'cannot find a deleted appointment by its description' do
-      @advisor_homepage.type_note_appt_string_and_enter @appt_7.detail
-      expect(@search_results_page.appt_results_count).to be_zero
-    end
-  end
-
-  ### DROP-IN APPOINTMENT DETAILS
-
-  describe '"waiting" drop-in appointment details' do
-
-    # Scheduler
-
-    context 'on the appointment intake desk' do
-
-      before(:all) do
-        @scheduler_intake_desk.hit_escape
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.create_appt @appt_1
-        @appts << @appt_1
-        @scheduler_intake_desk.wait_until(Utils.short_wait) { @scheduler_intake_desk.visible_appt_ids.include? @appt_1.id }
-        @visible_list_view_appt_data = @scheduler_intake_desk.visible_list_view_appt_data @appt_1
-      end
-
-      after(:all) { @scheduler_intake_desk.hit_escape }
-
-      it('show the arrival time') { expect(@visible_list_view_appt_data[:created_date]).to eql(@scheduler_intake_desk.appt_time_created_format(@appt_1.created_date).strip) }
-      it('show the student name') { expect(@visible_list_view_appt_data[:student_non_link_name]).to eql(@appt_1.student.full_name) }
-      it('show no link to the student page') { expect(@visible_list_view_appt_data[:student_link_name]).to be_nil }
-      it('show the student SID') { expect(@visible_list_view_appt_data[:student_sid]).to eql(@appt_1.student.sis_id) }
-      it('show the appointment reason(s)') { expect(@visible_list_view_appt_data[:topics]).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
-
-      it('allow the scheduler to expand an appointment\'s details') { @scheduler_intake_desk.view_appt_details @appt_1 }
-      it('show the student name') { expect(@scheduler_intake_desk.details_student_name).to eql(@appt_1.student.full_name) }
-      it('show the appointment reason(s)') { expect(@scheduler_intake_desk.appt_reasons.sort).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
-      it('show the arrival time') { expect(@scheduler_intake_desk.modal_created_at).to eql(@scheduler_intake_desk.appt_time_created_format(@appt_1.created_date).strip) }
-    end
-
-    # Drop-in Advisor
-
-    context 'on the waiting list' do
-
-      before(:all) do
-        @advisor_homepage.load_page
-        @advisor_homepage.wait_until(Utils.short_wait) { @scheduler_homepage.visible_appt_ids.any? }
-        @visible_list_view_appt_data = @advisor_homepage.visible_list_view_appt_data @appt_1
-      end
-
-      after(:all) { @advisor_homepage.hit_escape }
-
-      it('show the arrival time') { expect(@visible_list_view_appt_data[:created_date]).to eql(@advisor_homepage.appt_time_created_format(@appt_1.created_date).strip) }
-      it('show the student name') { expect(@visible_list_view_appt_data[:student_link_name]).to eql(@appt_1.student.full_name) }
-      it('show the student SID') { expect(@visible_list_view_appt_data[:student_sid]).to eql(@appt_1.student.sis_id) }
-      it('show the appointment reason(s)') { expect(@visible_list_view_appt_data[:topics]).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
-
-      it('allow the drop-in advisor to expand an appointment\'s details') { @advisor_homepage.view_appt_details @appt_1 }
-      it('show the student name') { expect(@advisor_homepage.details_student_name).to eql(@appt_1.student.full_name) }
-      it('show the appointment reason(s)') { expect(@advisor_homepage.appt_reasons.sort).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
-      it('show the arrival time') { expect(@advisor_homepage.modal_created_at).to eql(@advisor_homepage.appt_time_created_format(@appt_1.created_date).strip) }
-    end
-
-    context 'on the student page' do
-
-      before(:all) do
-        @advisor_homepage.click_student_link @appt_1
-        @advisor_student_page.show_appts
-        @advisor_student_page.wait_until(1) { @advisor_student_page.visible_message_ids.include? @appt_1.id }
-      end
-
-      context 'when collapsed' do
-
-        before(:all) { @visible_collapsed_date = @advisor_student_page.visible_collapsed_appt_data @appt_1 }
-
-        it('show the appointment detail') { expect(@visible_collapsed_date[:detail]).to eql(@appt_1.detail) }
-        it('show the appointment status') { expect(@visible_collapsed_date[:status]).to eql('ASSIGNED') }
-        it('show the appointment date') { expect(@visible_collapsed_date[:created_date].split("\n")[1]).to eql(@advisor_student_page.expected_item_short_date_format(@appt_1.created_date)) }
-      end
-
-      context 'when expanded' do
-
-        before(:all) do
-          @advisor_student_page.expand_item @appt_1
-          @visible_expanded_data = @advisor_student_page.visible_expanded_appt_data @appt_1
-        end
-
-        it('show the appointment detail') { expect(@visible_expanded_data[:detail]).to eql(@appt_1.detail) }
-        it('show the appointment date') { expect(@visible_expanded_data[:created_date]).to eql(@advisor_student_page.expected_item_short_date_format @appt_1.created_date) }
-        it('show the appointment check-in button') { expect(@advisor_student_page.check_in_button(@appt_1).exists?).to be true }
-        it('show no appointment check-in time') { expect(@visible_expanded_data[:check_in_time]).to be_nil }
-        it('show no appointment cancel reason') { expect(@visible_expanded_data[:cancel_reason]).to be_nil }
-        it('show no appointment cancel additional info') { expect(@visible_expanded_data[:cancel_addl_info]).to be_nil }
-        it('show no appointment advisor') { expect(@visible_expanded_data[:advisor_name]).to be_nil }
-        it('show the appointment type') { expect(@visible_expanded_data[:type]).to eql('Drop-in') }
-        it('show the appointment reasons') { expect(@visible_expanded_data[:topics]).to eql(@appt_1.topics.map { |t| t.name.upcase }.sort) }
-      end
-    end
-  end
-
-  ### DROP-IN APPOINTMENT ASSIGNMENTS
-
-  describe 'drop-in appointment assignment' do
-
-    # Scheduler
-
-    context 'on the appointment intake desk' do
-
-      after(:all) { @scheduler_intake_desk.hit_escape }
-
-      it 'allows the scheduler to un-reserve a reserved appointment' do
-        @scheduler_intake_desk.hit_escape
-        @scheduler_intake_desk.click_unreserve_appt_button @appt_1
-        @scheduler_intake_desk.reserved_for_el(@appt_1).when_not_present Utils.short_wait
-        @appt_1.reserve_advisor = nil
-      end
-
-      it 'allows the scheduler to reserve an unreserved appointment' do
-        @scheduler_intake_desk.hit_escape
-        @scheduler_intake_desk.reserve_appt_for_advisor(@appt_1, @test.drop_in_advisor)
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.reserved_for_el(@appt_1).visible? }
-        @appt_1.reserve_advisor = @test.drop_in_advisor
-      end
-    end
-
-    # Drop-in Advisor
-
-    context 'on the waiting list' do
-
-      before(:all) do
-        @advisor_homepage.load_page
-        @advisor_homepage.wait_until(Utils.short_wait) { @scheduler_homepage.visible_appt_ids.any? }
-        @visible_list_view_appt_data = @advisor_homepage.visible_list_view_appt_data @appt_1
-      end
-
-      after(:all) { @advisor_homepage.hit_escape }
-
-      it 'allow the drop-in advisor to un-reserve an appointment' do
-        @advisor_homepage.hit_escape
-        @advisor_homepage.click_unreserve_appt_button @appt_1
-        @advisor_homepage.wait_for_poller { !@advisor_homepage.reserved_for_el(@appt_1).exists? }
-        @appt_1.reserve_advisor = nil
-      end
-
-      it 'allow the drop-in advisor to reserve an appointment' do
-        @advisor_homepage.reserve_appt_for_advisor(@appt_1, @test.drop_in_advisor)
-        @advisor_homepage.reserved_for_el(@appt_1).when_visible 3
-        expect(@advisor_homepage.reserved_for_el(@appt_1).text).to eql('Assigned to you')
-        @appt_1.reserve_advisor = @test.drop_in_advisor
-      end
-    end
-
-    context 'on the student page' do
-
-      before(:all) do
-        @advisor_homepage.click_student_link @appt_1
-        @advisor_student_page.show_appts
-        @advisor_student_page.wait_until(1) { @advisor_student_page.visible_message_ids.include? @appt_1.id }
-        @advisor_student_page.expand_item @appt_1
-      end
-
-      it 'allow the drop-in advisor to unreserve the appointment' do
-        @advisor_student_page.click_unreserve_appt_button @appt_1
-        @advisor_student_page.reserved_for_el(@appt_1).when_not_present 3
-      end
-
-      it 'show Waiting status on the unreserved appointment' do
-        @advisor_student_page.collapse_item @appt_1
-        @advisor_student_page.wait_until(3) { @advisor_student_page.visible_collapsed_appt_data(@appt_1)[:status] == 'WAITING' }
-      end
-
-      it 'allow the drop-in advisor to reserve the appointment' do
-        @advisor_student_page.expand_item @appt_1
-        @advisor_student_page.reserve_appt_for_advisor(@appt_1, @test.drop_in_advisor)
-        @advisor_student_page.reserved_for_el(@appt_1).when_visible 3
-      end
-
-      it 'show Reserved status on the reserved appointment' do
-        @advisor_student_page.collapse_item @appt_1
-        @advisor_student_page.wait_until(3) { @advisor_student_page.visible_collapsed_appt_data(@appt_1)[:status] == 'ASSIGNED' }
-      end
-    end
-  end
-
-  ### DROP-IN APPOINTMENT UPDATES
-
-  describe 'drop-in appointment updating' do
-
-    # Scheduler
-
-    context 'on the intake desk' do
-
-      it 'allows the scheduler to cancel an edit' do
-        @scheduler_intake_desk.view_appt_details @appt_1
-        @scheduler_intake_desk.click_close_details_button
-        @scheduler_intake_desk.modal_student_name_element.when_not_visible 2
-      end
-
-      it 'allows the scheduler to remove reasons' do
-        @scheduler_intake_desk.hit_escape
-        @scheduler_intake_desk.view_appt_details @appt_1
-        @scheduler_intake_desk.remove_reasons(@appt_1, @appt_1.topics)
-        expect(@scheduler_intake_desk.appt_reasons).to be_empty
-        expect(@scheduler_intake_desk.details_update_button_element.enabled?).to be false
-      end
-
-      it 'allows the scheduler to add reasons' do
-        @scheduler_intake_desk.add_reasons(@appt_1, [Topic::READMISSION, Topic::SAP])
-        expect(@scheduler_intake_desk.appt_reasons.sort).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort)
-        expect(@scheduler_intake_desk.details_update_button_element.enabled?).to be true
-      end
-
-      it 'allows the scheduler to edit additional info' do
-        @appt_1.detail = "#{@appt_1.detail} - edited by scheduler"
-        @scheduler_intake_desk.enter_detail @appt_1
-      end
-
-      it 'allows the scheduler to save an edit' do
-        @scheduler_intake_desk.click_details_update_button
-        @scheduler_intake_desk.wait_until(Utils.short_wait) { @scheduler_intake_desk.visible_list_view_appt_data(@appt_1)[:topics] == (@appt_1.topics.map { |t| t.name.downcase }.sort) }
-      end
-    end
-
-    # Drop-in Advisor
-
-    context 'on the waiting list' do
-
-      it 'allows the drop-in advisor to cancel an edit' do
-        @advisor_homepage.load_page
-        @advisor_homepage.view_appt_details @appt_1
-        @advisor_homepage.click_close_details_button
-        @advisor_homepage.modal_student_name_element.when_not_visible 2
-      end
-
-      it 'allows the drop-in advisor to remove reasons' do
-        @advisor_homepage.hit_escape
-        @advisor_homepage.view_appt_details @appt_1
-        @advisor_homepage.remove_reasons(@appt_1, @appt_1.topics)
-        expect(@advisor_homepage.appt_reasons).to be_empty
-        expect(@advisor_homepage.details_update_button_element.enabled?).to be false
-      end
-
-      it 'allows the drop-in advisor to add reasons' do
-        @advisor_homepage.add_reasons(@appt_1, [Topic::RETROACTIVE_ADD, Topic::RETROACTIVE_DROP])
-        expect(@advisor_homepage.appt_reasons).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort)
-        expect(@advisor_homepage.details_update_button_element.enabled?).to be true
-      end
-
-      it 'allows the drop-in advisor to edit additional info' do
-        @appt_1.detail = "#{@appt_1.detail} - edited by advisor"
-        @advisor_homepage.enter_detail @appt_1
-      end
-
-      it 'allows the drop-in advisor to save an edit' do
-        @advisor_homepage.click_details_update_button
-        @advisor_homepage.wait_until(Utils.short_wait) { @advisor_homepage.visible_list_view_appt_data(@appt_1)[:topics] == (@appt_1.topics.map { |t| t.name.downcase }.sort) }
-      end
-    end
-  end
-
-  describe 'appointment search' do
-
-    before(:all) do
-      @advisor_homepage.hit_escape
-      @advisor_homepage.expand_search_options
-      @advisor_homepage.uncheck_include_students_cbx
-      @advisor_homepage.uncheck_include_classes_cbx
-    end
-
-    it 'can find a newly updated appointment by its description' do
-      @advisor_homepage.type_note_appt_string_and_enter @appt_1.detail
-      @search_results_page.wait_for_appt_search_result_rows
-      expect(@search_results_page.appt_link(@appt_1).exists?).to be true
-    end
-  end
-
-  ### DROP-IN APPOINTMENT CHECK-IN
-
-  describe 'drop-in appointment checkin' do
-
-    # Scheduler
-
-    context 'on the intake desk' do
-
-      before(:all) do
-        @scheduler_intake_desk.click_new_appt
-        @scheduler_intake_desk.create_appt @appt_2
-        @appts << @appt_2
-      end
-
-      it 'requires that a scheduler select a drop-in advisor for the appointment' do
-        @scheduler_intake_desk.click_appt_check_in_button @appt_2
-        @scheduler_intake_desk.modal_check_in_button_element.when_present 1
-        expect(@scheduler_intake_desk.modal_check_in_button_element.disabled?).to be true
-        @scheduler_intake_desk.select_check_in_advisor @test.drop_in_advisor
-        expect(@scheduler_intake_desk.modal_check_in_button_element.disabled?).to be false
-      end
-
-      it 'offers available drop-in advisors as advisor for the appointment' do
-        expect(@scheduler_intake_desk.check_in_advisors.sort).to include(@test.drop_in_advisor.uid)
-      end
-
-      it 'can be done from the intake desk view' do
-        @scheduler_intake_desk.select_check_in_advisor @test.drop_in_advisor
-        @scheduler_intake_desk.click_modal_check_in_button
-        @appt_2.status = AppointmentStatus::CHECKED_IN
-        @appt_2.advisor = @test.drop_in_advisor
-      end
-
-      it 'removes the appointment from the intake desk list' do
-        @scheduler_intake_desk.wait_until(Utils.short_wait) { !@scheduler_intake_desk.visible_appt_ids.include? @appt_2.id }
-      end
-    end
-
-    # Drop-in Advisor
-
-    context 'on the waiting list' do
-
-      before(:all) do
-        @advisor_student_page.click_home
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.create_appt @appt_3
-        @appts << @appt_3
-      end
-
-      it 'can be done from the list view' do
-        @advisor_homepage.click_appt_check_in_button @appt_3
-        @advisor_homepage.select_check_in_advisor @test.drop_in_advisor
-        @advisor_homepage.click_modal_check_in_button
-        @appt_3.status = AppointmentStatus::CHECKED_IN
-        @appt_3.advisor = @test.drop_in_advisor
-      end
-
-      it 'updates the status of the appointment on the waiting list' do
-        @advisor_homepage.wait_for_poller do
-          visible_data = @advisor_homepage.visible_list_view_appt_data(@appt_3)
-          visible_data[:checked_in_status] && visible_data[:checked_in_status].include?('CHECKED IN')
-        end
-      end
-
-      it 'updates the scheduler appointment desk view dynamically' do
-        @scheduler_intake_desk.wait_for_poller { (@scheduler_intake_desk.visible_appt_ids & [@appt_3.id]).empty? }
-      end
-
-      it('can be undone') { @advisor_homepage.undo_appt_check_in @appt_3 }
-      it('updates the status of the appointment once undone') { @advisor_homepage.check_in_button(@appt_3).when_visible Utils.short_wait }
-
-      it 'updates the scheduler appointment desk view dynamically once undone' do
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_3.id }
-      end
-    end
-
-    context 'on the student page' do
-
-      context 'when the advisor is not a drop-in advisor' do
-
-        before(:all) do
-          @advisor_homepage.log_out
-          @advisor_homepage.dev_auth @test.advisor
-          @advisor_student_page.load_page @appt_3.student
-        end
-
-        after(:all) { @advisor_student_page.log_out }
-
-        it 'cannot be done' do
-          @advisor_student_page.show_appts
-          @advisor_student_page.expand_item @appt_3
-          expect(@advisor_student_page.check_in_button(@appt_3).exists?).to be false
-        end
-      end
-
-      context 'when the advisor is a drop-in advisor' do
-
-        before(:all) do
-          @advisor_homepage.dev_auth @test.drop_in_advisor
-          @advisor_student_page.click_student_link @appt_3
-          @advisor_student_page.show_appts
-          @advisor_student_page.expand_item @appt_3
-        end
-
-        it 'can be done' do
-          @advisor_student_page.click_check_in_button @appt_3
-          @advisor_student_page.select_check_in_advisor @test.drop_in_advisor
-          @advisor_student_page.click_modal_check_in_button
-          @advisor_student_page.wait_until(Utils.short_wait) { @advisor_student_page.visible_expanded_appt_data(@appt_3)[:check_in_time] }
-          @appt_3.status = AppointmentStatus::CHECKED_IN
-          @appt_3.advisor = @test.drop_in_advisor
-        end
-
-        it 'updates the scheduler appointment desk view dynamically' do
-          @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_appt_ids.include? @appt_3.id }
-        end
-      end
-    end
-  end
-
-  ### DROP-IN APPOINTMENT CANCELLATION
-
-  describe 'drop-in appointment cancellation' do
-
-    before(:all) do
-      @advisor_student_page.click_home
-      [@appt_4, @appt_5, @appt_6].each do |appt|
-        @advisor_homepage.click_new_appt
-        @advisor_homepage.create_appt appt
-        @appts << appt
-      end
-    end
-
-    # Scheduler
-
-    context 'on the appointment intake desk' do
-
-      before(:all) { @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_4.id } }
-
-      it 'requires a reason' do
-        @scheduler_intake_desk.click_appt_dropdown_button @appt_4
-        @scheduler_intake_desk.click_cancel_appt_button @appt_4
-        expect(@scheduler_intake_desk.cancel_confirm_button_element.disabled?).to be true
-        @appt_4.cancel_reason = 'Cancelled by student'
-        @scheduler_intake_desk.select_cancel_reason @appt_4
-        expect(@scheduler_intake_desk.cancel_confirm_button_element.disabled?).to be false
-      end
-
-      it 'accepts additional info' do
-        @appt_4.cancel_detail = "Some 'splainin' to do #{@test.id}"
-        @scheduler_intake_desk.enter_cancel_explanation @appt_4
-      end
-
-      it 'can be done' do
-        @scheduler_intake_desk.click_cancel_confirm_button
-        @appt_4.status = AppointmentStatus::CANCELED
-      end
-
-      it 'removes the appointment from the list' do
-        @scheduler_intake_desk.wait_until(Utils.short_wait) { !@scheduler_intake_desk.visible_appt_ids.include? @appt_4.id }
-      end
-    end
-
-    # Drop-in Advisor
-
-    context 'on the waiting list' do
-
-      it 'requires a reason' do
-        @advisor_homepage.click_appt_dropdown_button @appt_5
-        @advisor_homepage.click_cancel_appt_button @appt_5
-        expect(@advisor_homepage.cancel_confirm_button_element.disabled?).to be true
-        @appt_5.cancel_reason = 'Cancelled by department/advisor'
-        @advisor_homepage.select_cancel_reason @appt_5
-        expect(@advisor_homepage.cancel_confirm_button_element.disabled?).to be false
-      end
-
-      it 'accepts additional info' do
-        @appt_5.cancel_detail = "Even more 'splainin' to do #{@test.id}"
-        @advisor_homepage.enter_cancel_explanation @appt_5
-      end
-
-      it 'can be done' do
-        @advisor_homepage.click_cancel_confirm_button
-        @appt_5.status = AppointmentStatus::CANCELED
-      end
-
-      it 'updates the appointment status on the waiting list' do
-        @advisor_homepage.wait_until(Utils.short_wait) do
-          visible_data = @advisor_homepage.visible_list_view_appt_data @appt_5
-          visible_data[:canceled_status] && visible_data[:canceled_status].include?('CANCELLED')
-        end
-      end
-
-      it 'updates the scheduler appointment desk view dynamically' do
-        @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_appt_ids.include? @appt_4.id }
-      end
-
-      it('can be undone') { @advisor_homepage.undo_appt_cancel @appt_5 }
-      it('updates the status of the appointment once undone') do
-        @advisor_homepage.wait_for_poller { @advisor_homepage.check_in_button(@appt_5).visible? }
-      end
-
-      it 'updates the scheduler appointment desk view dynamically once undone' do
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_5.id }
-      end
-    end
-
-    context 'on the student page' do
-
-      before(:all) do
-        @advisor_homepage.click_student_link @appt_6
-        @advisor_student_page.show_appts
-        @advisor_student_page.expand_item @appt_6
-      end
-
-      it 'requires a reason' do
-        @advisor_student_page.click_appt_dropdown_button @appt_6
-        @advisor_student_page.click_cancel_appt_button @appt_6
-        expect(@advisor_student_page.cancel_confirm_button_element.disabled?).to be true
-        @appt_6.cancel_reason = 'Cancelled by student'
-        @advisor_student_page.select_cancel_reason @appt_6
-        expect(@advisor_student_page.cancel_confirm_button_element.disabled?).to be false
-      end
-
-      it 'accepts additional info' do
-        @appt_6.cancel_detail = "Too much 'splainin' to do #{@test.id}"
-        @advisor_student_page.enter_cancel_explanation @appt_6
-      end
-
-      it 'can be done' do
-        @advisor_student_page.click_cancel_confirm_button
-        @advisor_student_page.wait_until(Utils.short_wait) do
-          visible_data = @advisor_student_page.visible_expanded_appt_data @appt_6
-          visible_data[:cancel_reason] == @appt_6.cancel_reason
-          visible_data[:cancel_addl_info] == @appt_6.cancel_detail
-        end
-        @appt_6.status = AppointmentStatus::CANCELED
-      end
-
-      it 'updates the scheduler appointment desk view dynamically' do
-        @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_appt_ids.include? @appt_6.id }
-      end
-    end
-  end
-
-  describe 'appointment search' do
-
-    before(:all) do
-      @advisor_homepage.hit_escape
-      @advisor_homepage.expand_search_options
-      @advisor_homepage.uncheck_include_students_cbx
-      @advisor_homepage.uncheck_include_classes_cbx
-    end
-
-    it 'can find a cancelled appointment by its cancellation detail' do
-      @advisor_homepage.type_note_appt_string_and_enter @appt_4.cancel_detail
-      @search_results_page.wait_for_appt_search_result_rows
-      expect(@search_results_page.appt_link(@appt_4).exists?).to be true
-    end
-  end
-
-  ### APPOINTMENT SORTING ###
-
-  describe 'intake desk appointments' do
-
-    it 'shows today\'s pending appointments sorted by creation time' do
-      pending_appts = @appts.select { |a| a.status == AppointmentStatus::WAITING }.sort_by(&:created_date).map(&:id)
-      expect(@scheduler_intake_desk.visible_appt_ids).to eql(pending_appts)
-    end
-  end
-
-  describe 'drop-in advisor waiting list' do
-
-    before(:all) do
-      @advisor_student_page.click_home
-      @advisor_homepage.wait_until(Utils.short_wait) { @advisor_homepage.visible_appt_ids.any? }
-    end
-
-    it 'shows all today\'s appointments sorted by creation time, with canceled and checked-in segregated at the bottom' do
-      non_pending_appts = @appts.select{ |a| [AppointmentStatus::CANCELED, AppointmentStatus::CHECKED_IN].include? a.status }.sort_by(&:created_date)
-      pending_appts = (@appts - non_pending_appts).sort_by(&:created_date)
-      @advisor_homepage.wait_for_poller { @advisor_homepage.visible_appt_ids == ((pending_appts + non_pending_appts).map(&:id)) }
-    end
-  end
-
-  describe 'student appointment timeline' do
-
-    before(:all) do
-      student = @students.last
-      checked_in_appt = Appointment.new(student: student, topics: [Topic::COURSE_ADD], detail: "Checked-in #{@test.id}")
-      canceled_appt = Appointment.new(student: student, topics: [Topic::COURSE_ADD], detail: "Canceled #{@test.id}", cancel_reason: 'Cancelled by student', cancel_detail: 'Foo')
-      pending_appt = Appointment.new(student: student, topics: [Topic::COURSE_ADD], detail: "Pending #{@test.id}")
-
-      @advisor_homepage.click_new_appt
-      @advisor_homepage.create_appt checked_in_appt
-      @advisor_homepage.click_appt_check_in_button checked_in_appt
-      @advisor_homepage.select_check_in_advisor @test.drop_in_advisor
-      @advisor_homepage.click_modal_check_in_button
-      @advisor_homepage.wait_for_poller do
-        visible_data = @advisor_homepage.visible_list_view_appt_data checked_in_appt
-        visible_data[:checked_in_status] && visible_data[:checked_in_status].include?('CHECKED IN')
-      end
-
-      @advisor_homepage.click_new_appt
-      @advisor_homepage.create_appt canceled_appt
-      @advisor_homepage.click_appt_dropdown_button canceled_appt
-      @advisor_homepage.click_cancel_appt_button canceled_appt
-      @advisor_homepage.select_cancel_reason canceled_appt
-      @advisor_homepage.enter_cancel_explanation canceled_appt
-      @advisor_homepage.click_cancel_confirm_button
-      @advisor_homepage.wait_for_poller do
-        visible_data = @advisor_homepage.visible_list_view_appt_data canceled_appt
-        visible_data[:canceled_status] && visible_data[:canceled_status].include?('CANCELLED')
-      end
-
-      @advisor_homepage.click_new_appt
-      @advisor_homepage.create_appt pending_appt
-
-      @advisor_homepage.click_student_link pending_appt
-      @advisor_student_page.show_appts
-      boa_appts = BOACUtils.get_student_appts(student, @test.students).reject &:deleted_date
-      sis_appts = NessieUtils.get_sis_appts student
-      @student_appts = boa_appts + sis_appts
-    end
-
-    it 'shows all non-deleted appointments sorted by creation time' do
-      expect(@advisor_student_page.visible_collapsed_item_ids('appointment')).to eql(@student_appts.sort_by(&:created_date).reverse.map(&:id).uniq)
-    end
-  end
-
-  ### ASSIGNMENTS REMOVED WHEN ADVISOR GOES OFF-DUTY ###
-
-  describe 'drop-in advisor' do
-
-    before(:all) do
-      @advisor_homepage.load_page
-      @advisor_homepage.click_new_appt
-      @advisor_homepage.create_appt @appt_10
-      @advisor_homepage.reserved_for_el(@appt_10).when_visible 2
-    end
-
-    it 'is warned that going off-duty will remove appointment assignments' do
-      @advisor_homepage.click_self_availability_button
-      @advisor_homepage.off_duty_confirm_button_element.when_visible 2
-    end
-
-    it 'can cancel going off-duty and keep appointment assignments' do
-      @advisor_homepage.click_off_duty_cancel
-      @advisor_homepage.reserved_for_el(@appt_10).when_visible 2
-    end
-
-    it 'loses appointment assignments when going off-duty' do
-      @advisor_homepage.click_self_availability_button
-      @advisor_homepage.click_off_duty_confirm
-      @advisor_homepage.wait_for_poller { !@advisor_homepage.reserved_for_el(@appt_10).exists? }
-    end
-
-    it 'can assign an appointment to itself while off-duty' do
-      @advisor_homepage.reserve_appt_for_advisor(@appt_10, @test.drop_in_advisor)
-      @advisor_homepage.wait_for_poller { @advisor_homepage.reserved_for_el(@appt_10).visible? }
-      expect(@advisor_homepage.reserved_for_el(@appt_10).text).to eql('Assigned to you')
-    end
-  end
-
-  describe 'scheduler' do
-
-    before(:all) { @scheduler_intake_desk.set_advisor_available @test.drop_in_advisor }
-
-    it 'is warned that taking an advisor off-duty will remove appointment assignments' do
-      @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.reserved_for_el(@appt_10).exists? }
-      @scheduler_intake_desk.click_advisor_availability_toggle @test.drop_in_advisor
-      @scheduler_intake_desk.off_duty_confirm_button_element.when_visible 2
-    end
-
-    it 'can cancel taking an advisor off-duty and keep appointment assignments' do
-      @scheduler_intake_desk.click_off_duty_cancel
-      expect(@scheduler_intake_desk.reserved_for_el(@appt_10).exists?).to be true
-    end
-
-    it 'loses appointment assignments when taking an advisor off-duty' do
-      @scheduler_intake_desk.click_advisor_availability_toggle @test.drop_in_advisor
-      @scheduler_intake_desk.click_off_duty_confirm
-      @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.reserved_for_el(@appt_10).exists? }
-    end
-
-    ### SCHEDULER - LOGGING RESOLVED ISSUE ###
-
-    context 'when logging a resolved issue' do
-
-      before(:all) { @resolved_issue = Appointment.new(student: @students[11], topics: [Topic::COURSE_ADD], detail: "A resolved issue #{@test.id}") }
-
-      it 'creates a checked-in appointment with itself' do
-        @scheduler_intake_desk.log_resolved_issue(@resolved_issue, @test.drop_in_scheduler)
-        expect(@resolved_issue.id).not_to be_nil
-      end
-
-      it 'updates the waiting list with the checked-in appointment' do
-        @advisor_homepage.wait_for_poller do
-          visible_data = @advisor_homepage.visible_list_view_appt_data(@resolved_issue)
-          visible_data[:checked_in_status] && visible_data[:checked_in_status].include?('CHECKED IN')
-        end
-      end
-
-      it 'updates the student page with the checked-in appointment' do
-        @advisor_student_page.load_page @resolved_issue.student
-        @advisor_student_page.show_appts
-        @advisor_student_page.expand_item @resolved_issue
-        visible_data = @advisor_student_page.visible_expanded_appt_data @resolved_issue
-        expect(visible_data[:advisor_role]).to include('Intake Desk')
-      end
-    end
-  end
-
-  ### SETTINGS PAGE - DROP-IN STATUS ###
-
-  describe 'settings page' do
-
-    before(:all) do
-      @advisor_homepage.load_page
-      @advisor_homepage.click_new_appt
-      @advisor_homepage.create_appt @appt_11
-    end
+    ### PERMISSIONS - SCHEDULER
 
     context 'when the user is a scheduler' do
 
-      it 'is offered in the header' do
-        @scheduler_intake_desk.click_header_dropdown
-        expect(@scheduler_intake_desk.settings_link?).to be true
+      before(:all) { @scheduler_homepage.dev_auth @test.drop_in_scheduler }
+
+      it 'drops the user onto the drop-in intake desk at login' do
+        expect(@scheduler_homepage.title).to include('Drop-in Appointments Desk')
+        @scheduler_intake_desk.new_appt_button_element.when_visible Utils.short_wait
       end
 
-      it 'cannot be reached in its admin flavor' do
-        @scheduler_flight_deck.load_page
-        @scheduler_flight_deck.wait_for_title 'Not Found'
+      it 'prevents the user from accessing a drop-in intake desk belonging to another department' do
+        @scheduler_intake_desk.load_page @other_dept
+        @scheduler_intake_desk.wait_for_title 'Not Found'
       end
+
+      it 'prevents the user from accessing a page other than the drop-in intake desk' do
+        @scheduler_intake_desk.navigate_to "#{BOACUtils.base_url}/student/#{@students.first.uid}"
+        @scheduler_intake_desk.wait_for_title 'Not Found'
+      end
+
+      # TODO user cannot get to any boa API endpoints other than drop-in endpoints
     end
+
+    ### PERMISSIONS - DROP-IN ADVISOR
 
     context 'when the user is a drop-in advisor' do
 
       before(:all) do
-        @advisor_homepage.click_settings_link
-        @scheduler_intake_desk.load_page @test.dept
-      end
-
-      it 'allows the user to remove its drop-in advising role' do
+        @advisor_homepage.dev_auth @test.drop_in_advisor
+        @advisor_flight_deck.load_advisor_page
         @advisor_flight_deck.disable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
-        @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.drop_in_advisor_uids.include?(@test.drop_in_advisor.uid) }
+        @advisor_flight_deck.enable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
+        @drop_in_advisors << @test.drop_in_advisor unless @drop_in_advisors.map(&:uid).include? @test.drop_in_advisor.uid
       end
 
-      it 'removes the user\'s access to the waiting list' do
+      after(:all) { @advisor_homepage.log_out }
+
+      it 'drops the user onto the homepage at login with a waiting list' do
         @advisor_homepage.load_page
-        sleep 1
+        expect(@advisor_homepage.title).to include('Home')
+        @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
+      end
+
+      it 'prevents the user from accessing the department drop-in intake desk' do
+        @advisor_appt_desk.load_page @test.dept
+        @advisor_appt_desk.wait_for_title 'Page not found'
+      end
+
+      it 'prevents the user from accessing a drop-in intake desk belonging to another department' do
+        @advisor_appt_desk.load_page @other_dept
+        @advisor_appt_desk.wait_for_title 'Page not found'
+      end
+    end
+
+    ### PERMISSIONS - NON-DROP-IN ADVISOR
+
+    context 'when the user is a non-drop-in advisor' do
+
+      before(:all) { @advisor_homepage.dev_auth @test.advisor }
+      after(:all) { @advisor_homepage.log_out }
+
+      it 'drops the user onto the homepage at login with no waiting list' do
+        expect(@advisor_homepage.title).to include('Home')
+        sleep 2
         expect(@advisor_homepage.new_appt_button?).to be false
       end
 
-      it 'removes the user\'s appointment assignments on the waiting list when the drop-in advising role is removed' do
-        @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_list_view_appt_data(@appt_11)[:reserved_by] }
+      it 'prevents the user from accessing the department drop-in intake desk' do
+        @advisor_appt_desk.load_page @test.dept
+        @advisor_appt_desk.wait_for_title 'Page not found'
+      end
+    end
+
+    ### PERMISSIONS - ADMIN
+
+    context 'when the user is an admin' do
+
+      before(:all) { @advisor_homepage.dev_auth }
+      after(:all) { @advisor_homepage.log_out }
+
+      it 'drops the user onto the homepage at login with no waiting list' do
+        expect(@advisor_homepage.title).to include('Home')
+        sleep 2
+        expect(@advisor_homepage.new_appt_button?).to be false
       end
 
-      it 'removes the user\'s appointment assignments on the student page when the drop-in advising role is removed' do
-        @advisor_student_page.load_page @appt_11.student
+      it 'allows the user to access any department\'s drop-in intake desk' do
+        @advisor_appt_desk.load_page @test.dept
+        @advisor_appt_desk.wait_for_title 'Drop-in Appointments Desk'
+        @advisor_appt_desk.load_page @other_dept
+        @advisor_appt_desk.wait_for_title 'Drop-in Appointments Desk'
+      end
+    end
+
+    ### ADVISOR AVAILABILITY ###
+
+    describe 'drop-in advisor availability' do
+
+      context 'on the intake desk' do
+
+        before(:all) { @scheduler_intake_desk.load_page @test.dept }
+        after(:all) { @scheduler_intake_desk.hit_escape }
+
+        it 'is shown for only drop-in advisors' do
+          @scheduler_intake_desk.new_appt_button_element.when_visible Utils.short_wait
+          expect(@scheduler_intake_desk.drop_in_advisor_uids.sort).to eql(@drop_in_advisors.map(&:uid).sort)
+        end
+
+        it('allows a scheduler to set a drop-in advisor to "unavailable"') { @scheduler_intake_desk.set_advisor_unavailable @test.drop_in_advisor }
+
+        it 'shows no unavailable advisors when making an appointment with a reservation' do
+          @scheduler_intake_desk.click_new_appt
+          expect(@scheduler_intake_desk.available_appt_advisor_uids).not_to include(@test.drop_in_advisor.uid)
+        end
+
+        it 'allows a scheduler to set a drop-in advisor to "available"' do
+          @scheduler_intake_desk.hit_escape
+          @scheduler_intake_desk.set_advisor_available @test.drop_in_advisor
+        end
+
+        it 'shows available advisors when making an appointment with a reservation' do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.available_appt_advisor_uids.include? @test.drop_in_advisor.uid }
+        end
+      end
+
+      context 'on the waiting list' do
+
+        before(:all) { @advisor_homepage.dev_auth @test.drop_in_advisor }
+
+        it 'is shown for the logged-in drop-in advisor' do
+          @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
+          @advisor_homepage.wait_for_poller { @advisor_homepage.self_available? }
+        end
+
+        it('allows a drop-in advisor to set itself "unavailable"') { @advisor_homepage.set_self_unavailable }
+        it('allows a drop-in advisor to set itself "available"') { @advisor_homepage.set_self_available }
+
+        it 'is shown for only drop-in advisors' do
+          @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
+          expect(@advisor_homepage.visible_drop_in_advisors_and_status).to eql(BOACUtils.get_drop_in_advisors_and_status(@test.dept))
+        end
+
+        it 'does not allow a drop-in advisor to toggle another advisor\'s availability' do
+          expect(@advisor_homepage.availability_toggle_button_elements.length).to eql(1)
+        end
+      end
+    end
+
+    ### ADVISOR STATUS ###
+
+    describe 'drop-in advisor status' do
+
+      context 'on the intake desk' do
+
+        it 'cannot be set' do
+          expect(@scheduler_intake_desk.status_clear_button?).to be false
+          expect(@scheduler_intake_desk.status_save_button?).to be false
+        end
+      end
+
+      context 'on the waiting list' do
+
+        it 'can be set' do
+          @advisor_homepage.create_status(@test.drop_in_advisor.dept_memberships.first, ("#{@test.id} drop-in advisor status" * 6))
+          @advisor_homepage.wait_until(2) { @advisor_homepage.status == @test.drop_in_advisor.dept_memberships.first.drop_in_status }
+        end
+
+        it 'updates the intake desk when set' do
+          @scheduler_intake_desk.wait_for_poller do
+            @scheduler_intake_desk.intake_desk_advisor_status(@test.drop_in_advisor)&.include? @test.drop_in_advisor.dept_memberships.first.drop_in_status
+          end
+        end
+
+        it 'can be cleared' do
+          @advisor_homepage.clear_status @test.drop_in_advisor.dept_memberships.first
+        end
+
+        it 'updates the intake desk when cleared' do
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.intake_desk_advisor_status(@test.advisor) == @test.advisor.dept_memberships.first.drop_in_status }
+        end
+      end
+    end
+
+    ### DROP-IN APPOINTMENT CREATION
+
+    describe 'drop-in appointment creation' do
+
+      # Scheduler
+
+      context 'on the intake desk' do
+
+        before(:all) do
+          existing_appts = BOACUtils.get_today_drop_in_appts(@test.dept, @test.students).select { |a| !a.deleted_date }
+          BOACUtils.delete_appts existing_appts
+        end
+
+        before(:each) { @scheduler_intake_desk.hit_escape }
+
+        it 'shows a No Appointments message when there are no appointments' do
+          @scheduler_intake_desk.empty_wait_list_msg_element.when_visible Utils.medium_wait
+          expect(@scheduler_intake_desk.empty_wait_list_msg.strip).to eql('No appointments yet')
+        end
+
+        it 'allows a scheduler to create but cancel a new appointment' do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.click_cancel_new_appt
+        end
+
+        it 'requires a scheduler to select a student for a new appointment' do
+          appt = Appointment.new(detail: 'Some detail')
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.add_reasons(appt, [Topic::OTHER])
+          @scheduler_intake_desk.enter_detail appt
+          expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be true
+          @scheduler_intake_desk.choose_appt_student @test.students.first
+          expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be false
+        end
+
+        it 'requires a scheduler to select a reason for a new appointment' do
+          appt = Appointment.new(detail: 'Some detail')
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.choose_appt_student @test.students.first
+          @scheduler_intake_desk.enter_detail appt
+          expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be true
+          @scheduler_intake_desk.add_reasons(appt, [Topic::OTHER])
+          @scheduler_intake_desk.wait_until(2) { !@scheduler_intake_desk.make_appt_button_element.disabled? }
+        end
+
+        it 'allows a scheduler to select an available advisor for a new reserved appointment' do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.wait_until(1) { @scheduler_intake_desk.available_appt_advisor_uids.sort.include? @test.drop_in_advisor.uid }
+        end
+
+        it 'shows a scheduler the right reasons for a new appointment' do
+          @scheduler_intake_desk.click_new_appt
+          expected_topics = Topic::TOPICS.select(&:for_appts).map &:name
+          @scheduler_intake_desk.wait_until(1, "Expected #{expected_topics}, got #{@scheduler_intake_desk.available_appt_reasons}") do
+            @scheduler_intake_desk.available_appt_reasons == expected_topics
+          end
+        end
+
+        it 'requires a scheduler to enter details for a new appointment' do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.choose_appt_student @test.students.first
+          @scheduler_intake_desk.add_reasons(@appt_9, [Topic::OTHER])
+          expect(@scheduler_intake_desk.make_appt_button_element.disabled?).to be true
+          @scheduler_intake_desk.enter_detail @appt_9
+          @scheduler_intake_desk.wait_until(3) { !@scheduler_intake_desk.make_appt_button_element.disabled? }
+        end
+
+        it 'allows a scheduler to create a new unreserved appointment' do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.create_appt @appt_7
+          expect(@appt_7.id).not_to be_nil
+        end
+
+        it 'allows a scheduler to create a new reserved apppointment' do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.create_appt @appt_8
+          expect(@appt_8.id).not_to be_nil
+          expect(@scheduler_intake_desk.visible_list_view_appt_data(@appt_8)[:reserved_by]).not_to be_nil
+        end
+
+        it 'prevents a scheduler from creating a new appointment for a student with an existing pending appointment' do
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_8.id }
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.choose_appt_student @appt_8.student
+          @scheduler_intake_desk.student_double_booking_msg_element.when_visible 3
+        end
+      end
+
+      # Drop-in Advisor
+
+      context 'on the waiting list' do
+
+        before(:all) do
+          existing_appts = BOACUtils.get_today_drop_in_appts(@test.dept, @test.students)
+          BOACUtils.delete_appts existing_appts
+        end
+
+        before(:each) { @advisor_homepage.hit_escape }
+
+        it 'shows a No Appointments message when there are no appointments' do
+          @advisor_homepage.empty_wait_list_msg_element.when_visible Utils.medium_wait
+          expect(@advisor_homepage.empty_wait_list_msg.strip).to eql('No appointments yet')
+        end
+
+        it 'updates the scheduler appointment desk with a No Appointments message when there are no appointments' do
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.empty_wait_list_msg? }
+        end
+
+        it 'allows a drop-in advisor to create but cancel a new appointment' do
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.click_cancel_new_appt
+        end
+
+        it 'requires a drop-in advisor to select a student for a new appointment' do
+          appt = Appointment.new(detail: 'Some detail')
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.add_reasons(appt, [Topic::OTHER])
+          @advisor_homepage.enter_detail appt
+          expect(@advisor_homepage.make_appt_button_element.disabled?).to be true
+          @advisor_homepage.choose_appt_student @test.students.first
+          expect(@advisor_homepage.make_appt_button_element.disabled?).to be false
+        end
+
+        it 'requires a drop-in advisor to select a reason for a new appointment' do
+          appt = Appointment.new(detail: 'Some detail')
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.choose_appt_student @test.students.first
+          @advisor_homepage.enter_detail appt
+          expect(@advisor_homepage.make_appt_button_element.disabled?).to be true
+          @advisor_homepage.add_reasons(appt, [Topic::OTHER])
+          expect(@advisor_homepage.make_appt_button_element.disabled?).to be false
+        end
+
+        it 'shows a drop-in advisor the right reasons for a new appointment' do
+          @advisor_homepage.click_new_appt
+          expected_topics = Topic::TOPICS.select(&:for_appts).map &:name
+          @advisor_homepage.wait_until(1, "Expected #{expected_topics}, got #{@advisor_homepage.available_appt_reasons}") do
+            @advisor_homepage.available_appt_reasons == expected_topics
+          end
+        end
+
+        it 'requires a drop-in advisor to enter details for a new appointment' do
+          appt = Appointment.new(detail: 'Some detail')
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.choose_appt_student @test.students.first
+          @advisor_homepage.add_reasons(appt, [Topic::OTHER])
+          expect(@advisor_homepage.make_appt_button_element.disabled?).to be true
+          @advisor_homepage.enter_detail appt
+          @advisor_homepage.wait_until(Utils.short_wait) { !@advisor_homepage.make_appt_button_element.disabled? }
+        end
+
+        it 'allows a drop-in advisor to create a new appointment' do
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.create_appt @appt_0
+          expect(@appt_0.id).not_to be_nil
+          @appts << @appt_0
+        end
+
+        it 'updates the scheduler appointment desk when a new appointment is created' do
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_0.id }
+        end
+
+        it 'prevents a drop-in advisor from creating a new appointment for a student with an existing pending appointment' do
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.choose_appt_student @appt_0.student
+          @advisor_homepage.student_double_booking_msg_element.when_visible 3
+        end
+      end
+    end
+
+    describe 'appointment search' do
+
+      before(:all) do
+        @advisor_homepage.hit_escape
+        @advisor_homepage.expand_search_options
+        @advisor_homepage.uncheck_include_students_cbx
+        @advisor_homepage.uncheck_include_classes_cbx
+      end
+
+      it 'can find a newly created appointment by its description' do
+        @advisor_homepage.type_note_appt_string_and_enter @appt_0.detail
+        @search_results_page.wait_for_appt_search_result_rows
+        expect(@search_results_page.appt_link(@appt_0).exists?).to be true
+      end
+
+      it 'cannot find a deleted appointment by its description' do
+        @advisor_homepage.type_note_appt_string_and_enter @appt_7.detail
+        expect(@search_results_page.appt_results_count).to be_zero
+      end
+    end
+
+    ### DROP-IN APPOINTMENT DETAILS
+
+    describe '"waiting" drop-in appointment details' do
+
+      # Scheduler
+
+      context 'on the appointment intake desk' do
+
+        before(:all) do
+          @scheduler_intake_desk.hit_escape
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.create_appt @appt_1
+          @appts << @appt_1
+          @scheduler_intake_desk.wait_until(Utils.short_wait) { @scheduler_intake_desk.visible_appt_ids.include? @appt_1.id }
+          @visible_list_view_appt_data = @scheduler_intake_desk.visible_list_view_appt_data @appt_1
+        end
+
+        after(:all) { @scheduler_intake_desk.hit_escape }
+
+        it('show the arrival time') { expect(@visible_list_view_appt_data[:created_date]).to eql(@scheduler_intake_desk.appt_time_created_format(@appt_1.created_date).strip) }
+        it('show the student name') { expect(@visible_list_view_appt_data[:student_non_link_name]).to eql(@appt_1.student.full_name) }
+        it('show no link to the student page') { expect(@visible_list_view_appt_data[:student_link_name]).to be_nil }
+        it('show the student SID') { expect(@visible_list_view_appt_data[:student_sid]).to eql(@appt_1.student.sis_id) }
+        it('show the appointment reason(s)') { expect(@visible_list_view_appt_data[:topics]).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
+
+        it('allow the scheduler to expand an appointment\'s details') { @scheduler_intake_desk.view_appt_details @appt_1 }
+        it('show the student name') { expect(@scheduler_intake_desk.details_student_name).to eql(@appt_1.student.full_name) }
+        it('show the appointment reason(s)') { expect(@scheduler_intake_desk.appt_reasons.sort).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
+        it('show the arrival time') { expect(@scheduler_intake_desk.modal_created_at).to eql(@scheduler_intake_desk.appt_time_created_format(@appt_1.created_date).strip) }
+      end
+
+      # Drop-in Advisor
+
+      context 'on the waiting list' do
+
+        before(:all) do
+          @advisor_homepage.load_page
+          @advisor_homepage.wait_until(Utils.short_wait) { @scheduler_homepage.visible_appt_ids.any? }
+          @visible_list_view_appt_data = @advisor_homepage.visible_list_view_appt_data @appt_1
+        end
+
+        after(:all) { @advisor_homepage.hit_escape }
+
+        it('show the arrival time') { expect(@visible_list_view_appt_data[:created_date]).to eql(@advisor_homepage.appt_time_created_format(@appt_1.created_date).strip) }
+        it('show the student name') { expect(@visible_list_view_appt_data[:student_link_name]).to eql(@appt_1.student.full_name) }
+        it('show the student SID') { expect(@visible_list_view_appt_data[:student_sid]).to eql(@appt_1.student.sis_id) }
+        it('show the appointment reason(s)') { expect(@visible_list_view_appt_data[:topics]).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
+
+        it('allow the drop-in advisor to expand an appointment\'s details') { @advisor_homepage.view_appt_details @appt_1 }
+        it('show the student name') { expect(@advisor_homepage.details_student_name).to eql(@appt_1.student.full_name) }
+        it('show the appointment reason(s)') { expect(@advisor_homepage.appt_reasons.sort).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort) }
+        it('show the arrival time') { expect(@advisor_homepage.modal_created_at).to eql(@advisor_homepage.appt_time_created_format(@appt_1.created_date).strip) }
+      end
+
+      context 'on the student page' do
+
+        before(:all) do
+          @advisor_homepage.click_student_link @appt_1
+          @advisor_student_page.show_appts
+          @advisor_student_page.wait_until(1) { @advisor_student_page.visible_message_ids.include? @appt_1.id }
+        end
+
+        context 'when collapsed' do
+
+          before(:all) { @visible_collapsed_date = @advisor_student_page.visible_collapsed_appt_data @appt_1 }
+
+          it('show the appointment detail') { expect(@visible_collapsed_date[:detail]).to eql(@appt_1.detail) }
+          it('show the appointment status') { expect(@visible_collapsed_date[:status]).to eql('ASSIGNED') }
+          it('show the appointment date') { expect(@visible_collapsed_date[:created_date].split("\n")[1]).to eql(@advisor_student_page.expected_item_short_date_format(@appt_1.created_date)) }
+        end
+
+        context 'when expanded' do
+
+          before(:all) do
+            @advisor_student_page.expand_item @appt_1
+            @visible_expanded_data = @advisor_student_page.visible_expanded_appt_data @appt_1
+          end
+
+          it('show the appointment detail') { expect(@visible_expanded_data[:detail]).to eql(@appt_1.detail) }
+          it('show the appointment date') { expect(@visible_expanded_data[:created_date]).to eql(@advisor_student_page.expected_item_short_date_format @appt_1.created_date) }
+          it('show the appointment check-in button') { expect(@advisor_student_page.check_in_button(@appt_1).exists?).to be true }
+          it('show no appointment check-in time') { expect(@visible_expanded_data[:check_in_time]).to be_nil }
+          it('show no appointment cancel reason') { expect(@visible_expanded_data[:cancel_reason]).to be_nil }
+          it('show no appointment cancel additional info') { expect(@visible_expanded_data[:cancel_addl_info]).to be_nil }
+          it('show no appointment advisor') { expect(@visible_expanded_data[:advisor_name]).to be_nil }
+          it('show the appointment type') { expect(@visible_expanded_data[:type]).to eql('Drop-in') }
+          it('show the appointment reasons') { expect(@visible_expanded_data[:topics]).to eql(@appt_1.topics.map { |t| t.name.upcase }.sort) }
+        end
+      end
+    end
+
+    ### DROP-IN APPOINTMENT ASSIGNMENTS
+
+    describe 'drop-in appointment assignment' do
+
+      # Scheduler
+
+      context 'on the appointment intake desk' do
+
+        after(:all) { @scheduler_intake_desk.hit_escape }
+
+        it 'allows the scheduler to un-reserve a reserved appointment' do
+          @scheduler_intake_desk.hit_escape
+          @scheduler_intake_desk.click_unreserve_appt_button @appt_1
+          @scheduler_intake_desk.reserved_for_el(@appt_1).when_not_present Utils.short_wait
+          @appt_1.reserve_advisor = nil
+        end
+
+        it 'allows the scheduler to reserve an unreserved appointment' do
+          @scheduler_intake_desk.hit_escape
+          @scheduler_intake_desk.reserve_appt_for_advisor(@appt_1, @test.drop_in_advisor)
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.reserved_for_el(@appt_1).visible? }
+          @appt_1.reserve_advisor = @test.drop_in_advisor
+        end
+      end
+
+      # Drop-in Advisor
+
+      context 'on the waiting list' do
+
+        before(:all) do
+          @advisor_homepage.load_page
+          @advisor_homepage.wait_until(Utils.short_wait) { @scheduler_homepage.visible_appt_ids.any? }
+          @visible_list_view_appt_data = @advisor_homepage.visible_list_view_appt_data @appt_1
+        end
+
+        after(:all) { @advisor_homepage.hit_escape }
+
+        it 'allow the drop-in advisor to un-reserve an appointment' do
+          @advisor_homepage.hit_escape
+          @advisor_homepage.click_unreserve_appt_button @appt_1
+          @advisor_homepage.wait_for_poller { !@advisor_homepage.reserved_for_el(@appt_1).exists? }
+          @appt_1.reserve_advisor = nil
+        end
+
+        it 'allow the drop-in advisor to reserve an appointment' do
+          @advisor_homepage.reserve_appt_for_advisor(@appt_1, @test.drop_in_advisor)
+          @advisor_homepage.reserved_for_el(@appt_1).when_visible 3
+          expect(@advisor_homepage.reserved_for_el(@appt_1).text).to eql('Assigned to you')
+          @appt_1.reserve_advisor = @test.drop_in_advisor
+        end
+      end
+
+      context 'on the student page' do
+
+        before(:all) do
+          @advisor_homepage.click_student_link @appt_1
+          @advisor_student_page.show_appts
+          @advisor_student_page.wait_until(1) { @advisor_student_page.visible_message_ids.include? @appt_1.id }
+          @advisor_student_page.expand_item @appt_1
+        end
+
+        it 'allow the drop-in advisor to unreserve the appointment' do
+          @advisor_student_page.click_unreserve_appt_button @appt_1
+          @advisor_student_page.reserved_for_el(@appt_1).when_not_present 3
+        end
+
+        it 'show Waiting status on the unreserved appointment' do
+          @advisor_student_page.collapse_item @appt_1
+          @advisor_student_page.wait_until(3) { @advisor_student_page.visible_collapsed_appt_data(@appt_1)[:status] == 'WAITING' }
+        end
+
+        it 'allow the drop-in advisor to reserve the appointment' do
+          @advisor_student_page.expand_item @appt_1
+          @advisor_student_page.reserve_appt_for_advisor(@appt_1, @test.drop_in_advisor)
+          @advisor_student_page.reserved_for_el(@appt_1).when_visible 3
+        end
+
+        it 'show Reserved status on the reserved appointment' do
+          @advisor_student_page.collapse_item @appt_1
+          @advisor_student_page.wait_until(3) { @advisor_student_page.visible_collapsed_appt_data(@appt_1)[:status] == 'ASSIGNED' }
+        end
+      end
+    end
+
+    ### DROP-IN APPOINTMENT UPDATES
+
+    describe 'drop-in appointment updating' do
+
+      # Scheduler
+
+      context 'on the intake desk' do
+
+        it 'allows the scheduler to cancel an edit' do
+          @scheduler_intake_desk.view_appt_details @appt_1
+          @scheduler_intake_desk.click_close_details_button
+          @scheduler_intake_desk.modal_student_name_element.when_not_visible 2
+        end
+
+        it 'allows the scheduler to remove reasons' do
+          @scheduler_intake_desk.hit_escape
+          @scheduler_intake_desk.view_appt_details @appt_1
+          @scheduler_intake_desk.remove_reasons(@appt_1, @appt_1.topics)
+          expect(@scheduler_intake_desk.appt_reasons).to be_empty
+          expect(@scheduler_intake_desk.details_update_button_element.enabled?).to be false
+        end
+
+        it 'allows the scheduler to add reasons' do
+          @scheduler_intake_desk.add_reasons(@appt_1, [Topic::READMISSION, Topic::SAP])
+          expect(@scheduler_intake_desk.appt_reasons.sort).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort)
+          expect(@scheduler_intake_desk.details_update_button_element.enabled?).to be true
+        end
+
+        it 'allows the scheduler to edit additional info' do
+          @appt_1.detail = "#{@appt_1.detail} - edited by scheduler"
+          @scheduler_intake_desk.enter_detail @appt_1
+        end
+
+        it 'allows the scheduler to save an edit' do
+          @scheduler_intake_desk.click_details_update_button
+          @scheduler_intake_desk.wait_until(Utils.short_wait) { @scheduler_intake_desk.visible_list_view_appt_data(@appt_1)[:topics] == (@appt_1.topics.map { |t| t.name.downcase }.sort) }
+        end
+      end
+
+      # Drop-in Advisor
+
+      context 'on the waiting list' do
+
+        it 'allows the drop-in advisor to cancel an edit' do
+          @advisor_homepage.load_page
+          @advisor_homepage.view_appt_details @appt_1
+          @advisor_homepage.click_close_details_button
+          @advisor_homepage.modal_student_name_element.when_not_visible 2
+        end
+
+        it 'allows the drop-in advisor to remove reasons' do
+          @advisor_homepage.hit_escape
+          @advisor_homepage.view_appt_details @appt_1
+          @advisor_homepage.remove_reasons(@appt_1, @appt_1.topics)
+          expect(@advisor_homepage.appt_reasons).to be_empty
+          expect(@advisor_homepage.details_update_button_element.enabled?).to be false
+        end
+
+        it 'allows the drop-in advisor to add reasons' do
+          @advisor_homepage.add_reasons(@appt_1, [Topic::RETROACTIVE_ADD, Topic::RETROACTIVE_DROP])
+          expect(@advisor_homepage.appt_reasons).to eql(@appt_1.topics.map { |t| t.name.downcase }.sort)
+          expect(@advisor_homepage.details_update_button_element.enabled?).to be true
+        end
+
+        it 'allows the drop-in advisor to edit additional info' do
+          @appt_1.detail = "#{@appt_1.detail} - edited by advisor"
+          @advisor_homepage.enter_detail @appt_1
+        end
+
+        it 'allows the drop-in advisor to save an edit' do
+          @advisor_homepage.click_details_update_button
+          @advisor_homepage.wait_until(Utils.short_wait) { @advisor_homepage.visible_list_view_appt_data(@appt_1)[:topics] == (@appt_1.topics.map { |t| t.name.downcase }.sort) }
+        end
+      end
+    end
+
+    describe 'appointment search' do
+
+      before(:all) do
+        @advisor_homepage.hit_escape
+        @advisor_homepage.expand_search_options
+        @advisor_homepage.uncheck_include_students_cbx
+        @advisor_homepage.uncheck_include_classes_cbx
+      end
+
+      it 'can find a newly updated appointment by its description' do
+        @advisor_homepage.type_note_appt_string_and_enter @appt_1.detail
+        @search_results_page.wait_for_appt_search_result_rows
+        expect(@search_results_page.appt_link(@appt_1).exists?).to be true
+      end
+    end
+
+    ### DROP-IN APPOINTMENT CHECK-IN
+
+    describe 'drop-in appointment checkin' do
+
+      # Scheduler
+
+      context 'on the intake desk' do
+
+        before(:all) do
+          @scheduler_intake_desk.click_new_appt
+          @scheduler_intake_desk.create_appt @appt_2
+          @appts << @appt_2
+        end
+
+        it 'requires that a scheduler select a drop-in advisor for the appointment' do
+          @scheduler_intake_desk.click_appt_check_in_button @appt_2
+          @scheduler_intake_desk.modal_check_in_button_element.when_present 1
+          expect(@scheduler_intake_desk.modal_check_in_button_element.disabled?).to be true
+          @scheduler_intake_desk.select_check_in_advisor @test.drop_in_advisor
+          expect(@scheduler_intake_desk.modal_check_in_button_element.disabled?).to be false
+        end
+
+        it 'offers available drop-in advisors as advisor for the appointment' do
+          expect(@scheduler_intake_desk.check_in_advisors.sort).to include(@test.drop_in_advisor.uid)
+        end
+
+        it 'can be done from the intake desk view' do
+          @scheduler_intake_desk.select_check_in_advisor @test.drop_in_advisor
+          @scheduler_intake_desk.click_modal_check_in_button
+          @appt_2.status = AppointmentStatus::CHECKED_IN
+          @appt_2.advisor = @test.drop_in_advisor
+        end
+
+        it 'removes the appointment from the intake desk list' do
+          @scheduler_intake_desk.wait_until(Utils.short_wait) { !@scheduler_intake_desk.visible_appt_ids.include? @appt_2.id }
+        end
+      end
+
+      # Drop-in Advisor
+
+      context 'on the waiting list' do
+
+        before(:all) do
+          @advisor_student_page.click_home
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.create_appt @appt_3
+          @appts << @appt_3
+        end
+
+        it 'can be done from the list view' do
+          @advisor_homepage.click_appt_check_in_button @appt_3
+          @advisor_homepage.select_check_in_advisor @test.drop_in_advisor
+          @advisor_homepage.click_modal_check_in_button
+          @appt_3.status = AppointmentStatus::CHECKED_IN
+          @appt_3.advisor = @test.drop_in_advisor
+        end
+
+        it 'updates the status of the appointment on the waiting list' do
+          @advisor_homepage.wait_for_poller do
+            visible_data = @advisor_homepage.visible_list_view_appt_data(@appt_3)
+            visible_data[:checked_in_status] && visible_data[:checked_in_status].include?('CHECKED IN')
+          end
+        end
+
+        it 'updates the scheduler appointment desk view dynamically' do
+          @scheduler_intake_desk.wait_for_poller { (@scheduler_intake_desk.visible_appt_ids & [@appt_3.id]).empty? }
+        end
+
+        it('can be undone') { @advisor_homepage.undo_appt_check_in @appt_3 }
+        it('updates the status of the appointment once undone') { @advisor_homepage.check_in_button(@appt_3).when_visible Utils.short_wait }
+
+        it 'updates the scheduler appointment desk view dynamically once undone' do
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_3.id }
+        end
+      end
+
+      context 'on the student page' do
+
+        context 'when the advisor is not a drop-in advisor' do
+
+          before(:all) do
+            @advisor_homepage.log_out
+            @advisor_homepage.dev_auth @test.advisor
+            @advisor_student_page.load_page @appt_3.student
+          end
+
+          after(:all) { @advisor_student_page.log_out }
+
+          it 'cannot be done' do
+            @advisor_student_page.show_appts
+            @advisor_student_page.expand_item @appt_3
+            expect(@advisor_student_page.check_in_button(@appt_3).exists?).to be false
+          end
+        end
+
+        context 'when the advisor is a drop-in advisor' do
+
+          before(:all) do
+            @advisor_homepage.dev_auth @test.drop_in_advisor
+            @advisor_student_page.click_student_link @appt_3
+            @advisor_student_page.show_appts
+            @advisor_student_page.expand_item @appt_3
+          end
+
+          it 'can be done' do
+            @advisor_student_page.click_check_in_button @appt_3
+            @advisor_student_page.select_check_in_advisor @test.drop_in_advisor
+            @advisor_student_page.click_modal_check_in_button
+            @advisor_student_page.wait_until(Utils.short_wait) { @advisor_student_page.visible_expanded_appt_data(@appt_3)[:check_in_time] }
+            @appt_3.status = AppointmentStatus::CHECKED_IN
+            @appt_3.advisor = @test.drop_in_advisor
+          end
+
+          it 'updates the scheduler appointment desk view dynamically' do
+            @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_appt_ids.include? @appt_3.id }
+          end
+        end
+      end
+    end
+
+    ### DROP-IN APPOINTMENT CANCELLATION
+
+    describe 'drop-in appointment cancellation' do
+
+      before(:all) do
+        @advisor_student_page.click_home
+        [@appt_4, @appt_5, @appt_6].each do |appt|
+          @advisor_homepage.click_new_appt
+          @advisor_homepage.create_appt appt
+          @appts << appt
+        end
+      end
+
+      # Scheduler
+
+      context 'on the appointment intake desk' do
+
+        before(:all) { @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_4.id } }
+
+        it 'requires a reason' do
+          @scheduler_intake_desk.click_appt_dropdown_button @appt_4
+          @scheduler_intake_desk.click_cancel_appt_button @appt_4
+          expect(@scheduler_intake_desk.cancel_confirm_button_element.disabled?).to be true
+          @appt_4.cancel_reason = 'Cancelled by student'
+          @scheduler_intake_desk.select_cancel_reason @appt_4
+          expect(@scheduler_intake_desk.cancel_confirm_button_element.disabled?).to be false
+        end
+
+        it 'accepts additional info' do
+          @appt_4.cancel_detail = "Some 'splainin' to do #{@test.id}"
+          @scheduler_intake_desk.enter_cancel_explanation @appt_4
+        end
+
+        it 'can be done' do
+          @scheduler_intake_desk.click_cancel_confirm_button
+          @appt_4.status = AppointmentStatus::CANCELED
+        end
+
+        it 'removes the appointment from the list' do
+          @scheduler_intake_desk.wait_until(Utils.short_wait) { !@scheduler_intake_desk.visible_appt_ids.include? @appt_4.id }
+        end
+      end
+
+      # Drop-in Advisor
+
+      context 'on the waiting list' do
+
+        it 'requires a reason' do
+          @advisor_homepage.click_appt_dropdown_button @appt_5
+          @advisor_homepage.click_cancel_appt_button @appt_5
+          expect(@advisor_homepage.cancel_confirm_button_element.disabled?).to be true
+          @appt_5.cancel_reason = 'Cancelled by department/advisor'
+          @advisor_homepage.select_cancel_reason @appt_5
+          expect(@advisor_homepage.cancel_confirm_button_element.disabled?).to be false
+        end
+
+        it 'accepts additional info' do
+          @appt_5.cancel_detail = "Even more 'splainin' to do #{@test.id}"
+          @advisor_homepage.enter_cancel_explanation @appt_5
+        end
+
+        it 'can be done' do
+          @advisor_homepage.click_cancel_confirm_button
+          @appt_5.status = AppointmentStatus::CANCELED
+        end
+
+        it 'updates the appointment status on the waiting list' do
+          @advisor_homepage.wait_until(Utils.short_wait) do
+            visible_data = @advisor_homepage.visible_list_view_appt_data @appt_5
+            visible_data[:canceled_status] && visible_data[:canceled_status].include?('CANCELLED')
+          end
+        end
+
+        it 'updates the scheduler appointment desk view dynamically' do
+          @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_appt_ids.include? @appt_4.id }
+        end
+
+        it('can be undone') { @advisor_homepage.undo_appt_cancel @appt_5 }
+        it('updates the status of the appointment once undone') do
+          @advisor_homepage.wait_for_poller { @advisor_homepage.check_in_button(@appt_5).visible? }
+        end
+
+        it 'updates the scheduler appointment desk view dynamically once undone' do
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.visible_appt_ids.include? @appt_5.id }
+        end
+      end
+
+      context 'on the student page' do
+
+        before(:all) do
+          @advisor_homepage.click_student_link @appt_6
+          @advisor_student_page.show_appts
+          @advisor_student_page.expand_item @appt_6
+        end
+
+        it 'requires a reason' do
+          @advisor_student_page.click_appt_dropdown_button @appt_6
+          @advisor_student_page.click_cancel_appt_button @appt_6
+          expect(@advisor_student_page.cancel_confirm_button_element.disabled?).to be true
+          @appt_6.cancel_reason = 'Cancelled by student'
+          @advisor_student_page.select_cancel_reason @appt_6
+          expect(@advisor_student_page.cancel_confirm_button_element.disabled?).to be false
+        end
+
+        it 'accepts additional info' do
+          @appt_6.cancel_detail = "Too much 'splainin' to do #{@test.id}"
+          @advisor_student_page.enter_cancel_explanation @appt_6
+        end
+
+        it 'can be done' do
+          @advisor_student_page.click_cancel_confirm_button
+          @advisor_student_page.wait_until(Utils.short_wait) do
+            visible_data = @advisor_student_page.visible_expanded_appt_data @appt_6
+            visible_data[:cancel_reason] == @appt_6.cancel_reason
+            visible_data[:cancel_addl_info] == @appt_6.cancel_detail
+          end
+          @appt_6.status = AppointmentStatus::CANCELED
+        end
+
+        it 'updates the scheduler appointment desk view dynamically' do
+          @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_appt_ids.include? @appt_6.id }
+        end
+      end
+    end
+
+    describe 'appointment search' do
+
+      before(:all) do
+        @advisor_homepage.hit_escape
+        @advisor_homepage.expand_search_options
+        @advisor_homepage.uncheck_include_students_cbx
+        @advisor_homepage.uncheck_include_classes_cbx
+      end
+
+      it 'can find a cancelled appointment by its cancellation detail' do
+        @advisor_homepage.type_note_appt_string_and_enter @appt_4.cancel_detail
+        @search_results_page.wait_for_appt_search_result_rows
+        expect(@search_results_page.appt_link(@appt_4).exists?).to be true
+      end
+    end
+
+    ### APPOINTMENT SORTING ###
+
+    describe 'intake desk appointments' do
+
+      it 'shows today\'s pending appointments sorted by creation time' do
+        pending_appts = @appts.select { |a| a.status == AppointmentStatus::WAITING }.sort_by(&:created_date).map(&:id)
+        expect(@scheduler_intake_desk.visible_appt_ids).to eql(pending_appts)
+      end
+    end
+
+    describe 'drop-in advisor waiting list' do
+
+      before(:all) do
+        @advisor_student_page.click_home
+        @advisor_homepage.wait_until(Utils.short_wait) { @advisor_homepage.visible_appt_ids.any? }
+      end
+
+      it 'shows all today\'s appointments sorted by creation time, with canceled and checked-in segregated at the bottom' do
+        non_pending_appts = @appts.select { |a| [AppointmentStatus::CANCELED, AppointmentStatus::CHECKED_IN].include? a.status }.sort_by(&:created_date)
+        pending_appts = (@appts - non_pending_appts).sort_by(&:created_date)
+        @advisor_homepage.wait_for_poller { @advisor_homepage.visible_appt_ids == ((pending_appts + non_pending_appts).map(&:id)) }
+      end
+    end
+
+    describe 'student appointment timeline' do
+
+      before(:all) do
+        student = @students.last
+        checked_in_appt = Appointment.new(student: student, topics: [Topic::COURSE_ADD], detail: "Checked-in #{@test.id}")
+        canceled_appt = Appointment.new(student: student, topics: [Topic::COURSE_ADD], detail: "Canceled #{@test.id}", cancel_reason: 'Cancelled by student', cancel_detail: 'Foo')
+        pending_appt = Appointment.new(student: student, topics: [Topic::COURSE_ADD], detail: "Pending #{@test.id}")
+
+        @advisor_homepage.click_new_appt
+        @advisor_homepage.create_appt checked_in_appt
+        @advisor_homepage.click_appt_check_in_button checked_in_appt
+        @advisor_homepage.select_check_in_advisor @test.drop_in_advisor
+        @advisor_homepage.click_modal_check_in_button
+        @advisor_homepage.wait_for_poller do
+          visible_data = @advisor_homepage.visible_list_view_appt_data checked_in_appt
+          visible_data[:checked_in_status] && visible_data[:checked_in_status].include?('CHECKED IN')
+        end
+
+        @advisor_homepage.click_new_appt
+        @advisor_homepage.create_appt canceled_appt
+        @advisor_homepage.click_appt_dropdown_button canceled_appt
+        @advisor_homepage.click_cancel_appt_button canceled_appt
+        @advisor_homepage.select_cancel_reason canceled_appt
+        @advisor_homepage.enter_cancel_explanation canceled_appt
+        @advisor_homepage.click_cancel_confirm_button
+        @advisor_homepage.wait_for_poller do
+          visible_data = @advisor_homepage.visible_list_view_appt_data canceled_appt
+          visible_data[:canceled_status] && visible_data[:canceled_status].include?('CANCELLED')
+        end
+
+        @advisor_homepage.click_new_appt
+        @advisor_homepage.create_appt pending_appt
+
+        @advisor_homepage.click_student_link pending_appt
         @advisor_student_page.show_appts
-        @advisor_student_page.expand_item @appt_11
-        expect(@advisor_student_page.visible_expanded_appt_data(@appt_11)[:reserve_advisor]).to be_nil
-        expect(@advisor_student_page.check_in_button(@appt_11).exists?).to be false
+        boa_appts = BOACUtils.get_student_appts(student, @test.students).reject &:deleted_date
+        sis_appts = NessieUtils.get_sis_appts student
+        @student_appts = boa_appts + sis_appts
       end
 
-      it 'allows the user to enable its drop-in advising role' do
-        @advisor_flight_deck.click_settings_link
-        @advisor_flight_deck.enable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
-        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.drop_in_advisor_uids.include? @test.drop_in_advisor.uid }
+      it 'shows all non-deleted appointments sorted by creation time' do
+        expect(@advisor_student_page.visible_collapsed_item_ids('appointment')).to eql(@student_appts.sort_by(&:created_date).reverse.map(&:id).uniq)
       end
+    end
 
-      it 'restores the user\'s access to the waiting list' do
+    ### ASSIGNMENTS REMOVED WHEN ADVISOR GOES OFF-DUTY ###
+
+    describe 'drop-in advisor' do
+
+      before(:all) do
         @advisor_homepage.load_page
-        @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
+        @advisor_homepage.click_new_appt
+        @advisor_homepage.create_appt @appt_10
+        @advisor_homepage.reserved_for_el(@appt_10).when_visible 2
+      end
+
+      it 'is warned that going off-duty will remove appointment assignments' do
+        @advisor_homepage.click_self_availability_button
+        @advisor_homepage.off_duty_confirm_button_element.when_visible 2
+      end
+
+      it 'can cancel going off-duty and keep appointment assignments' do
+        @advisor_homepage.click_off_duty_cancel
+        @advisor_homepage.reserved_for_el(@appt_10).when_visible 2
+      end
+
+      it 'loses appointment assignments when going off-duty' do
+        @advisor_homepage.click_self_availability_button
+        @advisor_homepage.click_off_duty_confirm
+        @advisor_homepage.wait_for_poller { !@advisor_homepage.reserved_for_el(@appt_10).exists? }
+      end
+
+      it 'can assign an appointment to itself while off-duty' do
+        @advisor_homepage.reserve_appt_for_advisor(@appt_10, @test.drop_in_advisor)
+        @advisor_homepage.wait_for_poller { @advisor_homepage.reserved_for_el(@appt_10).visible? }
+        expect(@advisor_homepage.reserved_for_el(@appt_10).text).to eql('Assigned to you')
+      end
+    end
+
+    describe 'scheduler' do
+
+      before(:all) { @scheduler_intake_desk.set_advisor_available @test.drop_in_advisor }
+
+      it 'is warned that taking an advisor off-duty will remove appointment assignments' do
+        @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.reserved_for_el(@appt_10).exists? }
+        @scheduler_intake_desk.click_advisor_availability_toggle @test.drop_in_advisor
+        @scheduler_intake_desk.off_duty_confirm_button_element.when_visible 2
+      end
+
+      it 'can cancel taking an advisor off-duty and keep appointment assignments' do
+        @scheduler_intake_desk.click_off_duty_cancel
+        expect(@scheduler_intake_desk.reserved_for_el(@appt_10).exists?).to be true
+      end
+
+      it 'loses appointment assignments when taking an advisor off-duty' do
+        @scheduler_intake_desk.click_advisor_availability_toggle @test.drop_in_advisor
+        @scheduler_intake_desk.click_off_duty_confirm
+        @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.reserved_for_el(@appt_10).exists? }
+      end
+
+      ### SCHEDULER - LOGGING RESOLVED ISSUE ###
+
+      context 'when logging a resolved issue' do
+
+        before(:all) { @resolved_issue = Appointment.new(student: @students[11], topics: [Topic::COURSE_ADD], detail: "A resolved issue #{@test.id}") }
+
+        it 'creates a checked-in appointment with itself' do
+          @scheduler_intake_desk.log_resolved_issue(@resolved_issue, @test.drop_in_scheduler)
+          expect(@resolved_issue.id).not_to be_nil
+        end
+
+        it 'updates the waiting list with the checked-in appointment' do
+          @advisor_homepage.wait_for_poller do
+            visible_data = @advisor_homepage.visible_list_view_appt_data(@resolved_issue)
+            visible_data[:checked_in_status] && visible_data[:checked_in_status].include?('CHECKED IN')
+          end
+        end
+
+        it 'updates the student page with the checked-in appointment' do
+          @advisor_student_page.load_page @resolved_issue.student
+          @advisor_student_page.show_appts
+          @advisor_student_page.expand_item @resolved_issue
+          visible_data = @advisor_student_page.visible_expanded_appt_data @resolved_issue
+          expect(visible_data[:advisor_role]).to include('Intake Desk')
+        end
+      end
+    end
+
+    ### SETTINGS PAGE - DROP-IN STATUS ###
+
+    describe 'settings page' do
+
+      before(:all) do
+        @advisor_homepage.load_page
+        @advisor_homepage.click_new_appt
+        @advisor_homepage.create_appt @appt_11
+      end
+
+      context 'when the user is a scheduler' do
+
+        it 'is offered in the header' do
+          @scheduler_intake_desk.click_header_dropdown
+          expect(@scheduler_intake_desk.settings_link?).to be true
+        end
+
+        it 'cannot be reached in its admin flavor' do
+          @scheduler_flight_deck.load_page
+          @scheduler_flight_deck.wait_for_title 'Not Found'
+        end
+      end
+
+      context 'when the user is a drop-in advisor' do
+
+        before(:all) do
+          @advisor_homepage.click_settings_link
+          @scheduler_intake_desk.load_page @test.dept
+        end
+
+        it 'allows the user to remove its drop-in advising role' do
+          @advisor_flight_deck.disable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
+          @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.drop_in_advisor_uids.include?(@test.drop_in_advisor.uid) }
+        end
+
+        it 'removes the user\'s access to the waiting list' do
+          @advisor_homepage.load_page
+          sleep 1
+          expect(@advisor_homepage.new_appt_button?).to be false
+        end
+
+        it 'removes the user\'s appointment assignments on the waiting list when the drop-in advising role is removed' do
+          @scheduler_intake_desk.wait_for_poller { !@scheduler_intake_desk.visible_list_view_appt_data(@appt_11)[:reserved_by] }
+        end
+
+        it 'removes the user\'s appointment assignments on the student page when the drop-in advising role is removed' do
+          @advisor_student_page.load_page @appt_11.student
+          @advisor_student_page.show_appts
+          @advisor_student_page.expand_item @appt_11
+          expect(@advisor_student_page.visible_expanded_appt_data(@appt_11)[:reserve_advisor]).to be_nil
+          expect(@advisor_student_page.check_in_button(@appt_11).exists?).to be false
+        end
+
+        it 'allows the user to enable its drop-in advising role' do
+          @advisor_flight_deck.click_settings_link
+          @advisor_flight_deck.enable_drop_in_advising_role @test.drop_in_advisor.dept_memberships.first
+          @scheduler_intake_desk.wait_for_poller { @scheduler_intake_desk.drop_in_advisor_uids.include? @test.drop_in_advisor.uid }
+        end
+
+        it 'restores the user\'s access to the waiting list' do
+          @advisor_homepage.load_page
+          @advisor_homepage.new_appt_button_element.when_visible Utils.short_wait
+        end
       end
     end
   end

--- a/spec/boac/boac_assignments_data_spec.rb
+++ b/spec/boac/boac_assignments_data_spec.rb
@@ -1,215 +1,218 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC assignment analytics' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOAC assignment analytics' do
 
-  begin
+    include Logging
 
-    if Utils.headless? && (BOACUtils.nessie_assignments || BOACUtils.nessie_scores)
+    begin
 
-      logger.warn 'This script requires admin Canvas access and cannot be run headless. Terminating.'
+      if Utils.headless? && (BOACUtils.nessie_assignments || BOACUtils.nessie_scores)
 
-    else
+        logger.warn 'This script requires admin Canvas access and cannot be run headless. Terminating.'
 
-      test = BOACTestConfig.new
-      test.assignments
-      testable_students = []
+      else
 
-      user_analytics_data_heading = %w(UID Term SiteCode SiteId
+        test = BOACTestConfig.new
+        test.assignments
+        testable_students = []
+
+        user_analytics_data_heading = %w(UID Term SiteCode SiteId
                                         AssignMin AssignMax AssignUser AssignPerc AssignRound
                                         GradesMin GradesMax GradesUser GradesPerc GradesRound)
-      user_course_analytics_data = Utils.create_test_output_csv('boac-canvas-courses.csv', user_analytics_data_heading)
+        user_course_analytics_data = Utils.create_test_output_csv('boac-canvas-courses.csv', user_analytics_data_heading)
 
-      user_course_assigns_heading = %w(UID CanvasID Site AssignmentID URL DueDate Submission SubmitDate Type OnTime)
-      user_course_assigns = Utils.create_test_output_csv('boac-assignments.csv', user_course_assigns_heading)
+        user_course_assigns_heading = %w(UID CanvasID Site AssignmentID URL DueDate Submission SubmitDate Type OnTime)
+        user_course_assigns = Utils.create_test_output_csv('boac-assignments.csv', user_course_assigns_heading)
 
-      @driver = Utils.launch_browser test.chrome_profile
-      @cal_net = Page::CalNetPage.new @driver
-      @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
-      @canvas_discussions_page = Page::CanvasAnnounceDiscussPage.new @driver
-      @canvas_grades_page = Page::CanvasGradesPage.new @driver
-      @canvas_users_page = Page::CanvasPage.new @driver
-      @e_grades_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
-      @boac_homepage = BOACHomePage.new @driver
-      @boac_student_page = BOACStudentPage.new @driver
+        @driver = Utils.launch_browser test.chrome_profile
+        @cal_net = Page::CalNetPage.new @driver
+        @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
+        @canvas_discussions_page = Page::CanvasAnnounceDiscussPage.new @driver
+        @canvas_grades_page = Page::CanvasGradesPage.new @driver
+        @canvas_users_page = Page::CanvasPage.new @driver
+        @e_grades_page = Page::JunctionPages::CanvasEGradesExportPage.new @driver
+        @boac_homepage = BOACHomePage.new @driver
+        @boac_student_page = BOACStudentPage.new @driver
 
-      (BOACUtils.nessie_assignments || BOACUtils.nessie_scores) ?
-          @boac_homepage.log_in(Utils.super_admin_username, Utils.super_admin_password, @cal_net) :
-          @boac_homepage.dev_auth
+        (BOACUtils.nessie_assignments || BOACUtils.nessie_scores) ?
+            @boac_homepage.log_in(Utils.super_admin_username, Utils.super_admin_password, @cal_net) :
+            @boac_homepage.dev_auth
 
-      test.test_students.each do |student|
+        test.test_students.each do |student|
 
-        boac_api_page = BOACApiStudentPage.new @driver
-        boac_api_page.get_data(@driver, student)
-        boac_api_page.set_canvas_id student
-        term = boac_api_page.terms.find { |t| boac_api_page.term_name(t) == test.term }
+          boac_api_page = BOACApiStudentPage.new @driver
+          boac_api_page.get_data(@driver, student)
+          boac_api_page.set_canvas_id student
+          term = boac_api_page.terms.find { |t| boac_api_page.term_name(t) == test.term }
 
-        if term
-          begin
+          if term
+            begin
 
-            # Collect all the Canvas sites in the term, matched and unmatched
-            term_sites = []
-            term_sites << boac_api_page.unmatched_sites(term).map { |s| {:data => s} }
+              # Collect all the Canvas sites in the term, matched and unmatched
+              term_sites = []
+              term_sites << boac_api_page.unmatched_sites(term).map { |s| {:data => s} }
 
-            courses = boac_api_page.courses term
-            if courses.any?
-              courses.each do |course|
-                course_sites = boac_api_page.course_sites course
-                term_sites << course_sites.map { |s| {:data => s, :index => course_sites.index(s)} }
+              courses = boac_api_page.courses term
+              if courses.any?
+                courses.each do |course|
+                  course_sites = boac_api_page.course_sites course
+                  term_sites << course_sites.map { |s| {:data => s, :index => course_sites.index(s)} }
+                end
               end
-            end
 
-            term_sites.flatten!
-            testable_students << student if term_sites.any?
+              term_sites.flatten!
+              testable_students << student if term_sites.any?
 
-            term_sites.each do |site|
-              begin
+              term_sites.each do |site|
+                begin
 
-                site_data = site[:data]
-                site_code = boac_api_page.site_metadata(site_data)[:code]
-                site_id = boac_api_page.site_metadata(site_data)[:site_id]
-                course = Course.new({:site_id => site_id})
-                test_case = "Canvas ID #{student.canvas_id} UID #{student.uid} term #{test.term} course site ID #{site_id}, #{site_code}"
+                  site_data = site[:data]
+                  site_code = boac_api_page.site_metadata(site_data)[:code]
+                  site_id = boac_api_page.site_metadata(site_data)[:site_id]
+                  course = Course.new({:site_id => site_id})
+                  test_case = "Canvas ID #{student.canvas_id} UID #{student.uid} term #{test.term} course site ID #{site_id}, #{site_code}"
 
-                logger.info "Checking site #{site_id}, #{site_code}"
+                  logger.info "Checking site #{site_id}, #{site_code}"
 
-                # Gather the analytics data obtained from Nessie
-                boac_api_assigns_submitted = boac_api_page.nessie_assigns_submitted site_data
-                boac_api_grades = boac_api_page.nessie_grades site_data
+                  # Gather the analytics data obtained from Nessie
+                  boac_api_assigns_submitted = boac_api_page.nessie_assigns_submitted site_data
+                  boac_api_grades = boac_api_page.nessie_grades site_data
 
-                if BOACUtils.nessie_assignments
+                  if BOACUtils.nessie_assignments
 
-                  logger.warn "Checking assignment submissions for #{test_case}"
+                    logger.warn "Checking assignment submissions for #{test_case}"
 
-                  @canvas_assignments_page.masquerade_as student
-                  ui_assignments = @canvas_assignments_page.get_student_view_assignments(@driver, course, student, @canvas_discussions_page)
-                  nessie_assignments = NessieUtils.get_assignments(student, course)
+                    @canvas_assignments_page.masquerade_as student
+                    ui_assignments = @canvas_assignments_page.get_student_view_assignments(@driver, course, student, @canvas_discussions_page)
+                    nessie_assignments = NessieUtils.get_assignments(student, course)
 
-                  if ui_assignments.any?
-                    # Compare the individual assignment data in Nessie with the same assignments in the Canvas UI
-                    it("has the right assignments for #{test_case}") { expect(ui_assignments.map(&:id).sort).to eql(nessie_assignments.map(&:id).sort) }
-                    ui_assignments.each do |ui|
-                      Utils.add_csv_row(user_course_assigns, [student.uid, student.canvas_id, site_id, ui.id, ui.url, ui.due_date, ui.submitted, ui.submission_date, ui.type, ui.on_time])
-                      nessie_assign = nessie_assignments.find { |n| n.id == ui.id }
-                      if nessie_assign
-                        it("has the right assignment submission status for assignment ID #{ui.id} #{test_case}") { expect(nessie_assign.submitted).to eql(ui.submitted) }
+                    if ui_assignments.any?
+                      # Compare the individual assignment data in Nessie with the same assignments in the Canvas UI
+                      it("has the right assignments for #{test_case}") { expect(ui_assignments.map(&:id).sort).to eql(nessie_assignments.map(&:id).sort) }
+                      ui_assignments.each do |ui|
+                        Utils.add_csv_row(user_course_assigns, [student.uid, student.canvas_id, site_id, ui.id, ui.url, ui.due_date, ui.submitted, ui.submission_date, ui.type, ui.on_time])
+                        nessie_assign = nessie_assignments.find { |n| n.id == ui.id }
+                        if nessie_assign
+                          it("has the right assignment submission status for assignment ID #{ui.id} #{test_case}") { expect(nessie_assign.submitted).to eql(ui.submitted) }
+                        end
                       end
+
+                      # Compare the total submitted assignment count in the BOAC API with the same assignment count in the Canvas UI
+                      submitted = ui_assignments.select &:submitted
+                      it("has the right Nessie assignments-submitted count for #{test_case}") { expect(boac_api_assigns_submitted[:score].to_i).to eql(submitted.length) }
+                    else
+                      logger.warn 'Either there are no assignments, or they are from a past semester and have been hidden in the UI.'
                     end
 
-                    # Compare the total submitted assignment count in the BOAC API with the same assignment count in the Canvas UI
-                    submitted = ui_assignments.select &:submitted
-                    it("has the right Nessie assignments-submitted count for #{test_case}") { expect(boac_api_assigns_submitted[:score].to_i).to eql(submitted.length) }
                   else
-                    logger.warn 'Either there are no assignments, or they are from a past semester and have been hidden in the UI.'
+                    logger.warn 'Skipping comparison of assignment submissions in Nessie versus Canvas UI'
                   end
 
-                else
-                  logger.warn 'Skipping comparison of assignment submissions in Nessie versus Canvas UI'
-                end
+                  if BOACUtils.nessie_scores
 
-                if BOACUtils.nessie_scores
+                    if boac_api_grades[:score].empty?
 
-                  if boac_api_grades[:score].empty?
+                      logger.warn "Skipping current score tests for #{test_case}"
 
-                    logger.warn "Skipping current score tests for #{test_case}"
-
-                  else
-
-                    logger.warn "Checking current score for #{test_case}"
-
-                    @canvas_grades_page.stop_masquerading if @canvas_grades_page.stop_masquerading_link?
-                    @canvas_grades_page.load_gradebook course
-                    scores = @canvas_grades_page.export_grades course
-
-                    gradebook_min = scores.first
-                    logger.debug "Gradebook minimum current score: #{gradebook_min}"
-                    gradebook_min = gradebook_min[:score]
-                    it("has the same Canvas Gradebook and Nessie grades minimum for #{test_case}") { expect((gradebook_min.to_i - 1)..(gradebook_min.to_i + 1)).to include(boac_api_grades[:min].to_i) }
-
-                    gradebook_max = scores.last
-                    logger.debug "Gradebook maximum current score: #{gradebook_max}"
-                    gradebook_max = gradebook_max[:score]
-                    it("has the same Canvas Gradebook and Nessie grades maximum for #{test_case}") { expect((gradebook_max.to_i - 1)..(gradebook_max.to_i + 1)).to include(boac_api_grades[:max].to_i) }
-
-                    gradebook_user_score = (scores.find { |s| s[:uid] == student.uid })[:score]
-                    it("has the same Canvas Gradebook and Nessie grades user score for #{test_case}") { expect((gradebook_user_score.to_i - 1)..(gradebook_user_score.to_i + 1)).to include(boac_api_grades[:score].to_i) }
-                  end
-
-                else
-                  logger.warn 'Skipping comparison of current scores in Nessie versus Canvas UI'
-                end
-
-                if BOACUtils.tooltips
-
-                  @boac_student_page.load_page student
-                  @boac_student_page.click_view_previous_semesters if test.term != BOACUtils.term
-
-                  # Find the site in the UI differently if it's matched versus unmatched
-                  site_code ?
-                      (analytics_xpath = @boac_student_page.course_site_xpath(test.term, site_code, site[:index])) :
-                      (analytics_xpath = @boac_student_page.unmatched_site_xpath(test.term, site_code))
-
-                  # TODO - check Assignments Submitted once boxplots return
-                  [boac_api_grades].each do |analytics|
-
-                    if analytics[:perc_round].nil?
-                      no_data = @boac_student_page.no_data?(analytics_xpath, analytics[:type])
-                      it("shows no '#{analytics[:type]}' data for #{test_case}") { expect(no_data).to be true }
                     else
-                      visible_analytics = case analytics[:type]
+
+                      logger.warn "Checking current score for #{test_case}"
+
+                      @canvas_grades_page.stop_masquerading if @canvas_grades_page.stop_masquerading_link?
+                      @canvas_grades_page.load_gradebook course
+                      scores = @canvas_grades_page.export_grades course
+
+                      gradebook_min = scores.first
+                      logger.debug "Gradebook minimum current score: #{gradebook_min}"
+                      gradebook_min = gradebook_min[:score]
+                      it("has the same Canvas Gradebook and Nessie grades minimum for #{test_case}") { expect((gradebook_min.to_i - 1)..(gradebook_min.to_i + 1)).to include(boac_api_grades[:min].to_i) }
+
+                      gradebook_max = scores.last
+                      logger.debug "Gradebook maximum current score: #{gradebook_max}"
+                      gradebook_max = gradebook_max[:score]
+                      it("has the same Canvas Gradebook and Nessie grades maximum for #{test_case}") { expect((gradebook_max.to_i - 1)..(gradebook_max.to_i + 1)).to include(boac_api_grades[:max].to_i) }
+
+                      gradebook_user_score = (scores.find { |s| s[:uid] == student.uid })[:score]
+                      it("has the same Canvas Gradebook and Nessie grades user score for #{test_case}") { expect((gradebook_user_score.to_i - 1)..(gradebook_user_score.to_i + 1)).to include(boac_api_grades[:score].to_i) }
+                    end
+
+                  else
+                    logger.warn 'Skipping comparison of current scores in Nessie versus Canvas UI'
+                  end
+
+                  if BOACUtils.tooltips
+
+                    @boac_student_page.load_page student
+                    @boac_student_page.click_view_previous_semesters if test.term != BOACUtils.term
+
+                    # Find the site in the UI differently if it's matched versus unmatched
+                    site_code ?
+                        (analytics_xpath = @boac_student_page.course_site_xpath(test.term, site_code, site[:index])) :
+                        (analytics_xpath = @boac_student_page.unmatched_site_xpath(test.term, site_code))
+
+                    # TODO - check Assignments Submitted once boxplots return
+                    [boac_api_grades].each do |analytics|
+
+                      if analytics[:perc_round].nil?
+                        no_data = @boac_student_page.no_data?(analytics_xpath, analytics[:type])
+                        it("shows no '#{analytics[:type]}' data for #{test_case}") { expect(no_data).to be true }
+                      else
+                        visible_analytics = case analytics[:type]
                                             when 'Assignments Submitted'
                                               @boac_student_page.visible_assignment_analytics(@driver, analytics_xpath, analytics)
                                             when 'Assignment Grades'
                                               @boac_student_page.visible_grades_analytics(@driver, analytics_xpath, analytics)
                                             else
                                               logger.error "Unsupported analytics type '#{analytics[:type]}'"
-                                          end
+                                            end
 
-                      it("shows the '#{analytics[:type]}' user percentile for #{test_case}") { expect(visible_analytics[:perc_round]).to eql(analytics[:perc_round]) }
-                      it("shows the '#{analytics[:type]}' user score for #{test_case}") { expect(visible_analytics[:score]).to eql(analytics[:score]) }
-                      it("shows the '#{analytics[:type]}' course maximum for #{test_case}") { expect(visible_analytics[:max]).to eql(analytics[:max]) }
+                        it("shows the '#{analytics[:type]}' user percentile for #{test_case}") { expect(visible_analytics[:perc_round]).to eql(analytics[:perc_round]) }
+                        it("shows the '#{analytics[:type]}' user score for #{test_case}") { expect(visible_analytics[:score]).to eql(analytics[:score]) }
+                        it("shows the '#{analytics[:type]}' course maximum for #{test_case}") { expect(visible_analytics[:max]).to eql(analytics[:max]) }
 
-                      if analytics[:graphable]
-                        it("shows the '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to eql(analytics[:perc_70]) }
-                        it("shows the '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to eql(analytics[:perc_50]) }
-                        it("shows the '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to eql(analytics[:perc_30]) }
-                        it("shows the '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to eql(analytics[:minimum]) }
-                      else
-                        it("shows no '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to be_nil }
-                        it("shows no '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to be_nil }
-                        it("shows no '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to be_nil }
-                        it("shows no '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to be_nil }
+                        if analytics[:graphable]
+                          it("shows the '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to eql(analytics[:perc_70]) }
+                          it("shows the '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to eql(analytics[:perc_50]) }
+                          it("shows the '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to eql(analytics[:perc_30]) }
+                          it("shows the '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to eql(analytics[:minimum]) }
+                        else
+                          it("shows no '#{analytics[:type]}' course 70th percentile for #{test_case}") { expect(visible_analytics[:perc_70]).to be_nil }
+                          it("shows no '#{analytics[:type]}' course 50th percentile for #{test_case}") { expect(visible_analytics[:perc_50]).to be_nil }
+                          it("shows no '#{analytics[:type]}' course 30th percentile for #{test_case}") { expect(visible_analytics[:perc_30]).to be_nil }
+                          it("shows no '#{analytics[:type]}' course minimum for #{test_case}") { expect(visible_analytics[:minimum]).to be_nil }
+                        end
                       end
                     end
                   end
-                end
 
-              rescue => e
-                Utils.log_error e
-                it("encountered an error with UID #{student.uid} #{test_case}") { fail }
-              ensure
-                row = [student.uid, test.term, site_code, site_id, boac_api_assigns_submitted[:min], boac_api_assigns_submitted[:max],
-                       boac_api_assigns_submitted[:score], boac_api_assigns_submitted[:perc], boac_api_assigns_submitted[:perc_round],
-                       boac_api_grades[:min], boac_api_grades[:max], boac_api_grades[:score], boac_api_grades[:perc], boac_api_grades[:perc_round]
-                ]
-                Utils.add_csv_row(user_course_analytics_data, row)
+                rescue => e
+                  Utils.log_error e
+                  it("encountered an error with UID #{student.uid} #{test_case}") { fail }
+                ensure
+                  row = [student.uid, test.term, site_code, site_id, boac_api_assigns_submitted[:min], boac_api_assigns_submitted[:max],
+                         boac_api_assigns_submitted[:score], boac_api_assigns_submitted[:perc], boac_api_assigns_submitted[:perc_round],
+                         boac_api_grades[:min], boac_api_grades[:max], boac_api_grades[:score], boac_api_grades[:perc], boac_api_grades[:perc_round]
+                  ]
+                  Utils.add_csv_row(user_course_analytics_data, row)
+                end
               end
+            rescue => e
+              Utils.log_error e
+              it("encountered an error with UID #{student.uid} term #{test.term}") { fail }
             end
-          rescue => e
-            Utils.log_error e
-            it("encountered an error with UID #{student.uid} term #{test.term}") { fail }
           end
         end
+
+        it('can be tested for at least one student') { expect(testable_students).not_to be_empty }
+
       end
-
-      it('can be tested for at least one student') { expect(testable_students).not_to be_empty }
-
+    rescue => e
+      Utils.log_error e
+      it('encountered an unexpected error') { fail }
+    ensure
+      Utils.quit_browser @driver
     end
-  rescue => e
-    Utils.log_error e
-    it('encountered an unexpected error') { fail }
-  ensure
-    Utils.quit_browser @driver
   end
 end

--- a/spec/boac/boac_authorized_user_spec.rb
+++ b/spec/boac/boac_authorized_user_spec.rb
@@ -1,85 +1,90 @@
 require_relative '../../util/spec_helper'
 
-if Utils.headless?
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  logger.warn 'This script requires CAS authentication and cannot be run in headless mode. Terminating.'
+  include Logging
 
-else
+  if Utils.headless?
 
-  describe 'BOAC' do
+    logger.warn 'This script requires CAS authentication and cannot be run in headless mode. Terminating.'
 
-    before(:all) do
-      @auth_user = BOACUser.new({:uid => Utils.super_admin_uid, :username => Utils.super_admin_username})
-      @initial_logins = BOACUtils.get_user_login_count @auth_user
+  else
 
-      @driver = Utils.launch_browser
-      @home_page = BOACHomePage.new @driver
-      @cal_net_page = Page::CalNetPage.new @driver
-    end
+    describe 'BOAC' do
 
-    after(:all) { Utils.quit_browser @driver }
+      before(:all) do
+        @auth_user = BOACUser.new({:uid => Utils.super_admin_uid, :username => Utils.super_admin_username})
+        @initial_logins = BOACUtils.get_user_login_count @auth_user
 
-    context 'when an authorized user logs in' do
-
-      before { @home_page.log_in(@auth_user.username, Utils.super_admin_password, @cal_net_page) }
-      after { @home_page.log_out }
-
-      it('records the login') { expect(BOACUtils.get_user_login_count @auth_user).to eql(@initial_logins + 1) }
-    end
-
-    context 'when an authorized user is deleted' do
-
-      before { BOACUtils.soft_delete_auth_user @auth_user }
-
-      it 'disallows login' do
-        @home_page.load_page
-        @home_page.click_sign_in_button
-        @cal_net_page.log_in(@auth_user.username, Utils.super_admin_password)
-        @home_page.not_auth_msg_element.when_visible Utils.short_wait
+        @driver = Utils.launch_browser
+        @home_page = BOACHomePage.new @driver
+        @cal_net_page = Page::CalNetPage.new @driver
       end
-    end
 
-    context 'when an authorized user is restored' do
+      after(:all) { Utils.quit_browser @driver }
 
-      before { BOACUtils.restore_auth_user @auth_user }
-      after { @home_page.log_out }
+      context 'when an authorized user logs in' do
 
-      it 'allows login' do
-        @home_page.click_sign_in_button
-        @home_page.wait_for_title 'Home'
+        before { @home_page.log_in(@auth_user.username, Utils.super_admin_password, @cal_net_page) }
+        after { @home_page.log_out }
+
+        it('records the login') { expect(BOACUtils.get_user_login_count @auth_user).to eql(@initial_logins + 1) }
       end
-    end
 
-    context 'when someone is not an authorized user' do
+      context 'when an authorized user is deleted' do
 
-      before { BOACUtils.hard_delete_auth_user @auth_user }
+        before { BOACUtils.soft_delete_auth_user @auth_user }
 
-      it 'disallows login' do
-        @home_page.load_page
-        @home_page.click_sign_in_button
-        @cal_net_page.log_in(@auth_user.username, Utils.super_admin_password)
-        @home_page.not_auth_msg_element.when_visible Utils.short_wait
+        it 'disallows login' do
+          @home_page.load_page
+          @home_page.click_sign_in_button
+          @cal_net_page.log_in(@auth_user.username, Utils.super_admin_password)
+          @home_page.not_auth_msg_element.when_visible Utils.short_wait
+        end
       end
-    end
 
-    context 'when someone is an authorized user' do
+      context 'when an authorized user is restored' do
 
-      before { BOACUtils.create_admin_auth_user @auth_user }
+        before { BOACUtils.restore_auth_user @auth_user }
+        after { @home_page.log_out }
 
-      it 'allows login' do
-        @home_page.click_sign_in_button
-        @home_page.wait_for_title 'Home'
+        it 'allows login' do
+          @home_page.click_sign_in_button
+          @home_page.wait_for_title 'Home'
+        end
       end
-    end
 
-    context 'when an authorized user\'s session is expired' do
+      context 'when someone is not an authorized user' do
 
-      before { @driver.manage.delete_all_cookies }
+        before { BOACUtils.hard_delete_auth_user @auth_user }
 
-      it 'forces login' do
-        @home_page.enter_search_string 'foo'
-        @home_page.hit_enter
-        @home_page.sign_in_element.when_visible Utils.short_wait
+        it 'disallows login' do
+          @home_page.load_page
+          @home_page.click_sign_in_button
+          @cal_net_page.log_in(@auth_user.username, Utils.super_admin_password)
+          @home_page.not_auth_msg_element.when_visible Utils.short_wait
+        end
+      end
+
+      context 'when someone is an authorized user' do
+
+        before { BOACUtils.create_admin_auth_user @auth_user }
+
+        it 'allows login' do
+          @home_page.click_sign_in_button
+          @home_page.wait_for_title 'Home'
+        end
+      end
+
+      context 'when an authorized user\'s session is expired' do
+
+        before { @driver.manage.delete_all_cookies }
+
+        it 'forces login' do
+          @home_page.enter_search_string 'foo'
+          @home_page.hit_enter
+          @home_page.sign_in_element.when_visible Utils.short_wait
+        end
       end
     end
   end

--- a/spec/boac/boac_class_pages_spec.rb
+++ b/spec/boac/boac_class_pages_spec.rb
@@ -1,313 +1,316 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    test = BOACTestConfig.new
-    test.class_pages
-    pages_tested = []
+    begin
 
-    courses_csv = Utils.create_test_output_csv('boac-class-page-courses.csv', %w(Term Course Title Format Units))
-    meetings_csv =Utils.create_test_output_csv('boac-class-page-meetings.csv', %w(Term Course Instructors Days Time Location))
-    students_sis_csv = Utils.create_test_output_csv('boac-class-page-student-sis.csv', %w(Term Course SID Level Majors Sports MidPoint Basis Grade))
-    students_canvas_csv = Utils.create_test_output_csv('boac-class-page-student-canvas.csv', %w(Term Course SID SiteId SiteCode SubmittedUser SubmittedMax ScoreUser ScoreMax))
+      test = BOACTestConfig.new
+      test.class_pages
+      pages_tested = []
 
-    @driver = Utils.launch_browser test.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @filtered_cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
-    @student_page = BOACStudentPage.new @driver
-    @class_page = BOACClassListViewPage.new @driver
-    @search_page = BOACSearchResultsPage.new @driver
+      courses_csv = Utils.create_test_output_csv('boac-class-page-courses.csv', %w(Term Course Title Format Units))
+      meetings_csv = Utils.create_test_output_csv('boac-class-page-meetings.csv', %w(Term Course Instructors Days Time Location))
+      students_sis_csv = Utils.create_test_output_csv('boac-class-page-student-sis.csv', %w(Term Course SID Level Majors Sports MidPoint Basis Grade))
+      students_canvas_csv = Utils.create_test_output_csv('boac-class-page-student-canvas.csv', %w(Term Course SID SiteId SiteCode SubmittedUser SubmittedMax ScoreUser ScoreMax))
 
-    @homepage.dev_auth test.advisor
-    test.test_students.each do |student|
-      begin
+      @driver = Utils.launch_browser test.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @filtered_cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
+      @student_page = BOACStudentPage.new @driver
+      @class_page = BOACClassListViewPage.new @driver
+      @search_page = BOACSearchResultsPage.new @driver
 
-        api_user_page = BOACApiStudentPage.new @driver
-        api_user_page.get_data(@driver, student)
+      @homepage.dev_auth test.advisor
+      test.test_students.each do |student|
+        begin
 
-        terms = api_user_page.terms
-        if terms.any?
-          terms.each do |term|
-            begin
+          api_user_page = BOACApiStudentPage.new @driver
+          api_user_page.get_data(@driver, student)
 
-              term_name = api_user_page.term_name term
-              term_id = api_user_page.term_id term
-              logger.info "Checking term #{term_name}"
+          terms = api_user_page.terms
+          if terms.any?
+            terms.each do |term|
+              begin
 
-              courses = api_user_page.courses term
-              courses.each do |course|
-                begin
+                term_name = api_user_page.term_name term
+                term_id = api_user_page.term_id term
+                logger.info "Checking term #{term_name}"
 
-                  course_sis_data = api_user_page.sis_course_data course
-                  unless course_sis_data[:code].include? 'PHYS ED'
-                    logger.info "Checking course #{course_sis_data[:code]}"
+                courses = api_user_page.courses term
+                courses.each do |course|
+                  begin
 
-                    sections = api_user_page.sections course
-                    sections.each do |section|
-                      begin
+                    course_sis_data = api_user_page.sis_course_data course
+                    unless course_sis_data[:code].include? 'PHYS ED'
+                      logger.info "Checking course #{course_sis_data[:code]}"
 
-                        section_data = api_user_page.sis_section_data section
-                        api_section_page = BOACApiSectionPage.new @driver
-                        api_section_page.get_data(@driver, term_id, section_data[:ccn])
-                        class_test_case = "term #{term_name} course #{course_sis_data[:code]} section #{section_data[:component]} #{section_data[:number]} #{section_data[:ccn]}"
-                        logger.info "Checking #{class_test_case}"
+                      sections = api_user_page.sections course
+                      sections.each do |section|
+                        begin
 
-                        # Check that a class page link is present if the section is primary
-                        @student_page.load_page student
-                        if terms.length > 1 && api_user_page.term_id(terms.last).to_s != BOACUtils.term_code.to_s
-                          @student_page.click_view_previous_semesters
-                        end
+                          section_data = api_user_page.sis_section_data section
+                          api_section_page = BOACApiSectionPage.new @driver
+                          api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                          class_test_case = "term #{term_name} course #{course_sis_data[:code]} section #{section_data[:component]} #{section_data[:number]} #{section_data[:ccn]}"
+                          logger.info "Checking #{class_test_case}"
 
-                        class_page_link_present = @student_page.verify_block { @student_page.class_page_link(term_id, section_data[:ccn]).when_present 1 }
-                        section_data[:primary] ?
-                            it("shows a class page link for #{class_test_case}") { expect(class_page_link_present).to be true } :
-                            it("shows no class page link for #{class_test_case}") { expect(class_page_link_present).to be false }
-
-                        # Check the class page only if it has not already been checked during a previous loop
-                        if class_page_link_present && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
-                          @student_page.click_class_page_link(term_id, section_data[:ccn])
-                          pages_tested << "#{term_id} #{section_data[:ccn]}"
-
-                          # COURSE AND MEETING DATA
-
-                          # Check that the course + section info is presented as expected
-                          visible_course_data = @class_page.visible_course_data
-                          section_course_code = course_sis_data[:code].gsub("#{section_data[:component]} #{section_data[:number]}", '').strip
-                          it("shows the right term for #{class_test_case}") { expect(visible_course_data[:term]).to eql(term_name) }
-                          it("shows the right course code for #{class_test_case}") { expect(visible_course_data[:code]).to eql(section_course_code) }
-                          it("shows the right course title for #{class_test_case}") { expect(visible_course_data[:title]).to eql(course_sis_data[:title]) }
-                          it("shows the right section format for #{class_test_case}") { expect(visible_course_data[:format]).to eql(section_data[:component]) }
-                          it("shows the right section number for #{class_test_case}") { expect(visible_course_data[:number]).to eql(section_data[:number]) }
-                          it("shows no empty course data for #{class_test_case}") do
-                            expect(visible_course_data.values.all?).to be true
-                            expect(visible_course_data.values.any? &:empty?).to be false
+                          # Check that a class page link is present if the section is primary
+                          @student_page.load_page student
+                          if terms.length > 1 && api_user_page.term_id(terms.last).to_s != BOACUtils.term_code.to_s
+                            @student_page.click_view_previous_semesters
                           end
 
-                          Utils.add_csv_row(courses_csv, [term_name, section_course_code, course_sis_data[:title], "#{section_data[:component]} #{section_data[:number]}", section_data[:units_completed]])
+                          class_page_link_present = @student_page.verify_block { @student_page.class_page_link(term_id, section_data[:ccn]).when_present 1 }
+                          section_data[:primary] ?
+                              it("shows a class page link for #{class_test_case}") { expect(class_page_link_present).to be true } :
+                              it("shows no class page link for #{class_test_case}") { expect(class_page_link_present).to be false }
 
-                          # Check that the section schedules are presented as expected
-                          api_section_page.meetings.each do |meet|
-                            index = api_section_page.meetings.index meet
-                            visible_meeting_data = @class_page.visible_meeting_data index
-                            expected_location = "#{meet[:location]}#{' — ' if meet[:location] && meet[:mode]}#{meet[:mode]}"
-                            it("shows the right instructors for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:instructors]).to eql(meet[:instructors]) }
-                            it("shows the right days for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:days]).to eql(meet[:days]) }
-                            it("shows the right time for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:time]).to eql(meet[:time]) }
-                            it("shows the right location for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:location]).to eql(expected_location) }
+                          # Check the class page only if it has not already been checked during a previous loop
+                          if class_page_link_present && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
+                            @student_page.click_class_page_link(term_id, section_data[:ccn])
+                            pages_tested << "#{term_id} #{section_data[:ccn]}"
 
-                            Utils.add_csv_row(meetings_csv, [term_name, section_course_code, meet[:instructors], meet[:days], meet[:time], expected_location])
-                          end
+                            # COURSE AND MEETING DATA
 
-                          # STUDENT DATA
-
-                          # Check that all students who should appear actually do
-                          visible_sids = @class_page.visible_sids.sort.uniq
-                          logger.info "Visible student count is #{visible_sids.length}"
-                          logger.error "Expecting #{api_section_page.student_sids.sort} but got #{visible_sids}" unless visible_sids == api_section_page.student_sids.sort
-                          it("shows the right students for #{class_test_case}") { expect(visible_sids.sort).to eql(api_section_page.student_sids.sort) }
-
-                          # Perform further tests on the students who appear on the first page
-                          @class_page.load_page(term_id, section_data[:ccn], student)
-                          visible_students = @class_page.class_list_view_sids
-                          expected_students = test.students.select { |s| visible_students.include? s.sis_id }
-                          expected_student_names = (expected_students.map { |u| "#{u.last_name}, #{u.first_name}" }).sort
-                          visible_student_names = (@class_page.list_view_names).sort
-                          logger.error "Expecting #{expected_student_names} and got #{visible_student_names}" unless visible_student_names == expected_student_names
-                          it("shows all the expected students for #{class_test_case}") { expect(visible_student_names).to eql(expected_student_names) }
-                          it("shows no blank student names for #{class_test_case}") { expect(visible_student_names.any? &:empty?).to be false }
-
-                          # Collect all the expected class page data for each student in the class
-                          all_student_data = []
-
-                          # Limit the detailed tests to a configurable number of students in the class
-                          expected_students = expected_students[0..BOACUtils.config['class_page_max_classmates']]
-                          expected_students.each do |student|
-
-                            # Load the student's data and find the matching course
-                            student_api = BOACApiStudentPage.new @driver
-                            student_api.get_data(@driver, student)
-                            term = student_api.terms.find { |t| student_api.term_name(t) == term_name }
-                            course = student_api.courses(term).find { |c| student_api.course_display_name(c) == course_sis_data[:code] }
-                            unless course
-                              logger.warn "No matching student course for UID #{student.uid} #{course_sis_data[:code]}"
+                            # Check that the course + section info is presented as expected
+                            visible_course_data = @class_page.visible_course_data
+                            section_course_code = course_sis_data[:code].gsub("#{section_data[:component]} #{section_data[:number]}", '').strip
+                            it("shows the right term for #{class_test_case}") { expect(visible_course_data[:term]).to eql(term_name) }
+                            it("shows the right course code for #{class_test_case}") { expect(visible_course_data[:code]).to eql(section_course_code) }
+                            it("shows the right course title for #{class_test_case}") { expect(visible_course_data[:title]).to eql(course_sis_data[:title]) }
+                            it("shows the right section format for #{class_test_case}") { expect(visible_course_data[:format]).to eql(section_data[:component]) }
+                            it("shows the right section number for #{class_test_case}") { expect(visible_course_data[:number]).to eql(section_data[:number]) }
+                            it("shows no empty course data for #{class_test_case}") do
+                              expect(visible_course_data.values.all?).to be true
+                              expect(visible_course_data.values.any? &:empty?).to be false
                             end
 
-                            # Collect the student data relevant to the class page
-                            student_class_page_data = {
-                              :sid => student.sis_id,
-                              :level => (student_api.sis_profile_data[:level].nil? ? '' : student_api.sis_profile_data[:level]),
-                              :majors => student_api.sis_profile_data[:majors],
-                              :graduation => student_api.sis_profile_data[:graduation],
-                              :academic_career_status => student_api.sis_profile_data[:academic_career_status],
-                              :sports => student_api.asc_teams,
-                              :grading_basis => student_api.sis_course_data(course)[:grading_basis],
-                              :final_grade => student_api.sis_course_data(course)[:grade],
-                              :midpoint_grade => student_api.sis_course_data(course)[:midpoint],
-                              :sites => (student_api.course_sites(course).map do |site|
-                                {
-                                  :site_id => student_api.site_metadata(site)[:site_id],
-                                  :site_code => student_api.site_metadata(site)[:code],
-                                  :nessie_assigns_submitted => student_api.nessie_assigns_submitted(site),
-                                  :nessie_grades => student_api.nessie_grades(site)
-                                }
-                              end)
-                            }
-                            all_student_data << student_class_page_data
-                          end
+                            Utils.add_csv_row(courses_csv, [term_name, section_course_code, course_sis_data[:title], "#{section_data[:component]} #{section_data[:number]}", section_data[:units_completed]])
 
-                          expected_students.each do |classmate|
+                            # Check that the section schedules are presented as expected
+                            api_section_page.meetings.each do |meet|
+                              index = api_section_page.meetings.index meet
+                              visible_meeting_data = @class_page.visible_meeting_data index
+                              expected_location = "#{meet[:location]}#{' — ' if meet[:location] && meet[:mode]}#{meet[:mode]}"
+                              it("shows the right instructors for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:instructors]).to eql(meet[:instructors]) }
+                              it("shows the right days for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:days]).to eql(meet[:days]) }
+                              it("shows the right time for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:time]).to eql(meet[:time]) }
+                              it("shows the right location for meeting #{index} for #{class_test_case}") { expect(visible_meeting_data[:location]).to eql(expected_location) }
+
+                              Utils.add_csv_row(meetings_csv, [term_name, section_course_code, meet[:instructors], meet[:days], meet[:time], expected_location])
+                            end
+
+                            # STUDENT DATA
+
+                            # Check that all students who should appear actually do
+                            visible_sids = @class_page.visible_sids.sort.uniq
+                            logger.info "Visible student count is #{visible_sids.length}"
+                            logger.error "Expecting #{api_section_page.student_sids.sort} but got #{visible_sids}" unless visible_sids == api_section_page.student_sids.sort
+                            it("shows the right students for #{class_test_case}") { expect(visible_sids.sort).to eql(api_section_page.student_sids.sort) }
+
+                            # Perform further tests on the students who appear on the first page
                             @class_page.load_page(term_id, section_data[:ccn], student)
-                            logger.info "Checking SIS data for UID #{classmate.uid}"
-                            student_test_case = "UID #{classmate.uid} #{class_test_case}"
-                            student_data = all_student_data.find { |d| d[:sid] == classmate.sis_id }
+                            visible_students = @class_page.class_list_view_sids
+                            expected_students = test.students.select { |s| visible_students.include? s.sis_id }
+                            expected_student_names = (expected_students.map { |u| "#{u.last_name}, #{u.first_name}" }).sort
+                            visible_student_names = (@class_page.list_view_names).sort
+                            logger.error "Expecting #{expected_student_names} and got #{visible_student_names}" unless visible_student_names == expected_student_names
+                            it("shows all the expected students for #{class_test_case}") { expect(visible_student_names).to eql(expected_student_names) }
+                            it("shows no blank student names for #{class_test_case}") { expect(visible_student_names.any? &:empty?).to be false }
 
-                            # Check the student's SIS and ASC data
-                            visible_student_sis_data = @class_page.visible_student_sis_data classmate
+                            # Collect all the expected class page data for each student in the class
+                            all_student_data = []
 
-                            if student_data[:academic_career_status] == 'Inactive'
-                              it "shows #{student_test_case} as inactive" do
-                                expect(visible_student_sis_data[:inactive]).to be true
+                            # Limit the detailed tests to a configurable number of students in the class
+                            expected_students = expected_students[0..BOACUtils.config['class_page_max_classmates']]
+                            expected_students.each do |student|
+
+                              # Load the student's data and find the matching course
+                              student_api = BOACApiStudentPage.new @driver
+                              student_api.get_data(@driver, student)
+                              term = student_api.terms.find { |t| student_api.term_name(t) == term_name }
+                              course = student_api.courses(term).find { |c| student_api.course_display_name(c) == course_sis_data[:code] }
+                              unless course
+                                logger.warn "No matching student course for UID #{student.uid} #{course_sis_data[:code]}"
                               end
-                            else
-                              it "does not show #{student_test_case} as inactive" do
-                                expect(visible_student_sis_data[:inactive]).to be false
-                              end
+
+                              # Collect the student data relevant to the class page
+                              student_class_page_data = {
+                                  :sid => student.sis_id,
+                                  :level => (student_api.sis_profile_data[:level].nil? ? '' : student_api.sis_profile_data[:level]),
+                                  :majors => student_api.sis_profile_data[:majors],
+                                  :graduation => student_api.sis_profile_data[:graduation],
+                                  :academic_career_status => student_api.sis_profile_data[:academic_career_status],
+                                  :sports => student_api.asc_teams,
+                                  :grading_basis => student_api.sis_course_data(course)[:grading_basis],
+                                  :final_grade => student_api.sis_course_data(course)[:grade],
+                                  :midpoint_grade => student_api.sis_course_data(course)[:midpoint],
+                                  :sites => (student_api.course_sites(course).map do |site|
+                                    {
+                                        :site_id => student_api.site_metadata(site)[:site_id],
+                                        :site_code => student_api.site_metadata(site)[:code],
+                                        :nessie_assigns_submitted => student_api.nessie_assigns_submitted(site),
+                                        :nessie_grades => student_api.nessie_grades(site)
+                                    }
+                                  end)
+                              }
+                              all_student_data << student_class_page_data
                             end
 
-                            active_majors = student_data[:majors].map { |m| m[:major] if m[:active] }.compact.sort
-                            if active_majors.any?
-                              it("shows the right majors for #{student_test_case}") do
-                                expect(visible_student_sis_data[:majors]).to eql(active_majors)
-                                expect(visible_student_sis_data[:majors]).not_to be_empty
-                              end
-                            else
-                              it("shows no majors for #{student_test_case}") do
-                                expect(visible_student_sis_data[:majors]).to be_nil
-                              end
-                            end
+                            expected_students.each do |classmate|
+                              @class_page.load_page(term_id, section_data[:ccn], student)
+                              logger.info "Checking SIS data for UID #{classmate.uid}"
+                              student_test_case = "UID #{classmate.uid} #{class_test_case}"
+                              student_data = all_student_data.find { |d| d[:sid] == classmate.sis_id }
 
-                            if student_data[:academic_career_status] == 'Completed'
-                              it("shows the right graduation date for #{student_test_case}") do
-                                expect(visible_student_sis_data[:graduation_date]).not_to be_nil
-                                expect(visible_student_sis_data[:graduation_date]).to eql('Graduated ' + Date.parse(student_data[:graduation][:date]).strftime('%b %e, %Y'))
-                              end
-                              it("shows the right graduation colleges for #{student_test_case}") do
-                                expect(visible_student_sis_data[:graduation_colleges]).not_to be_empty
-                                expect(visible_student_sis_data[:graduation_colleges]).to eql(student_data[:graduation][:colleges])
-                              end
-                            else
-                              it("shows the right level for #{student_test_case}") { expect(visible_student_sis_data[:level]).to eql(student_data[:level]) }
-                            end
+                              # Check the student's SIS and ASC data
+                              visible_student_sis_data = @class_page.visible_student_sis_data classmate
 
-                            if student_data[:sports]&.any? && test.dept == BOACDepartments::ASC
-                              sports = student_data[:sports].map { |s| s.gsub(' (AA)', '') }
-                              it("shows the right sports for #{student_test_case}") { expect(visible_student_sis_data[:sports]).to eql(sports.sort) }
-                            end
-
-                            if student_data[:grading_basis] == 'NON' || !student_data[:final_grade].empty?
-                              it("shows no grading basis for #{student_test_case}") { expect(visible_student_sis_data[:grading_basis]).to be_nil }
-                            else
-                              it "shows the grading basis for #{student_test_case}" do
-                                expect(visible_student_sis_data[:grading_basis]).not_to be_empty
-                                expect(visible_student_sis_data[:grading_basis]).to eql(student_data[:grading_basis])
-                              end
-                            end
-
-                            if student_data[:final_grade] && !student_data[:final_grade].empty?
-                              it "shows the grade for #{student_test_case}" do
-                                expect(visible_student_sis_data[:final_grade]).not_to be_empty
-                                expect(visible_student_sis_data[:final_grade]).to eql(student_data[:final_grade])
-                              end
-                            else
-                              it("shows no grade for #{student_test_case}") { expect(visible_student_sis_data[:final_grade]).to eql(student_data[:grading_basis]) }
-                            end
-
-                            # Midpoint grades display for the current term only.
-                            if student_data[:midpoint_grade] && term_id == BOACUtils.term_code
-                              it "shows the midpoint grade for #{student_test_case}" do
-                                expect(visible_student_sis_data[:mid_point_grade]).not_to be_empty
-                                expect(visible_student_sis_data[:mid_point_grade]).to eql(student_data[:midpoint_grade])
-                              end
-                            else
-                              it("shows no midpoint grade for #{student_test_case}") { expect(visible_student_sis_data[:midpoint_grade]).to be_nil }
-                            end
-
-                            Utils.add_csv_row(students_sis_csv, [term_name, section_course_code, student_data[:sid], student_data[:level], active_majors, student_data[:sports], student_data[:mid_point_grade], student_data[:grading_basis], student_data[:final_grade]])
-
-                            # Check the student's course site data
-                            student_data[:sites].each do |site|
-                              site_test_case = "#{student_test_case} site ID #{site[:site_id]}"
-                              index = student_data[:sites].index site
-                              visible_site_data = @class_page.visible_assigns_data(classmate, index)
-                              logger.debug "Checking #{site_test_case} at node #{index + 1}, code #{site[:site_code]}"
-
-                              if site[:nessie_assigns_submitted][:score].empty?
-                                it("shows a 'No Data' assignments submitted count for #{site_test_case}") { expect(visible_site_data[:assigns_submit_no_data]).to be_truthy }
+                              if student_data[:academic_career_status] == 'Inactive'
+                                it "shows #{student_test_case} as inactive" do
+                                  expect(visible_student_sis_data[:inactive]).to be true
+                                end
                               else
-                                expected_count = site[:nessie_assigns_submitted][:score]
-                                if expected_count == '0'
-                                  it("shows the null or zero assignments submitted count for #{site_test_case}") { expect(%w(0 --)).to include(visible_site_data[:assigns_submitted]) }
-                                else
-                                  it("shows the assignments submitted count for #{site_test_case}") { expect(visible_site_data[:assigns_submitted]).to eql(site[:nessie_assigns_submitted][:score]) }
+                                it "does not show #{student_test_case} as inactive" do
+                                  expect(visible_student_sis_data[:inactive]).to be false
                                 end
                               end
 
-                              # Currently no grades data is shown unless it can produce a boxplot
-                              if site[:nessie_grades][:score].empty?
-                                it("shows a 'No Data' assignments score for #{site_test_case}") { expect(visible_site_data[:assigns_grade_no_data]).to be_truthy }
+                              active_majors = student_data[:majors].map { |m| m[:major] if m[:active] }.compact.sort
+                              if active_majors.any?
+                                it("shows the right majors for #{student_test_case}") do
+                                  expect(visible_student_sis_data[:majors]).to eql(active_majors)
+                                  expect(visible_student_sis_data[:majors]).not_to be_empty
+                                end
                               else
-                                # TODO - BOAC-2754
-                                expected_score = site[:nessie_grades][:score]
-                                if expected_score == '0'
-                                  it("shows the null or zero assignments score for #{site_test_case}") { expect(%w(0 --)).to include(visible_site_data[:assigns_grade]) }
-                                else
-                                  it("shows the assignments score for #{site_test_case}") { expect(visible_site_data[:assigns_grade]).to eql(expected_score) }
+                                it("shows no majors for #{student_test_case}") do
+                                  expect(visible_student_sis_data[:majors]).to be_nil
                                 end
                               end
 
-                              Utils.add_csv_row(students_canvas_csv, [term_name, section_course_code, student_data[:sid], site[:site_id], site[:site_code], site[:nessie_assigns_submitted][:score], site[:nessie_assigns_submitted][:max], site[:nessie_grades][:score], site[:nessie_grades][:max]])
+                              if student_data[:academic_career_status] == 'Completed'
+                                it("shows the right graduation date for #{student_test_case}") do
+                                  expect(visible_student_sis_data[:graduation_date]).not_to be_nil
+                                  expect(visible_student_sis_data[:graduation_date]).to eql('Graduated ' + Date.parse(student_data[:graduation][:date]).strftime('%b %e, %Y'))
+                                end
+                                it("shows the right graduation colleges for #{student_test_case}") do
+                                  expect(visible_student_sis_data[:graduation_colleges]).not_to be_empty
+                                  expect(visible_student_sis_data[:graduation_colleges]).to eql(student_data[:graduation][:colleges])
+                                end
+                              else
+                                it("shows the right level for #{student_test_case}") { expect(visible_student_sis_data[:level]).to eql(student_data[:level]) }
+                              end
+
+                              if student_data[:sports]&.any? && test.dept == BOACDepartments::ASC
+                                sports = student_data[:sports].map { |s| s.gsub(' (AA)', '') }
+                                it("shows the right sports for #{student_test_case}") { expect(visible_student_sis_data[:sports]).to eql(sports.sort) }
+                              end
+
+                              if student_data[:grading_basis] == 'NON' || !student_data[:final_grade].empty?
+                                it("shows no grading basis for #{student_test_case}") { expect(visible_student_sis_data[:grading_basis]).to be_nil }
+                              else
+                                it "shows the grading basis for #{student_test_case}" do
+                                  expect(visible_student_sis_data[:grading_basis]).not_to be_empty
+                                  expect(visible_student_sis_data[:grading_basis]).to eql(student_data[:grading_basis])
+                                end
+                              end
+
+                              if student_data[:final_grade] && !student_data[:final_grade].empty?
+                                it "shows the grade for #{student_test_case}" do
+                                  expect(visible_student_sis_data[:final_grade]).not_to be_empty
+                                  expect(visible_student_sis_data[:final_grade]).to eql(student_data[:final_grade])
+                                end
+                              else
+                                it("shows no grade for #{student_test_case}") { expect(visible_student_sis_data[:final_grade]).to eql(student_data[:grading_basis]) }
+                              end
+
+                              # Midpoint grades display for the current term only.
+                              if student_data[:midpoint_grade] && term_id == BOACUtils.term_code
+                                it "shows the midpoint grade for #{student_test_case}" do
+                                  expect(visible_student_sis_data[:mid_point_grade]).not_to be_empty
+                                  expect(visible_student_sis_data[:mid_point_grade]).to eql(student_data[:midpoint_grade])
+                                end
+                              else
+                                it("shows no midpoint grade for #{student_test_case}") { expect(visible_student_sis_data[:midpoint_grade]).to be_nil }
+                              end
+
+                              Utils.add_csv_row(students_sis_csv, [term_name, section_course_code, student_data[:sid], student_data[:level], active_majors, student_data[:sports], student_data[:mid_point_grade], student_data[:grading_basis], student_data[:final_grade]])
+
+                              # Check the student's course site data
+                              student_data[:sites].each do |site|
+                                site_test_case = "#{student_test_case} site ID #{site[:site_id]}"
+                                index = student_data[:sites].index site
+                                visible_site_data = @class_page.visible_assigns_data(classmate, index)
+                                logger.debug "Checking #{site_test_case} at node #{index + 1}, code #{site[:site_code]}"
+
+                                if site[:nessie_assigns_submitted][:score].empty?
+                                  it("shows a 'No Data' assignments submitted count for #{site_test_case}") { expect(visible_site_data[:assigns_submit_no_data]).to be_truthy }
+                                else
+                                  expected_count = site[:nessie_assigns_submitted][:score]
+                                  if expected_count == '0'
+                                    it("shows the null or zero assignments submitted count for #{site_test_case}") { expect(%w(0 --)).to include(visible_site_data[:assigns_submitted]) }
+                                  else
+                                    it("shows the assignments submitted count for #{site_test_case}") { expect(visible_site_data[:assigns_submitted]).to eql(site[:nessie_assigns_submitted][:score]) }
+                                  end
+                                end
+
+                                # Currently no grades data is shown unless it can produce a boxplot
+                                if site[:nessie_grades][:score].empty?
+                                  it("shows a 'No Data' assignments score for #{site_test_case}") { expect(visible_site_data[:assigns_grade_no_data]).to be_truthy }
+                                else
+                                  # TODO - BOAC-2754
+                                  expected_score = site[:nessie_grades][:score]
+                                  if expected_score == '0'
+                                    it("shows the null or zero assignments score for #{site_test_case}") { expect(%w(0 --)).to include(visible_site_data[:assigns_grade]) }
+                                  else
+                                    it("shows the assignments score for #{site_test_case}") { expect(visible_site_data[:assigns_grade]).to eql(expected_score) }
+                                  end
+                                end
+
+                                Utils.add_csv_row(students_canvas_csv, [term_name, section_course_code, student_data[:sid], site[:site_id], site[:site_code], site[:nessie_assigns_submitted][:score], site[:nessie_assigns_submitted][:max], site[:nessie_grades][:score], site[:nessie_grades][:max]])
+
+                              end
+
+                              # TODO - the 'max' values are the same for all users
 
                             end
-
-                            # TODO - the 'max' values are the same for all users
-
                           end
-                        end
 
-                      rescue => e
-                        BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_sis_data[:code]}")
-                        it("test hit an error with UID #{student.uid} term #{term_name} course #{course_sis_data[:code]}") { fail }
+                        rescue => e
+                          BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_sis_data[:code]}")
+                          it("test hit an error with UID #{student.uid} term #{term_name} course #{course_sis_data[:code]}") { fail }
+                        end
                       end
                     end
+
+                  rescue => e
+                    BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_sis_data[:code]}")
+                    it("test hit an error with UID #{student.uid} term #{term_name} course #{course_sis_data[:code]}") { fail }
                   end
-
-                rescue => e
-                  BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_sis_data[:code]}")
-                  it("test hit an error with UID #{student.uid} term #{term_name} course #{course_sis_data[:code]}") { fail }
                 end
-              end
 
-            rescue => e
-              BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}")
-              it("test hit an error with UID #{student.uid} term #{term_name}") { fail }
+              rescue => e
+                BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}")
+                it("test hit an error with UID #{student.uid} term #{term_name}") { fail }
+              end
             end
           end
+
+        rescue => e
+          BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}")
+          it("test hit an error with UID #{student.uid}") { fail }
         end
-
-      rescue => e
-        BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}")
-        it("test hit an error with UID #{student.uid}") { fail }
       end
-    end
 
-  rescue => e
-    Utils.log_error e
-    it('test hit an error') { fail }
-  ensure
-    Utils.quit_browser @driver
+    rescue => e
+      Utils.log_error e
+      it('test hit an error') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end

--- a/spec/boac/boac_curated_group_spec.rb
+++ b/spec/boac/boac_curated_group_spec.rb
@@ -1,439 +1,442 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  test = BOACTestConfig.new
-  test.curated_groups
-  test_student = test.cohort_members[1]
-  logger.debug "Test student is UID #{test_student.uid} SID #{test_student.sis_id}"
+    include Logging
 
-  # Initialize groups to be used later in the tests
-  advisor_groups = [
-    (group_1 = CuratedGroup.new({:name => "Group 1 #{test.id}"})),
-    (group_2 = CuratedGroup.new({:name => "Group 2 #{test.id}"})),
-    (group_3 = CuratedGroup.new({:name => "Group 3 #{test.id}"})),
-    (group_4 = CuratedGroup.new({:name => "Group 4 #{test.id}"})),
-    (group_5 = CuratedGroup.new({:name => "Group 5 #{test.id}"})),
-    (group_6 = CuratedGroup.new({:name => "Group 6 #{test.id}"})),
-    (group_7 = CuratedGroup.new({:name => "Group 7 #{test.id}"})),
-    (group_8 = CuratedGroup.new({:name => "Group 8 #{test.id}"}))
-  ]
-  other_advisor = BOACUtils.get_admin_users.find { |u| u.uid != test.advisor.uid }
-  pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
-  pre_existing_groups = BOACUtils.get_user_curated_groups test.advisor
+    test = BOACTestConfig.new
+    test.curated_groups
+    test_student = test.cohort_members[1]
+    logger.debug "Test student is UID #{test_student.uid} SID #{test_student.sis_id}"
 
-  before(:all) do
-    @driver = Utils.launch_browser test.chrome_profile
-    @analytics_page = BOACApiStudentPage.new @driver
-    @homepage = BOACHomePage.new @driver
-    @group_page = BOACGroupPage.new @driver
-    @filtered_page = BOACFilteredCohortPage.new(@driver, test.advisor)
-    @student_page = BOACStudentPage.new @driver
-    @class_page = BOACClassListViewPage.new @driver
-    @search_page = BOACSearchResultsPage.new @driver
-
-    # Get enrollment data for test student for class page tests
-    @homepage.dev_auth test.advisor
-    @analytics_page.get_data(@driver, test_student)
-    @term = @analytics_page.terms.first
-    @course = @analytics_page.courses(@term).first
-
-    # Delete all pre-existing cohorts since they might contain group filters and prevent group deletion
-    @homepage.load_page
-    pre_existing_cohorts.each do |c|
-      @filtered_page.load_cohort c
-      @filtered_page.delete_cohort c
-    end
-
-    # Create a default filtered cohort
-    @filtered_page.search_and_create_new_cohort(test.default_cohort, default: true) unless test.default_cohort.id
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  it 'groups can all be deleted' do
-    pre_existing_groups.each do |c|
-      @group_page.load_page c
-      @group_page.delete_cohort c
-    end
-  end
-
-  describe 'group creation' do
-
-    it 'can be done using the filtered cohort list view group selector' do
-      @filtered_page.load_cohort test.default_cohort
-      @filtered_page.wait_for_student_list
-      sids = @filtered_page.list_view_sids
-      visible_members = test.students.select { |m| sids.include? m.sis_id }
-      group_created_from_filter = CuratedGroup.new({:name => "Group created from filtered cohort #{test.id}"})
-      @filtered_page.select_and_add_students_to_new_grp(visible_members, group_created_from_filter)
-    end
-
-    it 'can be done using the class page list view group selector' do
-      @class_page.load_page(@analytics_page.term_id(@term), @analytics_page.course_section_ccns(@course).first)
-      sids = @class_page.class_list_view_sids
-      visible_members = test.students.select { |m| sids.include? m.sis_id }
-      group_created_from_class = CuratedGroup.new({:name => "Group created from class page #{test.id}"})
-      @class_page.select_and_add_students_to_new_grp(visible_members, group_created_from_class)
-    end
-
-    it 'can be done using the user search results group selector' do
-      @homepage.type_non_note_string_and_enter test_student.sis_id
-      group_created_from_search = CuratedGroup.new({:name => "Group created from search results #{test.id}"})
-      @search_page.select_and_add_students_to_new_grp([test_student], group_created_from_search)
-    end
-
-    it 'can be done using the student page group selector' do
-      @student_page.load_page test_student
-      group_created_from_profile = CuratedGroup.new({:name => "Group created from student page #{test.id}"})
-      @student_page.add_student_to_new_grp(test_student, group_created_from_profile)
-    end
-
-    it 'can be done using bulk SIDs feature' do
-      students = test.students.first(10)
-      @homepage.click_sidebar_create_curated_group
-      group_created_from_bulk = CuratedGroup.new({:name => "Group created with bulk SIDs #{test.id}"})
-      @group_page.create_group_with_bulk_sids(students, group_created_from_bulk)
-      @group_page.wait_for_sidebar_group group_created_from_bulk
-      @group_page.group_name_heading(group_created_from_bulk).when_visible Utils.short_wait
-    end
-  end
-
-  describe 'group names' do
+    # Initialize groups to be used later in the tests
+    advisor_groups = [
+        (group_1 = CuratedGroup.new({:name => "Group 1 #{test.id}"})),
+        (group_2 = CuratedGroup.new({:name => "Group 2 #{test.id}"})),
+        (group_3 = CuratedGroup.new({:name => "Group 3 #{test.id}"})),
+        (group_4 = CuratedGroup.new({:name => "Group 4 #{test.id}"})),
+        (group_5 = CuratedGroup.new({:name => "Group 5 #{test.id}"})),
+        (group_6 = CuratedGroup.new({:name => "Group 6 #{test.id}"})),
+        (group_7 = CuratedGroup.new({:name => "Group 7 #{test.id}"})),
+        (group_8 = CuratedGroup.new({:name => "Group 8 #{test.id}"}))
+    ]
+    other_advisor = BOACUtils.get_admin_users.find { |u| u.uid != test.advisor.uid }
+    pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
+    pre_existing_groups = BOACUtils.get_user_curated_groups test.advisor
 
     before(:all) do
+      @driver = Utils.launch_browser test.chrome_profile
+      @analytics_page = BOACApiStudentPage.new @driver
+      @homepage = BOACHomePage.new @driver
+      @group_page = BOACGroupPage.new @driver
+      @filtered_page = BOACFilteredCohortPage.new(@driver, test.advisor)
+      @student_page = BOACStudentPage.new @driver
+      @class_page = BOACClassListViewPage.new @driver
+      @search_page = BOACSearchResultsPage.new @driver
 
+      # Get enrollment data for test student for class page tests
+      @homepage.dev_auth test.advisor
+      @analytics_page.get_data(@driver, test_student)
+      @term = @analytics_page.terms.first
+      @course = @analytics_page.courses(@term).first
+
+      # Delete all pre-existing cohorts since they might contain group filters and prevent group deletion
       @homepage.load_page
+      pre_existing_cohorts.each do |c|
+        @filtered_page.load_cohort c
+        @filtered_page.delete_cohort c
+      end
 
-      # Create a filtered cohort to verify that a group cannot have the same name
-      filters = CohortFilter.new
-      filters.set_custom_filters level: ['10']
-      @existing_filtered_cohort = FilteredCohort.new name: "Existing Filtered Cohort #{test.id}", search_criteria: filters
-      @group_page.click_sidebar_create_filtered
-      @filtered_page.perform_student_search @existing_filtered_cohort
-      @filtered_page.create_new_cohort @existing_filtered_cohort
-
-      # Create a curated group to verify that another group cannot have the same name
-      @existing_group = CuratedGroup.new({:name => "Existing Group #{test.id}"})
-      @student_page.load_page test_student
-      @student_page.add_student_to_new_grp(test_student, @existing_group)
-
-      # Create and then delete a curated group to verify that another group can have the same name
-      @deleted_group = CuratedGroup.new({:name => "Deleted Group #{test.id}"})
-      @student_page.add_student_to_new_grp(test_student, @deleted_group)
-      @group_page.load_page @deleted_group
-      @group_page.delete_cohort @deleted_group
-
-      @new_group = CuratedGroup.new({})
-      @student_page.load_page test_student
+      # Create a default filtered cohort
+      @filtered_page.search_and_create_new_cohort(test.default_cohort, default: true) unless test.default_cohort.id
     end
 
-    before(:each) { @student_page.cancel_group if @student_page.grp_cancel_button_element.visible? }
+    after(:all) { Utils.quit_browser @driver }
 
-    it 'are required' do
-      @student_page.click_add_to_grp_button
-      @student_page.click_create_new_grp
-      expect(@student_page.grp_save_button_element.disabled?).to be true
+    it 'groups can all be deleted' do
+      pre_existing_groups.each do |c|
+        @group_page.load_page c
+        @group_page.delete_cohort c
+      end
     end
 
-    it 'are truncated to 255 characters' do
-      @new_group.name = "#{'A llooooong title ' * 15}?"
-      @student_page.click_add_to_grp_button
-      @student_page.click_create_new_grp
-      @student_page.enter_group_name @new_group
-      expect(@student_page.grp_name_input).to eql(@new_group.name[0..254])
+    describe 'group creation' do
+
+      it 'can be done using the filtered cohort list view group selector' do
+        @filtered_page.load_cohort test.default_cohort
+        @filtered_page.wait_for_student_list
+        sids = @filtered_page.list_view_sids
+        visible_members = test.students.select { |m| sids.include? m.sis_id }
+        group_created_from_filter = CuratedGroup.new({:name => "Group created from filtered cohort #{test.id}"})
+        @filtered_page.select_and_add_students_to_new_grp(visible_members, group_created_from_filter)
+      end
+
+      it 'can be done using the class page list view group selector' do
+        @class_page.load_page(@analytics_page.term_id(@term), @analytics_page.course_section_ccns(@course).first)
+        sids = @class_page.class_list_view_sids
+        visible_members = test.students.select { |m| sids.include? m.sis_id }
+        group_created_from_class = CuratedGroup.new({:name => "Group created from class page #{test.id}"})
+        @class_page.select_and_add_students_to_new_grp(visible_members, group_created_from_class)
+      end
+
+      it 'can be done using the user search results group selector' do
+        @homepage.type_non_note_string_and_enter test_student.sis_id
+        group_created_from_search = CuratedGroup.new({:name => "Group created from search results #{test.id}"})
+        @search_page.select_and_add_students_to_new_grp([test_student], group_created_from_search)
+      end
+
+      it 'can be done using the student page group selector' do
+        @student_page.load_page test_student
+        group_created_from_profile = CuratedGroup.new({:name => "Group created from student page #{test.id}"})
+        @student_page.add_student_to_new_grp(test_student, group_created_from_profile)
+      end
+
+      it 'can be done using bulk SIDs feature' do
+        students = test.students.first(10)
+        @homepage.click_sidebar_create_curated_group
+        group_created_from_bulk = CuratedGroup.new({:name => "Group created with bulk SIDs #{test.id}"})
+        @group_page.create_group_with_bulk_sids(students, group_created_from_bulk)
+        @group_page.wait_for_sidebar_group group_created_from_bulk
+        @group_page.group_name_heading(group_created_from_bulk).when_visible Utils.short_wait
+      end
     end
 
-    it 'must not match a non-deleted group belonging to the same advisor' do
-      @new_group.name = @existing_group.name
-      @student_page.click_add_to_grp_button
-      @student_page.click_create_new_grp
-      @student_page.name_and_save_group @new_group
-      @student_page.dupe_grp_name_msg_element.when_visible Utils.short_wait
+    describe 'group names' do
+
+      before(:all) do
+
+        @homepage.load_page
+
+        # Create a filtered cohort to verify that a group cannot have the same name
+        filters = CohortFilter.new
+        filters.set_custom_filters level: ['10']
+        @existing_filtered_cohort = FilteredCohort.new name: "Existing Filtered Cohort #{test.id}", search_criteria: filters
+        @group_page.click_sidebar_create_filtered
+        @filtered_page.perform_student_search @existing_filtered_cohort
+        @filtered_page.create_new_cohort @existing_filtered_cohort
+
+        # Create a curated group to verify that another group cannot have the same name
+        @existing_group = CuratedGroup.new({:name => "Existing Group #{test.id}"})
+        @student_page.load_page test_student
+        @student_page.add_student_to_new_grp(test_student, @existing_group)
+
+        # Create and then delete a curated group to verify that another group can have the same name
+        @deleted_group = CuratedGroup.new({:name => "Deleted Group #{test.id}"})
+        @student_page.add_student_to_new_grp(test_student, @deleted_group)
+        @group_page.load_page @deleted_group
+        @group_page.delete_cohort @deleted_group
+
+        @new_group = CuratedGroup.new({})
+        @student_page.load_page test_student
+      end
+
+      before(:each) { @student_page.cancel_group if @student_page.grp_cancel_button_element.visible? }
+
+      it 'are required' do
+        @student_page.click_add_to_grp_button
+        @student_page.click_create_new_grp
+        expect(@student_page.grp_save_button_element.disabled?).to be true
+      end
+
+      it 'are truncated to 255 characters' do
+        @new_group.name = "#{'A llooooong title ' * 15}?"
+        @student_page.click_add_to_grp_button
+        @student_page.click_create_new_grp
+        @student_page.enter_group_name @new_group
+        expect(@student_page.grp_name_input).to eql(@new_group.name[0..254])
+      end
+
+      it 'must not match a non-deleted group belonging to the same advisor' do
+        @new_group.name = @existing_group.name
+        @student_page.click_add_to_grp_button
+        @student_page.click_create_new_grp
+        @student_page.name_and_save_group @new_group
+        @student_page.dupe_grp_name_msg_element.when_visible Utils.short_wait
+      end
+
+      it 'must not match a non-deleted filtered cohort belonging to the same advisor' do
+        @new_group.name = @existing_filtered_cohort.name
+        @student_page.click_add_to_grp_button
+        @student_page.click_create_new_grp
+        @student_page.name_and_save_group @new_group
+        @student_page.dupe_filtered_name_msg_element.when_visible Utils.short_wait
+      end
+
+      it 'can be the same as a deleted group belonging to the same advisor' do
+        @new_group.name = @deleted_group.name
+        @student_page.add_student_to_new_grp(test_student, @new_group)
+      end
+
+      it 'can be changed' do
+        @group_page.load_page @new_group
+        @group_page.rename_grp(@new_group, "#{@new_group.name} Renamed")
+      end
     end
 
-    it 'must not match a non-deleted filtered cohort belonging to the same advisor' do
-      @new_group.name = @existing_filtered_cohort.name
-      @student_page.click_add_to_grp_button
-      @student_page.click_create_new_grp
-      @student_page.name_and_save_group @new_group
-      @student_page.dupe_filtered_name_msg_element.when_visible Utils.short_wait
-    end
+    describe 'group membership' do
 
-    it 'can be the same as a deleted group belonging to the same advisor' do
-      @new_group.name = @deleted_group.name
-      @student_page.add_student_to_new_grp(test_student, @new_group)
-    end
+      before(:all) do
+        student = test.cohort_members.last
+        test.cohort_members.pop
+        @student_page.load_page student
+        advisor_groups.each { |c| @student_page.add_student_to_new_grp(student, c) }
+      end
 
-    it 'can be changed' do
-      @group_page.load_page @new_group
-      @group_page.rename_grp(@new_group, "#{@new_group.name} Renamed")
-    end
-  end
+      it 'can be added from filtered cohort list view using select-all' do
+        @filtered_page.load_cohort test.default_cohort
+        @filtered_page.select_and_add_all_students_to_grp(test.students, group_1)
+        @group_page.load_page group_1
+        expect(@group_page.visible_sids.sort).to eql(group_1.members.map(&:sis_id).sort)
+      end
 
-  describe 'group membership' do
+      it 'can be added from filtered cohort list view using individual selections' do
+        @filtered_page.load_cohort test.default_cohort
+        group_uids = group_2.members.map &:uid
+        visible_uids = @filtered_page.list_view_uids - group_uids
+        test.cohort_members = test.cohort_members.select { |m| visible_uids.include? m.uid }
+        @filtered_page.select_and_add_students_to_grp(test.cohort_members[0..-2], group_2)
+        @group_page.load_page group_2
+        expect(@group_page.visible_sids.sort).to eql(group_2.members.map(&:sis_id).sort)
+        test.cohort_members.pop
+      end
 
-    before(:all) do
-      student = test.cohort_members.last
-      test.cohort_members.pop
-      @student_page.load_page student
-      advisor_groups.each { |c| @student_page.add_student_to_new_grp(student, c) }
-    end
+      it 'can be added on the student page' do
+        @student_page.load_page test_student
+        @student_page.add_student_to_grp(test_student, group_3)
+        @group_page.load_page group_3
+        expect(@group_page.visible_sids.sort).to eql(group_3.members.map(&:sis_id).sort)
+      end
 
-    it 'can be added from filtered cohort list view using select-all' do
-      @filtered_page.load_cohort test.default_cohort
-      @filtered_page.select_and_add_all_students_to_grp(test.students, group_1)
-      @group_page.load_page group_1
-      expect(@group_page.visible_sids.sort).to eql(group_1.members.map(&:sis_id).sort)
-    end
-
-    it 'can be added from filtered cohort list view using individual selections' do
-      @filtered_page.load_cohort test.default_cohort
-      group_uids = group_2.members.map &:uid
-      visible_uids = @filtered_page.list_view_uids - group_uids
-      test.cohort_members = test.cohort_members.select { |m| visible_uids.include? m.uid }
-      @filtered_page.select_and_add_students_to_grp(test.cohort_members[0..-2], group_2)
-      @group_page.load_page group_2
-      expect(@group_page.visible_sids.sort).to eql(group_2.members.map(&:sis_id).sort)
-      test.cohort_members.pop
-    end
-
-    it 'can be added on the student page' do
-      @student_page.load_page test_student
-      @student_page.add_student_to_grp(test_student, group_3)
-      @group_page.load_page group_3
-      expect(@group_page.visible_sids.sort).to eql(group_3.members.map(&:sis_id).sort)
-    end
-
-    it 'can be added on the bulk-add-SIDs page' do
-      @group_page.load_page group_4
-      @group_page.add_comma_sep_sids_to_existing_grp(test.students.last(10), group_4)
-      missing_sids = group_4.members.map(&:sis_id).sort - @group_page.visible_sids.sort
-      # Account for SIDs that have no associated data and will not appear in Boa
-      if missing_sids.any?
-        missing_sids.each do |missing_sid|
-          logger.info "Checking data for missing SID '#{missing_sid}'"
-          student = group_4.members.find { |s| s.sis_id == missing_sid }
-          api_data = @analytics_page.get_data(@driver, student)
-          unless api_data
-            logger.info "Removing SID #{missing_sid} from the group since the student does not appear in Boa"
-            missing_sids.delete missing_sid
-            group_4.members.delete student
+      it 'can be added on the bulk-add-SIDs page' do
+        @group_page.load_page group_4
+        @group_page.add_comma_sep_sids_to_existing_grp(test.students.last(10), group_4)
+        missing_sids = group_4.members.map(&:sis_id).sort - @group_page.visible_sids.sort
+        # Account for SIDs that have no associated data and will not appear in Boa
+        if missing_sids.any?
+          missing_sids.each do |missing_sid|
+            logger.info "Checking data for missing SID '#{missing_sid}'"
+            student = group_4.members.find { |s| s.sis_id == missing_sid }
+            api_data = @analytics_page.get_data(@driver, student)
+            unless api_data
+              logger.info "Removing SID #{missing_sid} from the group since the student does not appear in Boa"
+              missing_sids.delete missing_sid
+              group_4.members.delete student
+            end
           end
         end
+        expect(missing_sids).to be_empty
       end
-      expect(missing_sids).to be_empty
+
+      it 'can be added on class page list view using select-all' do
+        @class_page.load_page(@analytics_page.term_id(@term), @analytics_page.course_section_ccns(@course).first)
+        @class_page.select_and_add_all_students_to_grp(test.students, group_5)
+        @group_page.load_page group_5
+        expect(@group_page.visible_sids.sort).to eql(group_5.members.map(&:sis_id).sort)
+      end
+
+      it 'can be added on class page list view using individual selections' do
+        @student_page.load_page test_student
+        @student_page.click_class_page_link(@analytics_page.term_id(@term), @analytics_page.course_section_ccns(@course).first)
+        @class_page.select_and_add_students_to_grp([test_student], group_6)
+        @group_page.load_page group_6
+        expect(@group_page.visible_sids.sort).to eql(group_3.members.map(&:sis_id).sort)
+      end
+
+      it 'can be added on user search results using select-all' do
+        @homepage.type_non_note_string_and_enter test_student.sis_id
+        @search_page.select_and_add_all_students_to_grp(test.students, group_7)
+        @group_page.load_page group_7
+        expect(@group_page.visible_sids.sort).to eql(group_7.members.map(&:sis_id).sort)
+      end
+
+      it 'can be added on user search results using individual selections' do
+        @homepage.type_non_note_string_and_enter test_student.sis_id
+        @search_page.select_and_add_students_to_grp([test_student], group_8)
+        @group_page.load_page group_8
+        expect(@group_page.visible_sids.sort).to eql(group_8.members.map(&:sis_id).sort)
+      end
+
+      it 'is shown on the student page' do
+        @student_page.load_page group_1.members.first
+        @student_page.click_add_to_grp_button
+        expect(@student_page.grp_selected? group_1).to be true
+      end
+
+      it 'can be removed on the group list view page' do
+        @group_page.load_page group_2
+        student = group_2.members.last
+        logger.info "Removing UID #{student.uid} from group '#{group_2.name}'"
+        @group_page.remove_student_by_row_index(group_2, student)
+        expect(@group_page.visible_sids.sort).to eql(group_2.members.map(&:sis_id).sort)
+      end
+
+      it 'can be removed on the student page using the group checkbox' do
+        @student_page.load_page group_1.members.last
+        @student_page.remove_student_from_grp(group_1.members.last, group_1)
+        @group_page.load_page group_1
+        expect(@group_page.visible_sids.sort).to eql(group_1.members.map(&:sis_id).sort)
+      end
     end
 
-    it 'can be added on class page list view using select-all' do
-      @class_page.load_page(@analytics_page.term_id(@term), @analytics_page.course_section_ccns(@course).first)
-      @class_page.select_and_add_all_students_to_grp(test.students, group_5)
-      @group_page.load_page group_5
-      expect(@group_page.visible_sids.sort).to eql(group_5.members.map(&:sis_id).sort)
+    describe 'membership on the sidebar' do
+
+      before(:all) do
+        @group_9 = CuratedGroup.new(name: "Group 9 #{test.id}")
+        @group_10 = CuratedGroup.new(name: "Group 10 #{test.id}")
+        @student = test.cohort_members.last
+        @student_page.load_page @student
+      end
+
+      it 'is updated when a student is added to a new group' do
+        @student_page.add_student_to_new_grp(@student, @group_9)
+        @student_page.wait_for_sidebar_group_member_count @group_9
+      end
+
+      it 'is updated when a student is removed from a new group' do
+        @group_page.click_sidebar_group_link @group_9
+        @group_page.remove_student_by_row_index(@group_9, @student)
+        @group_page.wait_for_sidebar_group_member_count @group_9
+      end
+
+      it 'is updated when the same student is added to yet another new group' do
+        @group_page.enter_string_and_hit_enter @student.sis_id
+        @search_page.select_and_add_students_to_new_grp([@student], @group_10)
+        @search_page.wait_for_sidebar_group_member_count @group_10
+        @search_page.wait_for_sidebar_group_member_count @group_9
+      end
+
+      it 'is updated when the same student is removed from yet another group' do
+        @student_page.click_sidebar_group_link @group_10
+        @group_page.remove_student_by_row_index(@group_10, @student)
+        @search_page.wait_for_sidebar_group_member_count @group_10
+        @search_page.wait_for_sidebar_group_member_count @group_9
+      end
     end
 
-    it 'can be added on class page list view using individual selections' do
-      @student_page.load_page test_student
-      @student_page.click_class_page_link(@analytics_page.term_id(@term), @analytics_page.course_section_ccns(@course).first)
-      @class_page.select_and_add_students_to_grp([test_student], group_6)
-      @group_page.load_page group_6
-      expect(@group_page.visible_sids.sort).to eql(group_3.members.map(&:sis_id).sort)
-    end
+    describe 'group bulk-add SIDs' do
 
-    it 'can be added on user search results using select-all' do
-      @homepage.type_non_note_string_and_enter test_student.sis_id
-      @search_page.select_and_add_all_students_to_grp(test.students, group_7)
-      @group_page.load_page group_7
-      expect(@group_page.visible_sids.sort).to eql(group_7.members.map(&:sis_id).sort)
-    end
+      before(:each) { @group_page.load_page group_4 }
 
-    it 'can be added on user search results using individual selections' do
-      @homepage.type_non_note_string_and_enter test_student.sis_id
-      @search_page.select_and_add_students_to_grp([test_student], group_8)
-      @group_page.load_page group_8
-      expect(@group_page.visible_sids.sort).to eql(group_8.members.map(&:sis_id).sort)
-    end
+      it 'rejects malformed input' do
+        @group_page.click_add_students_button
+        @group_page.enter_sid_list 'nullum magnum ingenium sine mixtura dementiae fuit'
+        @group_page.click_add_sids_to_group_button
+        @group_page.sids_bad_format_error_msg_element.when_visible Utils.short_wait
+      end
 
-    it 'is shown on the student page' do
-      @student_page.load_page group_1.members.first
-      @student_page.click_add_to_grp_button
-      expect(@student_page.grp_selected? group_1).to be true
-    end
+      it 'rejects SIDs that do not match any Boa student SIDs' do
+        @group_page.click_add_students_button
+        @group_page.enter_sid_list '9999999990, 9999999991'
+        @group_page.click_add_sids_to_group_button
+        @group_page.sids_not_found_error_msg_element.when_visible Utils.short_wait
+      end
 
-    it 'can be removed on the group list view page' do
-      @group_page.load_page group_2
-      student = group_2.members.last
-      logger.info "Removing UID #{student.uid} from group '#{group_2.name}'"
-      @group_page.remove_student_by_row_index(group_2, student)
-      expect(@group_page.visible_sids.sort).to eql(group_2.members.map(&:sis_id).sort)
-    end
+      it 'allows the user to add large sets of SIDs' do
+        students = test.students.first(BOACUtils.group_bulk_sids_max)
+        groups = students.each_slice((students.size / 3.0).round).to_a
 
-    it 'can be removed on the student page using the group checkbox' do
-      @student_page.load_page group_1.members.last
-      @student_page.remove_student_from_grp(group_1.members.last, group_1)
-      @group_page.load_page group_1
-      expect(@group_page.visible_sids.sort).to eql(group_1.members.map(&:sis_id).sort)
-    end
-  end
+        comma_separated = groups[0]
+        @group_page.add_comma_sep_sids_to_existing_grp(comma_separated, group_4)
+        @group_page.wait_for_list_to_load
 
-  describe 'membership on the sidebar' do
+        line_separated = groups[1]
+        @group_page.add_line_sep_sids_to_existing_grp(line_separated, group_4)
+        @group_page.wait_for_spinner
 
-    before(:all) do
-      @group_9 = CuratedGroup.new(name: "Group 9 #{test.id}")
-      @group_10 = CuratedGroup.new(name: "Group 10 #{test.id}")
-      @student = test.cohort_members.last
-      @student_page.load_page @student
-    end
+        space_separated = groups[2]
+        @group_page.add_space_sep_sids_to_existing_grp(space_separated, group_4)
+        @group_page.wait_for_spinner
+        @group_page.load_page group_4
 
-    it 'is updated when a student is added to a new group' do
-      @student_page.add_student_to_new_grp(@student, @group_9)
-      @student_page.wait_for_sidebar_group_member_count @group_9
-    end
-
-    it 'is updated when a student is removed from a new group' do
-      @group_page.click_sidebar_group_link @group_9
-      @group_page.remove_student_by_row_index(@group_9, @student)
-      @group_page.wait_for_sidebar_group_member_count @group_9
-    end
-
-    it 'is updated when the same student is added to yet another new group' do
-      @group_page.enter_string_and_hit_enter @student.sis_id
-      @search_page.select_and_add_students_to_new_grp([@student], @group_10)
-      @search_page.wait_for_sidebar_group_member_count @group_10
-      @search_page.wait_for_sidebar_group_member_count @group_9
-    end
-
-    it 'is updated when the same student is removed from yet another group' do
-      @student_page.click_sidebar_group_link @group_10
-      @group_page.remove_student_by_row_index(@group_10, @student)
-      @search_page.wait_for_sidebar_group_member_count @group_10
-      @search_page.wait_for_sidebar_group_member_count @group_9
-    end
-  end
-
-  describe 'group bulk-add SIDs' do
-
-    before(:each) { @group_page.load_page group_4 }
-
-    it 'rejects malformed input' do
-      @group_page.click_add_students_button
-      @group_page.enter_sid_list 'nullum magnum ingenium sine mixtura dementiae fuit'
-      @group_page.click_add_sids_to_group_button
-      @group_page.sids_bad_format_error_msg_element.when_visible Utils.short_wait
-    end
-
-    it 'rejects SIDs that do not match any Boa student SIDs' do
-      @group_page.click_add_students_button
-      @group_page.enter_sid_list '9999999990, 9999999991'
-      @group_page.click_add_sids_to_group_button
-      @group_page.sids_not_found_error_msg_element.when_visible Utils.short_wait
-    end
-
-    it 'allows the user to add large sets of SIDs' do
-      students = test.students.first(BOACUtils.group_bulk_sids_max)
-      groups = students.each_slice((students.size/3.0).round).to_a
-
-      comma_separated = groups[0]
-      @group_page.add_comma_sep_sids_to_existing_grp(comma_separated, group_4)
-      @group_page.wait_for_list_to_load
-
-      line_separated = groups[1]
-      @group_page.add_line_sep_sids_to_existing_grp(line_separated, group_4)
-      @group_page.wait_for_spinner
-
-      space_separated = groups[2]
-      @group_page.add_space_sep_sids_to_existing_grp(space_separated, group_4)
-      @group_page.wait_for_spinner
-      @group_page.load_page group_4
-
-      # Account for SIDs that have no associated data and will not appear in Boa
-      missing_sids = group_4.members.map(&:sis_id).sort - @group_page.visible_sids.sort
-      if missing_sids.any?
-        missing_sids.each do |missing_sid|
-          logger.info "Checking data for missing SID '#{missing_sid}'"
-          student = group_4.members.find { |s| s.sis_id == missing_sid }
-          api_data = @analytics_page.get_data(@driver, student)
-          unless api_data
-            logger.info "Removing SID #{missing_sid} from the group since the student does not appear in Boa"
-            missing_sids.delete missing_sid
-            group_4.members.delete student
+        # Account for SIDs that have no associated data and will not appear in Boa
+        missing_sids = group_4.members.map(&:sis_id).sort - @group_page.visible_sids.sort
+        if missing_sids.any?
+          missing_sids.each do |missing_sid|
+            logger.info "Checking data for missing SID '#{missing_sid}'"
+            student = group_4.members.find { |s| s.sis_id == missing_sid }
+            api_data = @analytics_page.get_data(@driver, student)
+            unless api_data
+              logger.info "Removing SID #{missing_sid} from the group since the student does not appear in Boa"
+              missing_sids.delete missing_sid
+              group_4.members.delete student
+            end
           end
         end
+        logger.warn "Missing SIDs in #{group_4.name}: #{missing_sids}"
+        expect(missing_sids).to be_empty
       end
-      logger.warn "Missing SIDs in #{group_4.name}: #{missing_sids}"
-      expect(missing_sids).to be_empty
-    end
-  end
-
-  describe 'groups' do
-
-    it 'can be renamed' do
-      @group_page.load_page advisor_groups.first
-      @group_page.rename_grp(advisor_groups.first, "#{advisor_groups.first.name} Renamed")
     end
 
-    it('allow a deletion to be canceled') { @group_page.cancel_cohort_deletion advisor_groups.first }
+    describe 'groups' do
 
-    context 'on the homepage' do
+      it 'can be renamed' do
+        @group_page.load_page advisor_groups.first
+        @group_page.rename_grp(advisor_groups.first, "#{advisor_groups.first.name} Renamed")
+      end
+
+      it('allow a deletion to be canceled') { @group_page.cancel_cohort_deletion advisor_groups.first }
+
+      context 'on the homepage' do
+
+        advisor_groups.each do |group|
+
+          it "shows the group named #{group.name}" do
+            @homepage.load_page
+            @homepage.wait_until(Utils.medium_wait) { @homepage.curated_groups.include? group.name }
+          end
+
+          it "shows the group #{group.name} membership count" do
+            @homepage.wait_until(Utils.short_wait, "Expected #{group.members.length} members, but got #{@homepage.member_count(group)}") do
+              @homepage.member_count(group) == group.members.length
+            end
+          end
+
+          it "shows the group #{group.name} members with alerts" do
+            @homepage.expand_member_rows group
+            @homepage.verify_member_alerts(group, test.advisor)
+          end
+
+        end
+      end
+    end
+
+    describe 'group membership' do
 
       advisor_groups.each do |group|
 
-        it "shows the group named #{group.name}" do
-          @homepage.load_page
-          @homepage.wait_until(Utils.medium_wait) { @homepage.curated_groups.include? group.name }
-        end
-
-        it "shows the group #{group.name} membership count" do
-          @homepage.wait_until(Utils.short_wait, "Expected #{group.members.length} members, but got #{@homepage.member_count(group)}") do
-            @homepage.member_count(group) == group.members.length
+        it "can be exported for group #{group.name}" do
+          if Utils.headless?
+            logger.warn "Skipping group export test for #{group.name} because the browser is headless"
+          else
+            @group_page.load_page group
+            csv = @group_page.export_student_list group
+            @group_page.verify_student_list_default_export(group.members, csv)
           end
         end
 
-        it "shows the group #{group.name} members with alerts" do
-          @homepage.expand_member_rows group
-          @homepage.verify_member_alerts(group, test.advisor)
-        end
-
-      end
-    end
-  end
-
-  describe 'group membership' do
-
-    advisor_groups.each do |group|
-
-      it "can be exported for group #{group.name}" do
-        if Utils.headless?
-          logger.warn "Skipping group export test for #{group.name} because the browser is headless"
-        else
-          @group_page.load_page group
-          csv = @group_page.export_student_list group
-          @group_page.verify_student_list_default_export(group.members, csv)
-        end
-      end
-
-      it "can be exported with custom columns for group #{group.name}" do
-        if Utils.headless?
-          logger.warn "Skipping group export test for #{group.name} because the browser is headless"
-        else
-          @group_page.load_page group
-          csv = @group_page.export_custom_student_list group
-          @group_page.verify_student_list_custom_export(group.members, csv)
+        it "can be exported with custom columns for group #{group.name}" do
+          if Utils.headless?
+            logger.warn "Skipping group export test for #{group.name} because the browser is headless"
+          else
+            @group_page.load_page group
+            csv = @group_page.export_custom_student_list group
+            @group_page.verify_student_list_custom_export(group.members, csv)
+          end
         end
       end
     end
-  end
 
-  describe 'groups' do
+    describe 'groups' do
 
-    before(:all) do
-      @homepage.log_out
-      @homepage.dev_auth other_advisor
+      before(:all) do
+        @homepage.log_out
+        @homepage.dev_auth other_advisor
+      end
+
+      it('does not appear in another user\'s sidebar') { expect(@homepage.sidebar_groups & advisor_groups.map(&:name)).to be_empty }
+
     end
-
-    it('does not appear in another user\'s sidebar') { expect(@homepage.sidebar_groups & advisor_groups.map(&:name)).to be_empty }
-
   end
 end

--- a/spec/boac/boac_filtered_admits_spec.rb
+++ b/spec/boac/boac_filtered_admits_spec.rb
@@ -1,216 +1,219 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOA' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOA' do
 
-  test = BOACTestConfig.new
-  test.filtered_admits
-  existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, admits: true
-  latest_update_date = NessieUtils.get_admit_data_update_date
-  all_admit_data = NessieUtils.get_admit_page_data
+    include Logging
 
-  before(:all) do
-    @driver = Utils.launch_browser test.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @cohort_page = BOACFilteredAdmitsPage.new @driver
-    @admit_page = BOACAdmitPage.new @driver
+    test = BOACTestConfig.new
+    test.filtered_admits
+    existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, admits: true
+    latest_update_date = NessieUtils.get_admit_data_update_date
+    all_admit_data = NessieUtils.get_admit_page_data
 
-    @homepage.dev_auth test.advisor
-    existing_cohorts.each do |c|
-      @cohort_page.load_cohort c
-      @cohort_page.delete_cohort c
-    end
-  end
+    before(:all) do
+      @driver = Utils.launch_browser test.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @cohort_page = BOACFilteredAdmitsPage.new @driver
+      @admit_page = BOACAdmitPage.new @driver
 
-  after(:all) { Utils.quit_browser @driver }
-
-  context 'filtered cohort search' do
-
-    before(:each) { @cohort_page.cancel_cohort if @cohort_page.cancel_cohort_button? && @cohort_page.cancel_cohort_button_element.visible? }
-
-    describe 'default search' do
-
-      before(:all) do
-        @all_admits = Cohort.new(id: '0', name: 'CE3 Admissions', member_data: test.searchable_data)
-        @homepage.load_page
-        @cohort_page.click_sidebar_all_admits
+      @homepage.dev_auth test.advisor
+      existing_cohorts.each do |c|
+        @cohort_page.load_cohort c
+        @cohort_page.delete_cohort c
       end
-
-      it 'shows the most recent data update date if the data is stale' do
-        if Date.parse(latest_update_date) == Date.today
-          expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be false
-        else
-          expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be true
-        end
-      end
-
-      it 'allows the advisor to export a list of all admits' do
-        @all_admits.export_csv = @cohort_page.export_student_list @all_admits
-        @cohort_page.verify_admits_present_in_export(all_admit_data, @all_admits.member_data, @all_admits.export_csv)
-      end
-
-      it('allows the advisor to export a list of all admits containing no email addresses') { @cohort_page.verify_no_email_in_export @all_admits.export_csv }
-
-      it('allows the advisor to export a list of all admits with all expected data') { @cohort_page.verify_mandatory_data_in_export @all_admits.export_csv }
-
-      it('allows the advisor to export a list of all admits with all possible data') { @cohort_page.verify_optional_data_in_export @all_admits.export_csv }
     end
 
-    test.searches.each_with_index do |cohort, i|
+    after(:all) { Utils.quit_browser @driver }
 
-      it "shows all the admits sorted by Last Name who match #{cohort.search_criteria.inspect}" do
-        # Follow both paths to create admit cohorts
-        if i.odd?
-          @homepage.load_page
-          @cohort_page.click_sidebar_create_ce3_filtered
-        else
+    context 'filtered cohort search' do
+
+      before(:each) { @cohort_page.cancel_cohort if @cohort_page.cancel_cohort_button? && @cohort_page.cancel_cohort_button_element.visible? }
+
+      describe 'default search' do
+
+        before(:all) do
+          @all_admits = Cohort.new(id: '0', name: 'CE3 Admissions', member_data: test.searchable_data)
           @homepage.load_page
           @cohort_page.click_sidebar_all_admits
-          @cohort_page.click_create_cohort
         end
 
-        @cohort_page.perform_admit_search cohort
-        cohort.member_data = @cohort_page.expected_admit_search_results(test, cohort.search_criteria)
-        cohort.members = cohort.member_data.map { |d| BOACUser.new(sis_id: d['sid']) }
-        expected_results = @cohort_page.expected_sids_by_last_name cohort.member_data
-        if cohort.member_data.length.zero?
-          @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count == 0 }
-        else
-          @cohort_page.sort_by_last_name
-          visible_results = @cohort_page.filter_result_all_row_cs_ids cohort
-          @cohort_page.wait_until(1, "Expected but not present: #{expected_results - visible_results}. Present but not expected: #{visible_results - expected_results}") do
-            visible_results.sort == expected_results.sort
+        it 'shows the most recent data update date if the data is stale' do
+          if Date.parse(latest_update_date) == Date.today
+            expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be false
+          else
+            expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be true
           end
-          @cohort_page.verify_list_view_sorting(expected_results, visible_results)
         end
-      end
 
-      it("shows the most recent data update date for #{cohort.search_criteria.inspect} if the data is stale") do
-        if Date.parse(latest_update_date) == Date.today
-          expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be false
-        else
-          expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be true
+        it 'allows the advisor to export a list of all admits' do
+          @all_admits.export_csv = @cohort_page.export_student_list @all_admits
+          @cohort_page.verify_admits_present_in_export(all_admit_data, @all_admits.member_data, @all_admits.export_csv)
         end
+
+        it('allows the advisor to export a list of all admits containing no email addresses') { @cohort_page.verify_no_email_in_export @all_admits.export_csv }
+
+        it('allows the advisor to export a list of all admits with all expected data') { @cohort_page.verify_mandatory_data_in_export @all_admits.export_csv }
+
+        it('allows the advisor to export a list of all admits with all possible data') { @cohort_page.verify_optional_data_in_export @all_admits.export_csv }
       end
 
-      it "shows the right data for the admits who match #{cohort.search_criteria.inspect}" do
-        failures = []
-        visible_sids = @cohort_page.filter_result_row_cs_ids
-        expected_admit_data = cohort.member_data.select { |d| visible_sids.include? d[:sid] }
-        expected_admit_data.each { |admit| @cohort_page.verify_admit_row_data(admit[:sid], admit, failures) }
-        logger.error "Failures: #{failures}" unless failures.empty?
-        expect(failures).to be_empty
-      end
+      test.searches.each_with_index do |cohort, i|
 
-      it "sorts by First Name all the admits who match #{cohort.search_criteria.inspect}" do
-        if cohort.member_data.length.zero?
-          logger.warn 'Skipping sort-by-first-name test since there are no results'
-        else
-          @cohort_page.sort_by_first_name
-          expected_results = @cohort_page.expected_sids_by_first_name(cohort.member_data)
-          visible_results = @cohort_page.filter_result_all_row_cs_ids cohort
-          @cohort_page.verify_list_view_sorting(expected_results, visible_results)
-          @cohort_page.wait_until(1, "Expected #{expected_results} but got #{visible_results}") { visible_results == expected_results }
+        it "shows all the admits sorted by Last Name who match #{cohort.search_criteria.inspect}" do
+          # Follow both paths to create admit cohorts
+          if i.odd?
+            @homepage.load_page
+            @cohort_page.click_sidebar_create_ce3_filtered
+          else
+            @homepage.load_page
+            @cohort_page.click_sidebar_all_admits
+            @cohort_page.click_create_cohort
+          end
+
+          @cohort_page.perform_admit_search cohort
+          cohort.member_data = @cohort_page.expected_admit_search_results(test, cohort.search_criteria)
+          cohort.members = cohort.member_data.map { |d| BOACUser.new(sis_id: d['sid']) }
+          expected_results = @cohort_page.expected_sids_by_last_name cohort.member_data
+          if cohort.member_data.length.zero?
+            @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count == 0 }
+          else
+            @cohort_page.sort_by_last_name
+            visible_results = @cohort_page.filter_result_all_row_cs_ids cohort
+            @cohort_page.wait_until(1, "Expected but not present: #{expected_results - visible_results}. Present but not expected: #{visible_results - expected_results}") do
+              visible_results.sort == expected_results.sort
+            end
+            @cohort_page.verify_list_view_sorting(expected_results, visible_results)
+          end
         end
-      end
 
-      it "sorts by CS ID all the admits who match #{cohort.search_criteria.inspect}" do
-        if cohort.member_data.length.zero?
-          logger.warn 'Skipping sort-by-cs-id test since there are no results'
-        else
-          @cohort_page.sort_by_cs_id
-          expected_results = cohort.member_data.map { |u| u[:sid].to_i }.sort
-          visible_results = @cohort_page.filter_result_all_row_cs_ids cohort
-          @cohort_page.verify_list_view_sorting(expected_results, visible_results)
-          @cohort_page.wait_until(1, "Expected #{expected_results} but got #{visible_results}") { visible_results == expected_results }
+        it("shows the most recent data update date for #{cohort.search_criteria.inspect} if the data is stale") do
+          if Date.parse(latest_update_date) == Date.today
+            expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be false
+          else
+            expect(@cohort_page.data_update_date_heading(latest_update_date).exists?).to be true
+          end
         end
-      end
 
-      it("offers an Export List button for a search #{cohort.search_criteria.inspect}") { expect(@cohort_page.export_list_button?).to be true }
-
-      it "offers links to admit pages for search #{cohort.search_criteria.inspect}" do
-        if cohort.member_data.length.zero?
-          logger.warn 'Skipping admit page link test since there are no results'
-        else
-          cs_id = @cohort_page.filter_result_row_cs_ids.first
-          @cohort_page.click_admit_link cs_id
-          @admit_page.sid_element.when_visible Utils.short_wait
-          expect(@admit_page.sid).to eql(cs_id)
+        it "shows the right data for the admits who match #{cohort.search_criteria.inspect}" do
+          failures = []
+          visible_sids = @cohort_page.filter_result_row_cs_ids
+          expected_admit_data = cohort.member_data.select { |d| visible_sids.include? d[:sid] }
+          expected_admit_data.each { |admit| @cohort_page.verify_admit_row_data(admit[:sid], admit, failures) }
+          logger.error "Failures: #{failures}" unless failures.empty?
+          expect(failures).to be_empty
         end
-      end
 
-      it "can be reloaded using the Back button on an admit page for search #{cohort.search_criteria.inspect}" do
-        if cohort.member_data.length.zero?
-          logger.warn 'Skipping admit page back button test since there are no results'
-        else
-          @admit_page.go_back
-          @cohort_page.wait_until(Utils.short_wait) { @cohort_page.wait_for_search_results == cohort.member_data.length }
+        it "sorts by First Name all the admits who match #{cohort.search_criteria.inspect}" do
+          if cohort.member_data.length.zero?
+            logger.warn 'Skipping sort-by-first-name test since there are no results'
+          else
+            @cohort_page.sort_by_first_name
+            expected_results = @cohort_page.expected_sids_by_first_name(cohort.member_data)
+            visible_results = @cohort_page.filter_result_all_row_cs_ids cohort
+            @cohort_page.verify_list_view_sorting(expected_results, visible_results)
+            @cohort_page.wait_until(1, "Expected #{expected_results} but got #{visible_results}") { visible_results == expected_results }
+          end
         end
-      end
 
-      it "allows the advisor to export a non-zero list of admits in a cohort using #{cohort.search_criteria.list_filters}" do
-        if cohort.member_data.length.zero?
-          expect(@cohort_page.export_list_button_element.disabled?).to be true
-        else
-          cohort.export_csv = @cohort_page.export_student_list cohort
-          @cohort_page.verify_admits_present_in_export(all_admit_data, cohort.member_data, cohort.export_csv)
+        it "sorts by CS ID all the admits who match #{cohort.search_criteria.inspect}" do
+          if cohort.member_data.length.zero?
+            logger.warn 'Skipping sort-by-cs-id test since there are no results'
+          else
+            @cohort_page.sort_by_cs_id
+            expected_results = cohort.member_data.map { |u| u[:sid].to_i }.sort
+            visible_results = @cohort_page.filter_result_all_row_cs_ids cohort
+            @cohort_page.verify_list_view_sorting(expected_results, visible_results)
+            @cohort_page.wait_until(1, "Expected #{expected_results} but got #{visible_results}") { visible_results == expected_results }
+          end
         end
+
+        it("offers an Export List button for a search #{cohort.search_criteria.inspect}") { expect(@cohort_page.export_list_button?).to be true }
+
+        it "offers links to admit pages for search #{cohort.search_criteria.inspect}" do
+          if cohort.member_data.length.zero?
+            logger.warn 'Skipping admit page link test since there are no results'
+          else
+            cs_id = @cohort_page.filter_result_row_cs_ids.first
+            @cohort_page.click_admit_link cs_id
+            @admit_page.sid_element.when_visible Utils.short_wait
+            expect(@admit_page.sid).to eql(cs_id)
+          end
+        end
+
+        it "can be reloaded using the Back button on an admit page for search #{cohort.search_criteria.inspect}" do
+          if cohort.member_data.length.zero?
+            logger.warn 'Skipping admit page back button test since there are no results'
+          else
+            @admit_page.go_back
+            @cohort_page.wait_until(Utils.short_wait) { @cohort_page.wait_for_search_results == cohort.member_data.length }
+          end
+        end
+
+        it "allows the advisor to export a non-zero list of admits in a cohort using #{cohort.search_criteria.list_filters}" do
+          if cohort.member_data.length.zero?
+            expect(@cohort_page.export_list_button_element.disabled?).to be true
+          else
+            cohort.export_csv = @cohort_page.export_student_list cohort
+            @cohort_page.verify_admits_present_in_export(all_admit_data, cohort.member_data, cohort.export_csv)
+          end
+        end
+
+        it "allows the advisor to export a non-zero list containing no emails for a cohort using #{cohort.search_criteria.list_filters}" do
+          cohort.member_data.length.zero? ? skip : @cohort_page.verify_no_email_in_export(cohort.export_csv)
+        end
+
+        it("allows the advisor to create a cohort using #{cohort.search_criteria.inspect}") { @cohort_page.create_new_cohort cohort }
+
+        it("shows the cohort filters for a cohort using #{cohort.search_criteria.inspect}") { @cohort_page.verify_admit_filters_present cohort }
+
+        it("shows the cohort member count in the sidebar using #{cohort.search_criteria.inspect}") { @cohort_page.wait_for_sidebar_cohort_member_count cohort }
+
+        it("offers no cohort history button for a cohort using #{cohort.search_criteria.inspect}") { expect(@cohort_page.history_button?).to be false }
       end
 
-      it "allows the advisor to export a non-zero list containing no emails for a cohort using #{cohort.search_criteria.list_filters}" do
-        cohort.member_data.length.zero? ? skip : @cohort_page.verify_no_email_in_export(cohort.export_csv)
-      end
+      context 'when the advisor enters invalid filter input' do
 
-      it("allows the advisor to create a cohort using #{cohort.search_criteria.inspect}") { @cohort_page.create_new_cohort cohort }
-
-      it("shows the cohort filters for a cohort using #{cohort.search_criteria.inspect}") { @cohort_page.verify_admit_filters_present cohort }
-
-      it("shows the cohort member count in the sidebar using #{cohort.search_criteria.inspect}") { @cohort_page.wait_for_sidebar_cohort_member_count cohort }
-
-      it("offers no cohort history button for a cohort using #{cohort.search_criteria.inspect}") { expect(@cohort_page.history_button?).to be false }
-    end
-
-    context 'when the advisor enters invalid filter input' do
-
-      before(:all) do
-        @homepage.load_page
-        @homepage.click_sidebar_create_ce3_filtered
-      end
-
-      shared_examples 'dependent range validation' do |filter_name|
         before(:all) do
-          @cohort_page.click_new_filter_button
-          @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option filter_name
+          @homepage.load_page
+          @homepage.click_sidebar_create_ce3_filtered
         end
 
-        it 'an error prompts for numeric input' do
-          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => 'A', 'max' => ''})
-          @cohort_page.depend_char_error_msg_element.when_visible 1
+        shared_examples 'dependent range validation' do |filter_name|
+          before(:all) do
+            @cohort_page.click_new_filter_button
+            @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option filter_name
+          end
+
+          it 'an error prompts for numeric input' do
+            @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => 'A', 'max' => ''})
+            @cohort_page.depend_char_error_msg_element.when_visible 1
+          end
+
+          it 'an error prompts for logical numeric input' do
+            @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '4', 'max' => '0'})
+            @cohort_page.depend_logic_error_msg_element.when_visible 1
+          end
+
+          it 'an error prompts for non-negative numbers' do
+            @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '-1', 'max' => '5'})
+            @cohort_page.depend_char_error_msg_element.when_visible 1
+          end
+
+          it 'no Add button appears without two valid values' do
+            @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '3.5', 'max' => ''})
+            expect(@cohort_page.unsaved_filter_add_button?).to be false
+          end
         end
 
-        it 'an error prompts for logical numeric input' do
-          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '4', 'max' => '0'})
-          @cohort_page.depend_logic_error_msg_element.when_visible 1
+        context 'in the Family Dependents filter' do
+          include_examples 'dependent range validation', 'familyDependentRanges'
         end
 
-        it 'an error prompts for non-negative numbers' do
-          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '-1', 'max' => '5'})
-          @cohort_page.depend_char_error_msg_element.when_visible 1
+        context 'in the Student Dependents filter' do
+          include_examples 'dependent range validation', 'studentDependentRanges'
         end
-
-        it 'no Add button appears without two valid values' do
-          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '3.5', 'max' => ''})
-          expect(@cohort_page.unsaved_filter_add_button?).to be false
-        end
-      end
-
-      context 'in the Family Dependents filter' do
-        include_examples 'dependent range validation', 'familyDependentRanges'
-      end
-
-      context 'in the Student Dependents filter' do
-        include_examples 'dependent range validation', 'studentDependentRanges'
       end
     end
   end

--- a/spec/boac/boac_filtered_cohort_history_spec.rb
+++ b/spec/boac/boac_filtered_cohort_history_spec.rb
@@ -1,55 +1,108 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOA cohort history' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'BOA cohort history' do
 
-  before(:all) do
-    @test = BOACTestConfig.new
-    @test.filtered_history
+    include Logging
 
-    @cohort_1_filters = CohortFilter.new
-    @cohort_1_filters.set_custom_filters major: ['English BA'], gender: ['Female']
-    @cohort_1 = FilteredCohort.new name: "Cohort 1 #{@test.id}", search_criteria: @cohort_1_filters
+    before(:all) do
+      @test = BOACTestConfig.new
+      @test.filtered_history
 
-    @cohort_2_filters = CohortFilter.new
-    @cohort_2_filters.set_custom_filters major: ['History BA'], college: ['Undergrad Non-Degree/NonFinAid']
-    @cohort_2 = FilteredCohort.new name: "Cohort 2 #{@test.id}", search_criteria: @cohort_2_filters
+      @cohort_1_filters = CohortFilter.new
+      @cohort_1_filters.set_custom_filters major: ['English BA'], gender: ['Female']
+      @cohort_1 = FilteredCohort.new name: "Cohort 1 #{@test.id}", search_criteria: @cohort_1_filters
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-    @group_page = BOACGroupPage.new @driver
-    @cohort_history_page = BOACFilteredCohortHistoryPage.new @driver
+      @cohort_2_filters = CohortFilter.new
+      @cohort_2_filters.set_custom_filters major: ['History BA'], college: ['Undergrad Non-Degree/NonFinAid']
+      @cohort_2 = FilteredCohort.new name: "Cohort 2 #{@test.id}", search_criteria: @cohort_2_filters
 
-    @homepage.dev_auth @test.advisor
-    BOACUtils.get_user_filtered_cohorts(@test.advisor, default: true).each do |c|
-      @cohort_page.load_cohort c
-      @cohort_page.delete_cohort c
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
+      @group_page = BOACGroupPage.new @driver
+      @cohort_history_page = BOACFilteredCohortHistoryPage.new @driver
+
+      @homepage.dev_auth @test.advisor
+      BOACUtils.get_user_filtered_cohorts(@test.advisor, default: true).each do |c|
+        @cohort_page.load_cohort c
+        @cohort_page.delete_cohort c
+      end
+      BOACUtils.get_user_curated_groups(@test.advisor).each do |g|
+        @group_page.load_page g
+        @group_page.delete_cohort g
+      end
     end
-    BOACUtils.get_user_curated_groups(@test.advisor).each do |g|
-      @group_page.load_page g
-      @group_page.delete_cohort g
+
+    after(:all) { Utils.quit_browser @driver }
+
+    context 'when a cohort is created' do
+
+      context 'and has members' do
+
+        before(:all) do
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.perform_student_search @cohort_1
+          @cohort_page.create_new_cohort @cohort_1
+          @cohort_page.set_cohort_members(@cohort_1, @test)
+          @cohort_1.history += @cohort_history_page.expected_history_entries(@cohort_1.members, 'ADDED', Time.now)
+          @cohort_page.load_cohort @cohort_1
+          @cohort_page.click_history
+        end
+
+        it 'lists all members as "added" entries' do
+          expect(@cohort_history_page.visible_history_entries).to eql(@cohort_1.history)
+        end
+
+        it 'offers a Back button on the history page' do
+          @cohort_history_page.click_back_to_cohort
+          @cohort_page.wait_for_search_results
+        end
+      end
+
+      context 'and has no members' do
+
+        before(:all) do
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.perform_student_search @cohort_2
+          @cohort_page.create_new_cohort @cohort_2
+          @cohort_page.set_cohort_members(@cohort_2, @test)
+          @cohort_2.history += @cohort_history_page.expected_history_entries(@cohort_2.members, 'ADDED', Time.now)
+          @cohort_page.load_cohort @cohort_2
+          @cohort_page.click_history
+        end
+
+        it 'shows a "no history" message' do
+          @cohort_history_page.no_history_msg_element.when_visible Utils.short_wait
+        end
+
+        it 'offers a Back button on the history page' do
+          @cohort_history_page.click_back_to_cohort
+          @cohort_page.wait_for_search_results
+        end
+      end
     end
-  end
 
-  after(:all) { Utils.quit_browser @driver }
-
-  context 'when a cohort is created' do
-
-    context 'and has members' do
+    context 'when an existing cohort\'s filters are modified' do
 
       before(:all) do
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.perform_student_search @cohort_1
-        @cohort_page.create_new_cohort @cohort_1
-        @cohort_page.set_cohort_members(@cohort_1, @test)
-        @cohort_1.history += @cohort_history_page.expected_history_entries(@cohort_1.members, 'ADDED', Time.now)
+        @initial_members = @cohort_1.members
+        @cohort_1.search_criteria.gender = ['Male']
         @cohort_page.load_cohort @cohort_1
+        @cohort_page.show_filters
+        @cohort_page.edit_filter_and_confirm('Gender', @cohort_1.search_criteria.gender.first)
+        @cohort_page.apply_and_save_cohort
+        @cohort_page.set_cohort_members(@cohort_1, @test)
+        added_members = @cohort_1.members - @initial_members
+        removed_members = @initial_members - @cohort_1.members
+        @cohort_1.history += @cohort_history_page.expected_history_entries(added_members, 'ADDED', Time.now)
+        @cohort_1.history += @cohort_history_page.expected_history_entries(removed_members, 'REMOVED', Time.now)
+        @cohort_1.history = @cohort_1.history.sort_by { |s| [s[:sid], s[:status]] }
         @cohort_page.click_history
       end
 
-      it 'lists all members as "added" entries' do
+      it 'shows the right "added" and "removed" entries' do
         expect(@cohort_history_page.visible_history_entries).to eql(@cohort_1.history)
       end
 
@@ -59,20 +112,41 @@ describe 'BOA cohort history' do
       end
     end
 
-    context 'and has no members' do
+    context 'when an existing cohort\'s members are modified' do
 
       before(:all) do
+        @group = CuratedGroup.new name: "Group #{@test.id}"
+        @cohort_page.click_sidebar_create_curated_group
+        @group_page.create_group_with_bulk_sids(@test.students[0..19], @group)
+        @group_page.wait_for_sidebar_group @group
+
+        @cohort_3_filters = CohortFilter.new
+        @cohort_3_filters.set_custom_filters curated_groups: [@group.id.to_s]
+        @cohort_3 = FilteredCohort.new name: "Cohort 3 #{@test.id}", search_criteria: @cohort_3_filters
+
+        # Restrict the searchable data to the group members
+        group_sids = @group.members.map &:sis_id
+        @test.students.keep_if { |s| group_sids.include? s.sis_id }
+
         @homepage.click_sidebar_create_filtered
-        @cohort_page.perform_student_search @cohort_2
-        @cohort_page.create_new_cohort @cohort_2
-        @cohort_page.set_cohort_members(@cohort_2, @test)
-        @cohort_2.history += @cohort_history_page.expected_history_entries(@cohort_2.members, 'ADDED', Time.now)
-        @cohort_page.load_cohort @cohort_2
+        @cohort_page.perform_student_search @cohort_3
+        @cohort_page.create_new_cohort @cohort_3
+        @cohort_3.history += @cohort_history_page.expected_history_entries(@group.members, 'ADDED', Time.now)
+        @cohort_page.load_cohort @cohort_3
+        @cohort_page.click_history
+
+        @group_page.load_page @group
+        added_members = @test.students[20..29]
+        @group_page.add_comma_sep_sids_to_existing_grp(added_members, @group)
+        @group_page.wait_for_sidebar_group @group
+        @cohort_3.history += @cohort_history_page.expected_history_entries(added_members, 'ADDED', Time.now)
+        @cohort_3.history = @cohort_3.history.sort_by { |s| [s[:sid], s[:status]] }
+        @cohort_page.load_cohort @cohort_3
         @cohort_page.click_history
       end
 
-      it 'shows a "no history" message' do
-        @cohort_history_page.no_history_msg_element.when_visible Utils.short_wait
+      it 'shows the right "added" and "removed" entries' do
+        expect(@cohort_history_page.visible_history_entries).to eql(@cohort_3.history)
       end
 
       it 'offers a Back button on the history page' do
@@ -81,76 +155,4 @@ describe 'BOA cohort history' do
       end
     end
   end
-
-  context 'when an existing cohort\'s filters are modified' do
-
-    before(:all) do
-      @initial_members = @cohort_1.members
-      @cohort_1.search_criteria.gender = ['Male']
-      @cohort_page.load_cohort @cohort_1
-      @cohort_page.show_filters
-      @cohort_page.edit_filter_and_confirm('Gender', @cohort_1.search_criteria.gender.first)
-      @cohort_page.apply_and_save_cohort
-      @cohort_page.set_cohort_members(@cohort_1, @test)
-      added_members = @cohort_1.members - @initial_members
-      removed_members = @initial_members - @cohort_1.members
-      @cohort_1.history += @cohort_history_page.expected_history_entries(added_members, 'ADDED', Time.now)
-      @cohort_1.history += @cohort_history_page.expected_history_entries(removed_members, 'REMOVED', Time.now)
-      @cohort_1.history = @cohort_1.history.sort_by { |s| [s[:sid], s[:status]] }
-      @cohort_page.click_history
-    end
-
-    it 'shows the right "added" and "removed" entries' do
-      expect(@cohort_history_page.visible_history_entries).to eql(@cohort_1.history)
-    end
-
-    it 'offers a Back button on the history page' do
-      @cohort_history_page.click_back_to_cohort
-      @cohort_page.wait_for_search_results
-    end
-  end
-
-  context 'when an existing cohort\'s members are modified' do
-
-    before(:all) do
-      @group = CuratedGroup.new name: "Group #{@test.id}"
-      @cohort_page.click_sidebar_create_curated_group
-      @group_page.create_group_with_bulk_sids(@test.students[0..19], @group)
-      @group_page.wait_for_sidebar_group @group
-
-      @cohort_3_filters = CohortFilter.new
-      @cohort_3_filters.set_custom_filters curated_groups: [@group.id.to_s]
-      @cohort_3 = FilteredCohort.new name: "Cohort 3 #{@test.id}", search_criteria: @cohort_3_filters
-
-      # Restrict the searchable data to the group members
-      group_sids = @group.members.map &:sis_id
-      @test.students.keep_if { |s| group_sids.include? s.sis_id }
-
-      @homepage.click_sidebar_create_filtered
-      @cohort_page.perform_student_search @cohort_3
-      @cohort_page.create_new_cohort @cohort_3
-      @cohort_3.history += @cohort_history_page.expected_history_entries(@group.members, 'ADDED', Time.now)
-      @cohort_page.load_cohort @cohort_3
-      @cohort_page.click_history
-
-      @group_page.load_page @group
-      added_members = @test.students[20..29]
-      @group_page.add_comma_sep_sids_to_existing_grp(added_members, @group)
-      @group_page.wait_for_sidebar_group @group
-      @cohort_3.history += @cohort_history_page.expected_history_entries(added_members, 'ADDED', Time.now)
-      @cohort_3.history = @cohort_3.history.sort_by { |s| [s[:sid], s[:status]] }
-      @cohort_page.load_cohort @cohort_3
-      @cohort_page.click_history
-    end
-
-    it 'shows the right "added" and "removed" entries' do
-      expect(@cohort_history_page.visible_history_entries).to eql(@cohort_3.history)
-    end
-
-    it 'offers a Back button on the history page' do
-      @cohort_history_page.click_back_to_cohort
-      @cohort_page.wait_for_search_results
-    end
-  end
-
 end

--- a/spec/boac/boac_filtered_cohort_spec.rb
+++ b/spec/boac/boac_filtered_cohort_spec.rb
@@ -1,796 +1,799 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC', order: :defined do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'BOAC', order: :defined do
 
-  test = BOACTestConfig.new
-  test.filtered_cohorts
-  pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
+    include Logging
 
-  before(:all) do
-    @driver = Utils.launch_browser test.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
-    @student_page = BOACStudentPage.new @driver
-
-    @homepage.dev_auth test.advisor
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  context 'when an advisor has no filtered cohorts' do
+    test = BOACTestConfig.new
+    test.filtered_cohorts
+    pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
 
     before(:all) do
-      @homepage.load_page
-      pre_existing_cohorts.each do |c|
-        @cohort_page.load_cohort c
-        @cohort_page.delete_cohort c
-      end
+      @driver = Utils.launch_browser test.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
+      @student_page = BOACStudentPage.new @driver
+
+      @homepage.dev_auth test.advisor
     end
 
-    it('shows a No Filtered Cohorts message on the homepage') do
-      @homepage.load_page
-      @homepage.no_filtered_cohorts_msg_element.when_visible Utils.short_wait
-    end
-  end
+    after(:all) { Utils.quit_browser @driver }
 
-  context 'filtered cohort search' do
+    context 'when an advisor has no filtered cohorts' do
 
-    before(:each) { @cohort_page.cancel_cohort if @cohort_page.cancel_cohort_button? && @cohort_page.cancel_cohort_button_element.visible? }
-
-    test.searches.each do |cohort|
-      it "shows all the students sorted by Last Name who match #{cohort.search_criteria.list_filters}" do
-        @cohort_page.click_sidebar_create_filtered
-        @cohort_page.perform_student_search cohort
-        @cohort_page.set_cohort_members(cohort, test)
-        expected = NessieFilterUtils.cohort_by_last_name(test, cohort.search_criteria)
-        if cohort.members.empty?
-          @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count == 0 }
-        else
-          visible = @cohort_page.visible_sids
-          @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
-            visible.sort == expected.sort
-          end
-          @cohort_page.verify_list_view_sorting(expected, visible)
-        end
-      end
-
-      it "shows me a query for #{cohort.search_criteria.list_filters}" do
-        NessieFilterUtils.cohort_by_level(test, cohort.search_criteria)
-      end
-
-      it "shows an Export List button for search #{cohort.search_criteria.list_filters}" do
-        button_enabled = @cohort_page.export_list_button_element.enabled?
-        cohort.members.any? ? (expect(button_enabled).to be true) : (expect(button_enabled).to be false)
-      end
-
-      it("allows the advisor to create a cohort using #{cohort.search_criteria.list_filters}") { @cohort_page.create_new_cohort cohort }
-
-      it("shows the cohort filters for a cohort using #{cohort.search_criteria.list_filters}") { @cohort_page.verify_student_filters_present cohort }
-
-      it "shows the filtered cohort on the homepage with criteria #{cohort.search_criteria.list_filters}" do
+      before(:all) do
         @homepage.load_page
-        @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? cohort.name }
+        pre_existing_cohorts.each do |c|
+          @cohort_page.load_cohort c
+          @cohort_page.delete_cohort c
+        end
       end
 
-      it "shows the filtered cohort member count with criteria #{cohort.search_criteria.list_filters}" do
-        @homepage.wait_until(Utils.short_wait, "Expected #{cohort.members.length} but got #{@homepage.member_count(cohort)}") do
-          @homepage.member_count(cohort) == cohort.members.length
+      it('shows a No Filtered Cohorts message on the homepage') do
+        @homepage.load_page
+        @homepage.no_filtered_cohorts_msg_element.when_visible Utils.short_wait
+      end
+    end
+
+    context 'filtered cohort search' do
+
+      before(:each) { @cohort_page.cancel_cohort if @cohort_page.cancel_cohort_button? && @cohort_page.cancel_cohort_button_element.visible? }
+
+      test.searches.each do |cohort|
+        it "shows all the students sorted by Last Name who match #{cohort.search_criteria.list_filters}" do
+          @cohort_page.click_sidebar_create_filtered
+          @cohort_page.perform_student_search cohort
+          @cohort_page.set_cohort_members(cohort, test)
+          expected = NessieFilterUtils.cohort_by_last_name(test, cohort.search_criteria)
+          if cohort.members.empty?
+            @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count == 0 }
+          else
+            visible = @cohort_page.visible_sids
+            @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
+              visible.sort == expected.sort
+            end
+            @cohort_page.verify_list_view_sorting(expected, visible)
+          end
+        end
+
+        it "shows me a query for #{cohort.search_criteria.list_filters}" do
+          NessieFilterUtils.cohort_by_level(test, cohort.search_criteria)
+        end
+
+        it "shows an Export List button for search #{cohort.search_criteria.list_filters}" do
+          button_enabled = @cohort_page.export_list_button_element.enabled?
+          cohort.members.any? ? (expect(button_enabled).to be true) : (expect(button_enabled).to be false)
+        end
+
+        it("allows the advisor to create a cohort using #{cohort.search_criteria.list_filters}") { @cohort_page.create_new_cohort cohort }
+
+        it("shows the cohort filters for a cohort using #{cohort.search_criteria.list_filters}") { @cohort_page.verify_student_filters_present cohort }
+
+        it "shows the filtered cohort on the homepage with criteria #{cohort.search_criteria.list_filters}" do
+          @homepage.load_page
+          @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? cohort.name }
+        end
+
+        it "shows the filtered cohort member count with criteria #{cohort.search_criteria.list_filters}" do
+          @homepage.wait_until(Utils.short_wait, "Expected #{cohort.members.length} but got #{@homepage.member_count(cohort)}") do
+            @homepage.member_count(cohort) == cohort.members.length
+          end
         end
       end
     end
-  end
 
-  context 'export' do
+    context 'export' do
 
-    before(:all) do
-      # For export tests, pick the most populous cohort
-      @cohort = test.searches.select(&:member_count).sort_by(&:member_count).last
-      @cohort_page.load_cohort @cohort
+      before(:all) do
+        # For export tests, pick the most populous cohort
+        @cohort = test.searches.select(&:member_count).sort_by(&:member_count).last
+        @cohort_page.load_cohort @cohort
+      end
+
+      it "allows the advisor to export a non-empty list of students in a cohort" do
+        parsed_csv = @cohort_page.export_student_list @cohort
+        @cohort_page.verify_student_list_default_export(@cohort.members, parsed_csv)
+      end
+
+      it "allows the advisor to choose columns to include when exporting a cohort" do
+        parsed_csv = @cohort_page.export_custom_student_list @cohort
+        @cohort_page.verify_student_list_custom_export(@cohort.members, parsed_csv)
+      end
     end
 
-    it "allows the advisor to export a non-empty list of students in a cohort" do
-      parsed_csv = @cohort_page.export_student_list @cohort
-      @cohort_page.verify_student_list_default_export(@cohort.members, parsed_csv)
-    end
+    context 'sorting' do
 
-    it "allows the advisor to choose columns to include when exporting a cohort" do
-      parsed_csv = @cohort_page.export_custom_student_list @cohort
-      @cohort_page.verify_student_list_custom_export(@cohort.members, parsed_csv)
-    end
-  end
+      before(:all) do
+        # For sorting tests, pick the most populous cohort
+        @cohort = test.searches.select(&:member_count).sort_by(&:member_count).last
+        @cohort_page.load_cohort @cohort
+      end
 
-  context 'sorting' do
-
-    before(:all) do
-      # For sorting tests, pick the most populous cohort
-      @cohort = test.searches.select(&:member_count).sort_by(&:member_count).last
-      @cohort_page.load_cohort @cohort
-    end
-
-    it "sorts by First Name" do
-      @cohort_page.sort_by_first_name
-      expected = NessieFilterUtils.cohort_by_first_name(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
-
-    it "sorts by Team" do
-      if [BOACDepartments::ADMIN, BOACDepartments::ASC].include? test.dept
-        @cohort_page.sort_by_team
-        expected = NessieFilterUtils.cohort_by_team(test, @cohort.search_criteria)
+      it "sorts by First Name" do
+        @cohort_page.sort_by_first_name
+        expected = NessieFilterUtils.cohort_by_first_name(test, @cohort.search_criteria)
         @cohort_page.compare_visible_sids_to_expected expected
       end
-    end
 
-    it "sorts by GPA ascending" do
-      @cohort_page.sort_by_gpa_cumulative
-      expected = NessieFilterUtils.cohort_by_gpa_asc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Team" do
+        if [BOACDepartments::ADMIN, BOACDepartments::ASC].include? test.dept
+          @cohort_page.sort_by_team
+          expected = NessieFilterUtils.cohort_by_team(test, @cohort.search_criteria)
+          @cohort_page.compare_visible_sids_to_expected expected
+        end
+      end
 
-    it "sorts by GPA descending" do
-      @cohort_page.sort_by_gpa_cumulative_desc
-      expected = NessieFilterUtils.cohort_by_gpa_desc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by GPA ascending" do
+        @cohort_page.sort_by_gpa_cumulative
+        expected = NessieFilterUtils.cohort_by_gpa_asc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by GPA ascending (term #{BOACUtils.previous_term_code})" do
-      term = BOACUtils.previous_term_code
-      @cohort_page.sort_by_last_term_gpa term
-      expected = NessieFilterUtils.cohort_by_gpa_last_term_asc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by GPA descending" do
+        @cohort_page.sort_by_gpa_cumulative_desc
+        expected = NessieFilterUtils.cohort_by_gpa_desc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by GPA descending (term #{BOACUtils.previous_term_code})" do
-      term = BOACUtils.previous_term_code
-      @cohort_page.sort_by_last_term_gpa_desc term
-      expected = NessieFilterUtils.cohort_by_gpa_last_term_desc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by GPA ascending (term #{BOACUtils.previous_term_code})" do
+        term = BOACUtils.previous_term_code
+        @cohort_page.sort_by_last_term_gpa term
+        expected = NessieFilterUtils.cohort_by_gpa_last_term_asc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by GPA ascending (#{BOACUtils.previous_term_code BOACUtils.previous_term_code})" do
-      term = BOACUtils.previous_term_code BOACUtils.previous_term_code
-      @cohort_page.sort_by_last_term_gpa term
-      expected = NessieFilterUtils.cohort_by_gpa_last_last_term_asc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by GPA descending (term #{BOACUtils.previous_term_code})" do
+        term = BOACUtils.previous_term_code
+        @cohort_page.sort_by_last_term_gpa_desc term
+        expected = NessieFilterUtils.cohort_by_gpa_last_term_desc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by GPA descending (#{BOACUtils.previous_term_code BOACUtils.previous_term_code})" do
-      term = BOACUtils.previous_term_code BOACUtils.previous_term_code
-      @cohort_page.sort_by_last_term_gpa_desc term
-      expected = NessieFilterUtils.cohort_by_gpa_last_last_term_desc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by GPA ascending (#{BOACUtils.previous_term_code BOACUtils.previous_term_code})" do
+        term = BOACUtils.previous_term_code BOACUtils.previous_term_code
+        @cohort_page.sort_by_last_term_gpa term
+        expected = NessieFilterUtils.cohort_by_gpa_last_last_term_asc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Level" do
-      @cohort_page.sort_by_level
-      expected = NessieFilterUtils.cohort_by_level(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by GPA descending (#{BOACUtils.previous_term_code BOACUtils.previous_term_code})" do
+        term = BOACUtils.previous_term_code BOACUtils.previous_term_code
+        @cohort_page.sort_by_last_term_gpa_desc term
+        expected = NessieFilterUtils.cohort_by_gpa_last_last_term_desc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Major" do
-      @cohort_page.sort_by_major
-      expected = NessieFilterUtils.cohort_by_major(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Level" do
+        @cohort_page.sort_by_level
+        expected = NessieFilterUtils.cohort_by_level(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Entering Term" do
-      @cohort_page.sort_by_entering_term
-      expected = NessieFilterUtils.cohort_by_matriculation(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Major" do
+        @cohort_page.sort_by_major
+        expected = NessieFilterUtils.cohort_by_major(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Terms in Attendance ascending" do
-      @cohort_page.sort_by_terms_in_attend
-      expected = NessieFilterUtils.cohort_by_terms_in_attend_asc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Entering Term" do
+        @cohort_page.sort_by_entering_term
+        expected = NessieFilterUtils.cohort_by_matriculation(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Terms in Attendance descending" do
-      @cohort_page.sort_by_terms_in_attend_desc
-      expected = NessieFilterUtils.cohort_by_terms_in_attend_desc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Terms in Attendance ascending" do
+        @cohort_page.sort_by_terms_in_attend
+        expected = NessieFilterUtils.cohort_by_terms_in_attend_asc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Units In Progress ascending" do
-      @cohort_page.sort_by_units_in_progress
-      expected = NessieFilterUtils.cohort_by_units_in_prog_asc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Terms in Attendance descending" do
+        @cohort_page.sort_by_terms_in_attend_desc
+        expected = NessieFilterUtils.cohort_by_terms_in_attend_desc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Units In Progress descending" do
-      @cohort_page.sort_by_units_in_progress_desc
-      expected = NessieFilterUtils.cohort_by_units_in_prog_desc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Units In Progress ascending" do
+        @cohort_page.sort_by_units_in_progress
+        expected = NessieFilterUtils.cohort_by_units_in_prog_asc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Units Completed ascending" do
-      @cohort_page.sort_by_units_completed
-      expected = NessieFilterUtils.cohort_by_units_complete_asc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Units In Progress descending" do
+        @cohort_page.sort_by_units_in_progress_desc
+        expected = NessieFilterUtils.cohort_by_units_in_prog_desc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "sorts by Units Completed descending" do
-      @cohort_page.sort_by_units_completed_desc
-      expected = NessieFilterUtils.cohort_by_units_complete_desc(test, @cohort.search_criteria)
-      @cohort_page.compare_visible_sids_to_expected expected
-    end
+      it "sorts by Units Completed ascending" do
+        @cohort_page.sort_by_units_completed
+        expected = NessieFilterUtils.cohort_by_units_complete_asc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    ### HOMEPAGE COHORTS ###
+      it "sorts by Units Completed descending" do
+        @cohort_page.sort_by_units_completed_desc
+        expected = NessieFilterUtils.cohort_by_units_complete_desc(test, @cohort.search_criteria)
+        @cohort_page.compare_visible_sids_to_expected expected
+      end
 
-    it "shows the first 50 filtered cohort members who have alerts on the homepage" do
-      @homepage.load_page
-      @homepage.expand_member_rows @cohort
-      @homepage.verify_member_alerts(@cohort, test.advisor)
-    end
+      ### HOMEPAGE COHORTS ###
 
-    it "by default sorts by alert count descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = @homepage.expected_sids_by_alerts_desc @cohort.members
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
+      it "shows the first 50 filtered cohort members who have alerts on the homepage" do
+        @homepage.load_page
+        @homepage.expand_member_rows @cohort
+        @homepage.verify_member_alerts(@cohort, test.advisor)
+      end
+
+      it "by default sorts by alert count descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = @homepage.expected_sids_by_alerts_desc @cohort.members
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by alert count ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = @homepage.expected_sids_by_alerts @cohort.members
+        @homepage.sort_by_alert_count @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") { @homepage.all_row_sids(@cohort) == expected_sequence }
+      end
+
+      it "allows the advisor to sort by name ascending cohort the first 50 members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_last_name_asc @cohort.members.map &:sis_id
+        @homepage.sort_by_name @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by name descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_last_name_desc @cohort.members.map &:sis_id
+        @homepage.sort_by_name @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by SID ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = @cohort.members.map(&:sis_id).sort
+        @homepage.sort_by_sid @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by SID descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = @cohort.members.map(&:sis_id).sort.reverse
+        @homepage.sort_by_sid @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by major ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_major_asc @cohort.members.map &:sis_id
+        @homepage.sort_by_major @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by major descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_major_desc @cohort.members.map &:sis_id
+        @homepage.sort_by_major @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by expected grad date ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_grad_term_asc @cohort.members.map &:sis_id
+        @homepage.sort_by_expected_grad @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by expected grad date descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_grad_term_desc @cohort.members.map &:sis_id
+        @homepage.sort_by_expected_grad @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by term units ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_units_in_prog_asc @cohort.members.map &:sis_id
+        @homepage.sort_by_term_units @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by term units descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_units_in_prog_desc @cohort.members.map &:sis_id
+        @homepage.sort_by_term_units @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by cumulative units ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_units_complete_asc @cohort.members.map &:sis_id
+        @homepage.sort_by_cumul_units @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by cumulative descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_units_complete_desc @cohort.members.map &:sis_id
+        @homepage.sort_by_cumul_units @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by GPA ascending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_gpa_asc @cohort.members.map &:sis_id
+        @homepage.sort_by_gpa @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "allows the advisor to sort by GPA descending the first 50 cohort members who have alerts on the homepage" do
+        expected_sequence = NessieFilterUtils.list_by_gpa_desc @cohort.members.map &:sis_id
+        @homepage.sort_by_gpa @cohort
+        @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
+          @homepage.all_row_sids(@cohort) == expected_sequence
+        end
+      end
+
+      it "offers a link to the filtered cohort" do
+        @homepage.click_filtered_cohort @cohort
+        @cohort_page.cohort_heading(@cohort).when_visible Utils.medium_wait
       end
     end
 
-    it "allows the advisor to sort by alert count ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = @homepage.expected_sids_by_alerts @cohort.members
-      @homepage.sort_by_alert_count @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") { @homepage.all_row_sids(@cohort) == expected_sequence }
-    end
+    context 'validation' do
 
-    it "allows the advisor to sort by name ascending cohort the first 50 members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_last_name_asc @cohort.members.map &:sis_id
-      @homepage.sort_by_name @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
+      it 'requires a title' do
+        @homepage.click_sidebar_create_filtered
+        @cohort_page.perform_student_search test.searches.first
+        @cohort_page.click_save_cohort_button_one
+        expect(@cohort_page.save_cohort_button_two_element.disabled?).to be true
+      end
+
+      it 'truncates a title over 255 characters' do
+        cohort = FilteredCohort.new({name: "#{test.id}#{'A loooooong title ' * 15}?"})
+        @homepage.load_page
+        @homepage.click_sidebar_create_filtered
+        @cohort_page.perform_student_search test.searches.first
+        @cohort_page.save_and_name_cohort cohort
+        cohort.name = cohort.name[0..254]
+        @cohort_page.wait_for_filtered_cohort cohort
+        test.searches << cohort
+      end
+
+      it 'requires that a title be unique among the user\'s existing cohorts' do
+        cohort = FilteredCohort.new({name: test.searches.first.name})
+        @cohort_page.click_sidebar_create_filtered
+        @cohort_page.perform_student_search test.searches.first
+        @cohort_page.save_and_name_cohort cohort
+        @cohort_page.dupe_filtered_name_msg_element.when_visible Utils.short_wait
       end
     end
 
-    it "allows the advisor to sort by name descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_last_name_desc @cohort.members.map &:sis_id
-      @homepage.sort_by_name @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
+    context 'when the advisor views its cohorts' do
+
+      it('shows only the advisor\'s cohorts on the homepage') do
+        test.searches.flatten!
+        @homepage.load_page
+        @homepage.wait_until(Utils.short_wait) { @homepage.filtered_cohorts.any? }
+        @homepage.wait_until(1, "Expected #{(test.searches.map &:name).sort}, but got #{@homepage.filtered_cohorts.sort}") do
+          @homepage.filtered_cohorts.sort == (test.searches.map &:name).sort
+        end
       end
     end
 
-    it "allows the advisor to sort by SID ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = @cohort.members.map(&:sis_id).sort
-      @homepage.sort_by_sid @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
+    context 'when the advisor enters invalid filter input' do
+
+      before(:all) { @homepage.click_sidebar_create_filtered }
+
+      shared_examples 'GPA range validation' do |filter_name|
+        before(:all) do
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option filter_name
+        end
+
+        it 'an error prompts for numeric input' do
+          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => 'A', 'max' => ''})
+          @cohort_page.gpa_filter_range_error_element.when_visible 1
+        end
+
+        it 'an error prompts for logical numeric input' do
+          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '4', 'max' => '0'})
+          @cohort_page.gpa_filter_logical_error_element.when_visible 1
+        end
+
+        it 'an error prompts for numeric input from 0 to 4' do
+          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '-1', 'max' => '5'})
+          @cohort_page.gpa_filter_range_error_element.when_visible 1
+        end
+
+        it 'no Add button appears without two valid values' do
+          @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '3.5', 'max' => ''})
+          expect(@cohort_page.unsaved_filter_add_button?).to be false
+        end
+      end
+
+      context 'in the cumulative GPA filter' do
+        include_examples 'GPA range validation', 'gpaRanges'
+      end
+
+      context 'in the term GPA filter' do
+        include_examples 'GPA range validation', 'lastTermGpaRanges'
+      end
+
+      context 'in the Last Name filter' do
+
+        before(:all) do
+          @cohort_page.unsaved_filter_cancel_button
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option 'lastNameRanges'
+        end
+
+        it 'an error prompts for logical input' do
+          @cohort_page.choose_new_filter_sub_option('lastNameRanges', {'min' => 'Z', 'max' => 'A'})
+          @cohort_page.last_name_filter_logical_error_element.when_visible 1
+        end
+
+        it 'no Add button appears without two valid values' do
+          @cohort_page.choose_new_filter_sub_option('lastNameRanges', {'min' => 'P', 'max' => ''})
+          expect(@cohort_page.unsaved_filter_add_button?).to be false
+        end
       end
     end
 
-    it "allows the advisor to sort by SID descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = @cohort.members.map(&:sis_id).sort.reverse
-      @homepage.sort_by_sid @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
+    context 'when the advisor edits a cohort\'s search filters' do
 
-    it "allows the advisor to sort by major ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_major_asc @cohort.members.map &:sis_id
-      @homepage.sort_by_major @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
+      before(:all) { @cohort_page.search_and_create_new_cohort(test.default_cohort, default: true) }
 
-    it "allows the advisor to sort by major descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_major_desc @cohort.members.map &:sis_id
-      @homepage.sort_by_major @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by expected grad date ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_grad_term_asc @cohort.members.map &:sis_id
-      @homepage.sort_by_expected_grad @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by expected grad date descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_grad_term_desc @cohort.members.map &:sis_id
-      @homepage.sort_by_expected_grad @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by term units ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_units_in_prog_asc @cohort.members.map &:sis_id
-      @homepage.sort_by_term_units @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by term units descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_units_in_prog_desc @cohort.members.map &:sis_id
-      @homepage.sort_by_term_units @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by cumulative units ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_units_complete_asc @cohort.members.map &:sis_id
-      @homepage.sort_by_cumul_units @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by cumulative descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_units_complete_desc @cohort.members.map &:sis_id
-      @homepage.sort_by_cumul_units @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by GPA ascending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_gpa_asc @cohort.members.map &:sis_id
-      @homepage.sort_by_gpa @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "allows the advisor to sort by GPA descending the first 50 cohort members who have alerts on the homepage" do
-      expected_sequence = NessieFilterUtils.list_by_gpa_desc @cohort.members.map &:sis_id
-      @homepage.sort_by_gpa @cohort
-      @homepage.wait_until(1, "Expected #{expected_sequence}, but got #{@homepage.all_row_sids @cohort}") do
-        @homepage.all_row_sids(@cohort) == expected_sequence
-      end
-    end
-
-    it "offers a link to the filtered cohort" do
-      @homepage.click_filtered_cohort @cohort
-      @cohort_page.cohort_heading(@cohort).when_visible Utils.medium_wait
-    end
-  end
-
-  context 'validation' do
-
-    it 'requires a title' do
-      @homepage.click_sidebar_create_filtered
-      @cohort_page.perform_student_search test.searches.first
-      @cohort_page.click_save_cohort_button_one
-      expect(@cohort_page.save_cohort_button_two_element.disabled?).to be true
-    end
-
-    it 'truncates a title over 255 characters' do
-      cohort = FilteredCohort.new({name: "#{test.id}#{'A loooooong title ' * 15}?"})
-      @homepage.load_page
-      @homepage.click_sidebar_create_filtered
-      @cohort_page.perform_student_search test.searches.first
-      @cohort_page.save_and_name_cohort cohort
-      cohort.name = cohort.name[0..254]
-      @cohort_page.wait_for_filtered_cohort cohort
-      test.searches << cohort
-    end
-
-    it 'requires that a title be unique among the user\'s existing cohorts' do
-      cohort = FilteredCohort.new({name: test.searches.first.name})
-      @cohort_page.click_sidebar_create_filtered
-      @cohort_page.perform_student_search test.searches.first
-      @cohort_page.save_and_name_cohort cohort
-      @cohort_page.dupe_filtered_name_msg_element.when_visible Utils.short_wait
-    end
-  end
-
-  context 'when the advisor views its cohorts' do
-
-    it('shows only the advisor\'s cohorts on the homepage') do
-      test.searches.flatten!
-      @homepage.load_page
-      @homepage.wait_until(Utils.short_wait) { @homepage.filtered_cohorts.any? }
-      @homepage.wait_until(1, "Expected #{(test.searches.map &:name).sort}, but got #{@homepage.filtered_cohorts.sort}") do
-        @homepage.filtered_cohorts.sort == (test.searches.map &:name).sort
-      end
-    end
-  end
-
-  context 'when the advisor enters invalid filter input' do
-
-    before(:all) { @homepage.click_sidebar_create_filtered }
-
-    shared_examples 'GPA range validation' do |filter_name|
-      before(:all) do
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option filter_name
+      before(:each) do
+        if @cohort_page.cohort_update_button?
+          @cohort_page.wait_for_update_and_click @cohort_page.cohort_update_cancel_button_element
+        end
       end
 
-      it 'an error prompts for numeric input' do
-        @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => 'A', 'max' => ''})
-        @cohort_page.gpa_filter_range_error_element.when_visible 1
-      end
-
-      it 'an error prompts for logical numeric input' do
-        @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '4', 'max' => '0'})
-        @cohort_page.gpa_filter_logical_error_element.when_visible 1
-      end
-
-      it 'an error prompts for numeric input from 0 to 4' do
-        @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '-1', 'max' => '5'})
-        @cohort_page.gpa_filter_range_error_element.when_visible 1
-      end
-
-      it 'no Add button appears without two valid values' do
-        @cohort_page.choose_new_filter_sub_option(filter_name, {'min' => '3.5', 'max' => ''})
-        expect(@cohort_page.unsaved_filter_add_button?).to be false
-      end
-    end
-
-    context 'in the cumulative GPA filter' do
-      include_examples 'GPA range validation', 'gpaRanges'
-    end
-
-    context 'in the term GPA filter' do
-      include_examples 'GPA range validation', 'lastTermGpaRanges'
-    end
-
-    context 'in the Last Name filter' do
-
-      before(:all) do
-        @cohort_page.unsaved_filter_cancel_button
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option 'lastNameRanges'
-      end
-
-      it 'an error prompts for logical input' do
-        @cohort_page.choose_new_filter_sub_option('lastNameRanges', {'min' => 'Z', 'max' => 'A'})
-        @cohort_page.last_name_filter_logical_error_element.when_visible 1
-      end
-
-      it 'no Add button appears without two valid values' do
-        @cohort_page.choose_new_filter_sub_option('lastNameRanges', {'min' => 'P', 'max' => ''})
-        expect(@cohort_page.unsaved_filter_add_button?).to be false
-      end
-    end
-  end
-
-  context 'when the advisor edits a cohort\'s search filters' do
-
-    before(:all) { @cohort_page.search_and_create_new_cohort(test.default_cohort, default: true) }
-
-    before(:each) do
-      if @cohort_page.cohort_update_button?
-        @cohort_page.wait_for_update_and_click @cohort_page.cohort_update_cancel_button_element
-      end
-    end
-
-    it 'allows the advisor to edit an Academic Standing filter' do
-      test.default_cohort.search_criteria.academic_standing = ['Good Standing']
-      @cohort_page.edit_filter_and_confirm('Academic Standing', test.default_cohort.search_criteria.academic_standing.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Academic Standing filter' do
-      test.default_cohort.search_criteria.academic_standing.shift
-      @cohort_page.remove_filter_of_type 'Academic Standing'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a College filter' do
-      test.default_cohort.search_criteria.college = ['Undergrad Chemistry']
-      @cohort_page.edit_filter_and_confirm('College', test.default_cohort.search_criteria.college.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a College filter' do
-      test.default_cohort.search_criteria.college.shift
-      @cohort_page.remove_filter_of_type 'College'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a cumulative GPA filter' do
-      test.default_cohort.search_criteria.gpa = [{'min' => '3.00', 'max' => '4'}]
-      @cohort_page.edit_filter_and_confirm('GPA (Cumulative)', test.default_cohort.search_criteria.gpa.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a cumulative GPA filter' do
-      test.default_cohort.search_criteria.gpa.shift
-      @cohort_page.remove_filter_of_type 'GPA (Cumulative)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a term GPA filter' do
-      test.default_cohort.search_criteria.gpa_last_term = [{'min' => '2', 'max' => '3.80'}]
-      @cohort_page.edit_filter_and_confirm('GPA (Last Term)', test.default_cohort.search_criteria.gpa_last_term.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a term GPA filter' do
-      test.default_cohort.search_criteria.gpa_last_term.shift
-      @cohort_page.remove_filter_of_type 'GPA (Last Term)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Level filter' do
-      test.default_cohort.search_criteria.level = ['Junior (60-89 Units)']
-      @cohort_page.edit_filter_and_confirm('Level', test.default_cohort.search_criteria.level.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Level filter' do
-      test.default_cohort.search_criteria.level.shift
-      @cohort_page.remove_filter_of_type 'Level'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Units Completed filter' do
-      test.default_cohort.search_criteria.units_completed = ['60 - 89']
-      @cohort_page.edit_filter_and_confirm('Units Completed', test.default_cohort.search_criteria.units_completed.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Units Completed filter' do
-      test.default_cohort.search_criteria.units_completed.shift
-      @cohort_page.remove_filter_of_type 'Units Completed'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit an Intended Major filter' do
-      test.default_cohort.search_criteria.intended_major = ['History BA']
-      @cohort_page.edit_filter_and_confirm('Intended Major', test.default_cohort.search_criteria.intended_major.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Intended Major filter' do
-      test.default_cohort.search_criteria.intended_major.shift
-      @cohort_page.remove_filter_of_type 'Intended Major'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Major filter' do
-      test.default_cohort.search_criteria.major = ['Bioengineering BS']
-      @cohort_page.edit_filter_and_confirm('Major', test.default_cohort.search_criteria.major.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Major filter' do
-      test.default_cohort.search_criteria.major.shift
-      @cohort_page.remove_filter_of_type 'Major'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Minor filter' do
-      test.default_cohort.search_criteria.minor = ['History UG']
-      @cohort_page.edit_filter_and_confirm('Minor', test.default_cohort.search_criteria.minor.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Minor filter' do
-      test.default_cohort.search_criteria.minor.shift
-      @cohort_page.remove_filter_of_type 'Minor'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Transfer Student filter' do
-      test.default_cohort.search_criteria.transfer_student = nil
-      @cohort_page.remove_filter_of_type 'Transfer Student'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit an Entering Term filter' do
-      new_term_id = (test.default_cohort.search_criteria.entering_terms.first.to_i - 10).to_s
-      test.default_cohort.search_criteria.entering_terms = [new_term_id]
-      @cohort_page.edit_filter_and_confirm('Entering Term', test.default_cohort.search_criteria.entering_terms.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Entering Term filter' do
-      test.default_cohort.search_criteria.entering_terms.shift
-      @cohort_page.remove_filter_of_type 'Entering Term'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit an Expected Graduation Term filter' do
-      new_term_id = (test.default_cohort.search_criteria.expected_grad_terms.first.to_i + 10).to_s
-      test.default_cohort.search_criteria.expected_grad_terms = [new_term_id]
-      @cohort_page.edit_filter_and_confirm('Expected Graduation Term', test.default_cohort.search_criteria.expected_grad_terms.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Expected Graduation Term filter' do
-      test.default_cohort.search_criteria.expected_grad_terms.shift
-      @cohort_page.remove_filter_of_type 'Expected Graduation Term'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Unrepresented Minority filter' do
-      test.default_cohort.search_criteria.underrepresented_minority = nil
-      @cohort_page.remove_filter_of_type 'Underrepresented Minority'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit an Ethnicity filter' do
-      test.default_cohort.search_criteria.ethnicity = ['Thai']
-      @cohort_page.edit_filter_and_confirm('Ethnicity', test.default_cohort.search_criteria.ethnicity.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Ethnicity filter' do
-      test.default_cohort.search_criteria.ethnicity.shift
-      @cohort_page.remove_filter_of_type 'Ethnicity'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Visa Type filter' do
-      test.default_cohort.search_criteria.visa_type = ['Permanent Resident']
-      @cohort_page.edit_filter_and_confirm('Visa Type', test.default_cohort.search_criteria.visa_type.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Visa Type filter' do
-      test.default_cohort.search_criteria.visa_type.shift
-      @cohort_page.remove_filter_of_type 'Visa Type'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Gender filter' do
-      test.default_cohort.search_criteria.gender = ['Female']
-      @cohort_page.edit_filter_and_confirm('Gender', test.default_cohort.search_criteria.gender.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Gender filter' do
-      test.default_cohort.search_criteria.gender.shift
-      @cohort_page.remove_filter_of_type 'Gender'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit an Ethnicity (COE) filter' do
-      test.default_cohort.search_criteria.coe_ethnicity = ['Mexican / Mexican-American / Chicano']
-      @cohort_page.edit_filter_and_confirm('Ethnicity (COE)', test.default_cohort.search_criteria.coe_ethnicity.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Ethnicity (COE) filter' do
-      test.default_cohort.search_criteria.coe_ethnicity.shift
-      @cohort_page.remove_filter_of_type 'Ethnicity (COE)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Gender (COE) filter' do
-      test.default_cohort.search_criteria.coe_gender = ['Male']
-      @cohort_page.edit_filter_and_confirm('Gender (COE)', test.default_cohort.search_criteria.coe_gender.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Gender (COE) filter' do
-      test.default_cohort.search_criteria.coe_gender.shift
-      @cohort_page.remove_filter_of_type 'Gender (COE)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Underrepresented Minority (COE) filter' do
-      test.default_cohort.search_criteria.coe_underrepresented_minority = false
-      @cohort_page.remove_filter_of_type 'Underrepresented Minority (COE)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Inactive (ASC) filter' do
-      test.default_cohort.search_criteria.asc_inactive = nil
-      @cohort_page.remove_filter_of_type 'Inactive (ASC)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove an Intensive filter' do
-      test.default_cohort.search_criteria.asc_intensive = false
-      @cohort_page.remove_filter_of_type 'Intensive'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Team filter' do
-      test.default_cohort.search_criteria.asc_team = [Squad::WCR]
-      @cohort_page.edit_filter_and_confirm('Team', test.default_cohort.search_criteria.asc_team.first.name)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Team filter' do
-      test.default_cohort.search_criteria.asc_team.shift
-      @cohort_page.remove_filter_of_type 'Team'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a PREP filter' do
-      test.default_cohort.search_criteria.coe_prep = ['T-PREP']
-      @cohort_page.edit_filter_and_confirm('PREP', test.default_cohort.search_criteria.coe_prep.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a PREP filter' do
-      test.default_cohort.search_criteria.coe_prep.shift
-      @cohort_page.remove_filter_of_type 'PREP'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a Last Name filter' do
-      test.default_cohort.search_criteria.last_name = [{'min' => 'B', 'max' => 'Y'}]
-      @cohort_page.edit_filter_and_confirm('Last Name', test.default_cohort.search_criteria.last_name.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Last Name filter' do
-      test.default_cohort.search_criteria.last_name = nil
-      @cohort_page.remove_filter_of_type 'Last Name'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to edit a My Students filter' do
-      if test.default_cohort.search_criteria.cohort_owner_academic_plans
-        test.default_cohort.search_criteria.cohort_owner_academic_plans = ['*']
-        @cohort_page.edit_filter_and_confirm('My Students', '*')
+      it 'allows the advisor to edit an Academic Standing filter' do
+        test.default_cohort.search_criteria.academic_standing = ['Good Standing']
+        @cohort_page.edit_filter_and_confirm('Academic Standing', test.default_cohort.search_criteria.academic_standing.first)
         @cohort_page.verify_student_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for editing My Students since the filter is not available to the user'
       end
-    end
 
-    it 'allows the advisor to remove a My Students filter' do
-      if test.default_cohort.search_criteria.cohort_owner_academic_plans
-        test.default_cohort.search_criteria.cohort_owner_academic_plans.shift
-        @cohort_page.remove_filter_of_type 'My Students'
+      it 'allows the advisor to remove an Academic Standing filter' do
+        test.default_cohort.search_criteria.academic_standing.shift
+        @cohort_page.remove_filter_of_type 'Academic Standing'
         @cohort_page.verify_student_filters_present test.default_cohort
-      else
-        logger.warn 'Skipping test for removing My Students since the filter is not available to the user'
+      end
+
+      it 'allows the advisor to edit a College filter' do
+        test.default_cohort.search_criteria.college = ['Undergrad Chemistry']
+        @cohort_page.edit_filter_and_confirm('College', test.default_cohort.search_criteria.college.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a College filter' do
+        test.default_cohort.search_criteria.college.shift
+        @cohort_page.remove_filter_of_type 'College'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a cumulative GPA filter' do
+        test.default_cohort.search_criteria.gpa = [{'min' => '3.00', 'max' => '4'}]
+        @cohort_page.edit_filter_and_confirm('GPA (Cumulative)', test.default_cohort.search_criteria.gpa.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a cumulative GPA filter' do
+        test.default_cohort.search_criteria.gpa.shift
+        @cohort_page.remove_filter_of_type 'GPA (Cumulative)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a term GPA filter' do
+        test.default_cohort.search_criteria.gpa_last_term = [{'min' => '2', 'max' => '3.80'}]
+        @cohort_page.edit_filter_and_confirm('GPA (Last Term)', test.default_cohort.search_criteria.gpa_last_term.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a term GPA filter' do
+        test.default_cohort.search_criteria.gpa_last_term.shift
+        @cohort_page.remove_filter_of_type 'GPA (Last Term)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Level filter' do
+        test.default_cohort.search_criteria.level = ['Junior (60-89 Units)']
+        @cohort_page.edit_filter_and_confirm('Level', test.default_cohort.search_criteria.level.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Level filter' do
+        test.default_cohort.search_criteria.level.shift
+        @cohort_page.remove_filter_of_type 'Level'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Units Completed filter' do
+        test.default_cohort.search_criteria.units_completed = ['60 - 89']
+        @cohort_page.edit_filter_and_confirm('Units Completed', test.default_cohort.search_criteria.units_completed.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Units Completed filter' do
+        test.default_cohort.search_criteria.units_completed.shift
+        @cohort_page.remove_filter_of_type 'Units Completed'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit an Intended Major filter' do
+        test.default_cohort.search_criteria.intended_major = ['History BA']
+        @cohort_page.edit_filter_and_confirm('Intended Major', test.default_cohort.search_criteria.intended_major.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Intended Major filter' do
+        test.default_cohort.search_criteria.intended_major.shift
+        @cohort_page.remove_filter_of_type 'Intended Major'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Major filter' do
+        test.default_cohort.search_criteria.major = ['Bioengineering BS']
+        @cohort_page.edit_filter_and_confirm('Major', test.default_cohort.search_criteria.major.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Major filter' do
+        test.default_cohort.search_criteria.major.shift
+        @cohort_page.remove_filter_of_type 'Major'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Minor filter' do
+        test.default_cohort.search_criteria.minor = ['History UG']
+        @cohort_page.edit_filter_and_confirm('Minor', test.default_cohort.search_criteria.minor.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Minor filter' do
+        test.default_cohort.search_criteria.minor.shift
+        @cohort_page.remove_filter_of_type 'Minor'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Transfer Student filter' do
+        test.default_cohort.search_criteria.transfer_student = nil
+        @cohort_page.remove_filter_of_type 'Transfer Student'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit an Entering Term filter' do
+        new_term_id = (test.default_cohort.search_criteria.entering_terms.first.to_i - 10).to_s
+        test.default_cohort.search_criteria.entering_terms = [new_term_id]
+        @cohort_page.edit_filter_and_confirm('Entering Term', test.default_cohort.search_criteria.entering_terms.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Entering Term filter' do
+        test.default_cohort.search_criteria.entering_terms.shift
+        @cohort_page.remove_filter_of_type 'Entering Term'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit an Expected Graduation Term filter' do
+        new_term_id = (test.default_cohort.search_criteria.expected_grad_terms.first.to_i + 10).to_s
+        test.default_cohort.search_criteria.expected_grad_terms = [new_term_id]
+        @cohort_page.edit_filter_and_confirm('Expected Graduation Term', test.default_cohort.search_criteria.expected_grad_terms.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Expected Graduation Term filter' do
+        test.default_cohort.search_criteria.expected_grad_terms.shift
+        @cohort_page.remove_filter_of_type 'Expected Graduation Term'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Unrepresented Minority filter' do
+        test.default_cohort.search_criteria.underrepresented_minority = nil
+        @cohort_page.remove_filter_of_type 'Underrepresented Minority'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit an Ethnicity filter' do
+        test.default_cohort.search_criteria.ethnicity = ['Thai']
+        @cohort_page.edit_filter_and_confirm('Ethnicity', test.default_cohort.search_criteria.ethnicity.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Ethnicity filter' do
+        test.default_cohort.search_criteria.ethnicity.shift
+        @cohort_page.remove_filter_of_type 'Ethnicity'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Visa Type filter' do
+        test.default_cohort.search_criteria.visa_type = ['Permanent Resident']
+        @cohort_page.edit_filter_and_confirm('Visa Type', test.default_cohort.search_criteria.visa_type.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Visa Type filter' do
+        test.default_cohort.search_criteria.visa_type.shift
+        @cohort_page.remove_filter_of_type 'Visa Type'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Gender filter' do
+        test.default_cohort.search_criteria.gender = ['Female']
+        @cohort_page.edit_filter_and_confirm('Gender', test.default_cohort.search_criteria.gender.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Gender filter' do
+        test.default_cohort.search_criteria.gender.shift
+        @cohort_page.remove_filter_of_type 'Gender'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit an Ethnicity (COE) filter' do
+        test.default_cohort.search_criteria.coe_ethnicity = ['Mexican / Mexican-American / Chicano']
+        @cohort_page.edit_filter_and_confirm('Ethnicity (COE)', test.default_cohort.search_criteria.coe_ethnicity.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Ethnicity (COE) filter' do
+        test.default_cohort.search_criteria.coe_ethnicity.shift
+        @cohort_page.remove_filter_of_type 'Ethnicity (COE)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Gender (COE) filter' do
+        test.default_cohort.search_criteria.coe_gender = ['Male']
+        @cohort_page.edit_filter_and_confirm('Gender (COE)', test.default_cohort.search_criteria.coe_gender.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Gender (COE) filter' do
+        test.default_cohort.search_criteria.coe_gender.shift
+        @cohort_page.remove_filter_of_type 'Gender (COE)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Underrepresented Minority (COE) filter' do
+        test.default_cohort.search_criteria.coe_underrepresented_minority = false
+        @cohort_page.remove_filter_of_type 'Underrepresented Minority (COE)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Inactive (ASC) filter' do
+        test.default_cohort.search_criteria.asc_inactive = nil
+        @cohort_page.remove_filter_of_type 'Inactive (ASC)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Intensive filter' do
+        test.default_cohort.search_criteria.asc_intensive = false
+        @cohort_page.remove_filter_of_type 'Intensive'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Team filter' do
+        test.default_cohort.search_criteria.asc_team = [Squad::WCR]
+        @cohort_page.edit_filter_and_confirm('Team', test.default_cohort.search_criteria.asc_team.first.name)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Team filter' do
+        test.default_cohort.search_criteria.asc_team.shift
+        @cohort_page.remove_filter_of_type 'Team'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a PREP filter' do
+        test.default_cohort.search_criteria.coe_prep = ['T-PREP']
+        @cohort_page.edit_filter_and_confirm('PREP', test.default_cohort.search_criteria.coe_prep.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a PREP filter' do
+        test.default_cohort.search_criteria.coe_prep.shift
+        @cohort_page.remove_filter_of_type 'PREP'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a Last Name filter' do
+        test.default_cohort.search_criteria.last_name = [{'min' => 'B', 'max' => 'Y'}]
+        @cohort_page.edit_filter_and_confirm('Last Name', test.default_cohort.search_criteria.last_name.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Last Name filter' do
+        test.default_cohort.search_criteria.last_name = nil
+        @cohort_page.remove_filter_of_type 'Last Name'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to edit a My Students filter' do
+        if test.default_cohort.search_criteria.cohort_owner_academic_plans
+          test.default_cohort.search_criteria.cohort_owner_academic_plans = ['*']
+          @cohort_page.edit_filter_and_confirm('My Students', '*')
+          @cohort_page.verify_student_filters_present test.default_cohort
+        else
+          logger.warn 'Skipping test for editing My Students since the filter is not available to the user'
+        end
+      end
+
+      it 'allows the advisor to remove a My Students filter' do
+        if test.default_cohort.search_criteria.cohort_owner_academic_plans
+          test.default_cohort.search_criteria.cohort_owner_academic_plans.shift
+          @cohort_page.remove_filter_of_type 'My Students'
+          @cohort_page.verify_student_filters_present test.default_cohort
+        else
+          logger.warn 'Skipping test for removing My Students since the filter is not available to the user'
+        end
+      end
+
+      it 'allows the advisor to edit an Advisor (COE) filter' do
+        test.default_cohort.search_criteria.coe_advisor = [BOACUtils.get_dept_advisors(BOACDepartments::COE).last.uid.to_s]
+        @cohort_page.edit_filter_and_confirm('Advisor (COE)', test.default_cohort.search_criteria.coe_advisor.first)
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Advisor (COE) filter' do
+        test.default_cohort.search_criteria.coe_advisor.shift
+        @cohort_page.remove_filter_of_type 'Advisor (COE)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove an Inactive (CoE) filter' do
+        test.default_cohort.search_criteria.coe_inactive = nil
+        @cohort_page.remove_filter_of_type 'Inactive (COE)'
+        @cohort_page.verify_student_filters_present test.default_cohort
+      end
+
+      it 'allows the advisor to remove a Probation filter' do
+        test.default_cohort.search_criteria.coe_probation = nil
+        @cohort_page.remove_filter_of_type 'Probation'
       end
     end
 
-    it 'allows the advisor to edit an Advisor (COE) filter' do
-      test.default_cohort.search_criteria.coe_advisor = [BOACUtils.get_dept_advisors(BOACDepartments::COE).last.uid.to_s]
-      @cohort_page.edit_filter_and_confirm('Advisor (COE)', test.default_cohort.search_criteria.coe_advisor.first)
-      @cohort_page.verify_student_filters_present test.default_cohort
+    context 'when the advisor edits a cohort\'s name' do
+
+      it 'renames the existing cohort' do
+        cohort = test.searches.first
+        id = cohort.id
+        @cohort_page.rename_cohort(cohort, "#{cohort.name} - Renamed")
+        expect(cohort.id).to eql(id)
+      end
     end
 
-    it 'allows the advisor to remove an Advisor (COE) filter' do
-      test.default_cohort.search_criteria.coe_advisor.shift
-      @cohort_page.remove_filter_of_type 'Advisor (COE)'
-      @cohort_page.verify_student_filters_present test.default_cohort
+    context 'when the advisor deletes a cohort and tries to navigate to the deleted cohort' do
+
+      before(:all) do
+        @cohort_page.load_cohort test.searches.first
+        @cohort_page.delete_cohort test.searches.first
+      end
+
+      it 'shows a Not Found page' do
+        @cohort_page.navigate_to "#{BOACUtils.base_url}/cohort/#{test.searches.first.id}"
+        @cohort_page.wait_for_title 'Page not found'
+      end
     end
 
-    it 'allows the advisor to remove an Inactive (CoE) filter' do
-      test.default_cohort.search_criteria.coe_inactive = nil
-      @cohort_page.remove_filter_of_type 'Inactive (COE)'
-      @cohort_page.verify_student_filters_present test.default_cohort
-    end
-
-    it 'allows the advisor to remove a Probation filter' do
-      test.default_cohort.search_criteria.coe_probation = nil
-      @cohort_page.remove_filter_of_type 'Probation'
-    end
   end
-
-  context 'when the advisor edits a cohort\'s name' do
-
-    it 'renames the existing cohort' do
-      cohort = test.searches.first
-      id = cohort.id
-      @cohort_page.rename_cohort(cohort, "#{cohort.name} - Renamed")
-      expect(cohort.id).to eql(id)
-    end
-  end
-
-  context 'when the advisor deletes a cohort and tries to navigate to the deleted cohort' do
-
-    before(:all) do
-      @cohort_page.load_cohort test.searches.first
-      @cohort_page.delete_cohort test.searches.first
-    end
-
-    it 'shows a Not Found page' do
-      @cohort_page.navigate_to "#{BOACUtils.base_url}/cohort/#{test.searches.first.id}"
-      @cohort_page.wait_for_title 'Page not found'
-    end
-  end
-
 end

--- a/spec/boac/boac_filtered_group_spec.rb
+++ b/spec/boac/boac_filtered_group_spec.rb
@@ -1,250 +1,253 @@
 require_relative '../../util/spec_helper'
 
-test = BOACTestConfig.new
-test.filtered_groups
-test.students.shuffle!
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-group_1_students = test.students.first(1000)
-group_2_students = test.students.last(1000)
-test.students = group_1_students + group_2_students
+  test = BOACTestConfig.new
+  test.filtered_groups
+  test.students.shuffle!
 
-describe 'A BOA filtered cohort' do
+  group_1_students = test.students.first(1000)
+  group_2_students = test.students.last(1000)
+  test.students = group_1_students + group_2_students
 
-  include Logging
+  describe 'A BOA filtered cohort' do
 
-  before(:all) do
-
-    @students_to_add_remove = []
-    @cohorts = []
-
-    @group_1 = CuratedGroup.new(name: "Group 1 #{test.id}", members: [])
-    @group_2 = CuratedGroup.new(name: "Group 2 #{test.id}", members: [])
-
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @group_page = BOACGroupPage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
-    @student_page = BOACStudentPage.new @driver
-
-    @homepage.dev_auth test.advisor
-
-    pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
-    pre_existing_cohorts.each { |c| @cohort_page.load_cohort(c); @cohort_page.delete_cohort(c) }
-
-    pre_existing_groups = BOACUtils.get_user_curated_groups test.advisor
-    pre_existing_groups.each { |c| @group_page.load_page(c); @group_page.delete_cohort(c) }
-  end
-
-  context 'when a user has no groups' do
-
-    it 'offers no group filter options' do
-      @homepage.click_sidebar_create_filtered
-      @cohort_page.click_new_filter_button
-      @cohort_page.new_filter_option('curatedGroupIds').when_visible 1
-      expect(@cohort_page.new_filter_option('curatedGroupIds').attribute('disabled')).to eql('true')
-    end
-  end
-
-  context 'when a user has groups' do
+    include Logging
 
     before(:all) do
-      @cohort_page.click_sidebar_create_curated_group
-      @group_page.create_group_with_bulk_sids(group_1_students, @group_1)
-      @group_page.click_sidebar_create_curated_group
-      @group_page.create_group_with_bulk_sids(group_2_students, @group_2)
+
+      @students_to_add_remove = []
+      @cohorts = []
+
+      @group_1 = CuratedGroup.new(name: "Group 1 #{test.id}", members: [])
+      @group_2 = CuratedGroup.new(name: "Group 2 #{test.id}", members: [])
+
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @group_page = BOACGroupPage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
+      @student_page = BOACStudentPage.new @driver
+
+      @homepage.dev_auth test.advisor
+
+      pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
+      pre_existing_cohorts.each { |c| @cohort_page.load_cohort(c); @cohort_page.delete_cohort(c) }
+
+      pre_existing_groups = BOACUtils.get_user_curated_groups test.advisor
+      pre_existing_groups.each { |c| @group_page.load_page(c); @group_page.delete_cohort(c) }
     end
 
-    it 'shows the user\'s own groups as filter options' do
-      @group_page.click_sidebar_create_filtered
-      @cohort_page.click_new_filter_button
-      @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option('curatedGroupIds')
-      @cohort_page.new_filter_sub_option_element('curatedGroupIds', @group_1.id).when_present 1
-      @cohort_page.new_filter_sub_option_element('curatedGroupIds', @group_2.id).when_present 1
+    context 'when a user has no groups' do
+
+      it 'offers no group filter options' do
+        @homepage.click_sidebar_create_filtered
+        @cohort_page.click_new_filter_button
+        @cohort_page.new_filter_option('curatedGroupIds').when_visible 1
+        expect(@cohort_page.new_filter_option('curatedGroupIds').attribute('disabled')).to eql('true')
+      end
     end
 
-    test.searches.each do |cohort|
+    context 'when a user has groups' do
 
-      it "allows the user to filter a group by active students with #{cohort.search_criteria.list_filters}" do
-        # Add the groups to the search criteria, and restrict the searchable data to the group members
-        cohort.search_criteria.curated_groups = [@group_1.id.to_s, @group_2.id.to_s]
-        @cohort_page.set_cohort_members(cohort, test)
-        expected = cohort.members.map &:sis_id
+      before(:all) do
+        @cohort_page.click_sidebar_create_curated_group
+        @group_page.create_group_with_bulk_sids(group_1_students, @group_1)
+        @group_page.click_sidebar_create_curated_group
+        @group_page.create_group_with_bulk_sids(group_2_students, @group_2)
+      end
 
-        @cohort_page.click_sidebar_create_filtered
-        @cohort_page.perform_student_search cohort
-        @cohort_page.wait_for_spinner
-        @cohort_page.create_new_cohort cohort
-        @cohorts << cohort
+      it 'shows the user\'s own groups as filter options' do
+        @group_page.click_sidebar_create_filtered
+        @cohort_page.click_new_filter_button
+        @cohort_page.wait_for_update_and_click @cohort_page.new_filter_option('curatedGroupIds')
+        @cohort_page.new_filter_sub_option_element('curatedGroupIds', @group_1.id).when_present 1
+        @cohort_page.new_filter_sub_option_element('curatedGroupIds', @group_2.id).when_present 1
+      end
 
-        if cohort.members.length.zero?
-          @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count == 0 }
-        else
-          visible = @cohort_page.visible_sids
-          @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
-            visible.sort == expected.sort
+      test.searches.each do |cohort|
+
+        it "allows the user to filter a group by active students with #{cohort.search_criteria.list_filters}" do
+          # Add the groups to the search criteria, and restrict the searchable data to the group members
+          cohort.search_criteria.curated_groups = [@group_1.id.to_s, @group_2.id.to_s]
+          @cohort_page.set_cohort_members(cohort, test)
+          expected = cohort.members.map &:sis_id
+
+          @cohort_page.click_sidebar_create_filtered
+          @cohort_page.perform_student_search cohort
+          @cohort_page.wait_for_spinner
+          @cohort_page.create_new_cohort cohort
+          @cohorts << cohort
+
+          if cohort.members.length.zero?
+            @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count == 0 }
+          else
+            visible = @cohort_page.visible_sids
+            @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
+              visible.sort == expected.sort
+            end
           end
         end
       end
-    end
 
-    context 'when a user has a cohort with group filters' do
+      context 'when a user has a cohort with group filters' do
 
-      it 'shows the group filter on a cohort' do
-        @cohort_page.show_filters
-        @cohort_page.existing_filter_element('My Curated Groups', @group_1.name).when_visible 1
-        @cohort_page.existing_filter_element('My Curated Groups', @group_2.name).when_visible 1
-      end
+        it 'shows the group filter on a cohort' do
+          @cohort_page.show_filters
+          @cohort_page.existing_filter_element('My Curated Groups', @group_1.name).when_visible 1
+          @cohort_page.existing_filter_element('My Curated Groups', @group_2.name).when_visible 1
+        end
 
-      it 'updates the cohort member count in the sidebar when students are removed from the group' do
-        # Get the cohort with the most students for further tests to guarantee there are enough students to use
-        @cohorts.sort_by! { |c| c.members.length }
-        @students_to_add_remove << @cohorts.last.members[0..1]
-        @students_to_add_remove.flatten!
-        @students_to_add_remove.each do |student|
-          group = [@group_1, @group_2].find { |g| g.members.include? student }
-          @student_page.load_page student
-          @student_page.remove_student_from_grp(student, group)
-          test.students.delete_if { |s| s.sis_id == student.sis_id }
+        it 'updates the cohort member count in the sidebar when students are removed from the group' do
+          # Get the cohort with the most students for further tests to guarantee there are enough students to use
+          @cohorts.sort_by! { |c| c.members.length }
+          @students_to_add_remove << @cohorts.last.members[0..1]
+          @students_to_add_remove.flatten!
+          @students_to_add_remove.each do |student|
+            group = [@group_1, @group_2].find { |g| g.members.include? student }
+            @student_page.load_page student
+            @student_page.remove_student_from_grp(student, group)
+            test.students.delete_if { |s| s.sis_id == student.sis_id }
+            @cohort_page.set_cohort_members(@cohorts.last, test)
+            @student_page.wait_for_sidebar_cohort_member_count @cohorts.last
+          end
+        end
+
+        it 'updates the cohort student list when students are removed from the group' do
+          @cohort_page.load_cohort @cohorts.last
+          expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
+        end
+
+        it 'updates the cohort member count on the homepage when students are removed from the group' do
+          @homepage.load_page
+          @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
+          @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
+            @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+          end
+        end
+
+        it 'updates the cohort member count in the sidebar when students are added to the group via bulk-add' do
+          @group_page.load_page @group_1
+          @group_page.add_comma_sep_sids_to_existing_grp([@students_to_add_remove.first], @group_1)
+          test.students << @students_to_add_remove.first
           @cohort_page.set_cohort_members(@cohorts.last, test)
           @student_page.wait_for_sidebar_cohort_member_count @cohorts.last
         end
-      end
 
-      it 'updates the cohort student list when students are removed from the group' do
-        @cohort_page.load_cohort @cohorts.last
-        expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
-      end
+        it 'updates the cohort student list when students are added to the group via bulk-add' do
+          @cohort_page.load_cohort @cohorts.last
+          expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
+        end
 
-      it 'updates the cohort member count on the homepage when students are removed from the group' do
-        @homepage.load_page
-        @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
-        @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
-          @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+        it 'updates the cohort member count on the homepage when students are added to the group via bulk-add' do
+          @homepage.load_page
+          @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
+          @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
+            @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+          end
+        end
+
+        it 'updates the cohort member count in the sidebar when students are added to the group via a group selector' do
+          @student_page.load_page @students_to_add_remove.last
+          @student_page.add_student_to_grp(@students_to_add_remove.last, @group_1)
+          test.students << @students_to_add_remove.last
+          @cohort_page.set_cohort_members(@cohorts.last, test)
+          @student_page.wait_for_sidebar_cohort_member_count @cohorts.last
+        end
+
+        it 'updates the cohort student list when students are added to the group via a group selector' do
+          @cohort_page.load_cohort @cohorts.last
+          expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
+        end
+
+        it 'updates the cohort member count on the homepage when students are added to the group via a group selector' do
+          @homepage.load_page
+          @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
+          @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
+            @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+          end
+        end
+
+        it 'updates the cohort member count in the sidebar when a group is removed from the cohort' do
+          @cohort_page.load_cohort @cohorts.last
+          @cohort_page.show_filters
+          @cohort_page.remove_filter_of_type 'My Curated Groups'
+          @cohort_page.wait_for_update_and_click @cohort_page.unsaved_filter_apply_button_element
+          @cohort_page.click_save_cohort_button_one
+          @cohorts.last.search_criteria.curated_groups.delete @group_1.id.to_s
+          test.students -= group_1_students
+          @cohort_page.set_cohort_members(@cohorts.last, test)
+          @cohort_page.wait_for_sidebar_cohort_member_count @cohorts.last
+        end
+
+        it 'updates the cohort student list when a group is removed from the cohort' do
+          expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
+        end
+
+        it 'updates the cohort member count on the homepage when a group is removed from the cohort' do
+          @homepage.load_page
+          @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
+          @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
+            @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+          end
+        end
+
+        it 'shows no link to the cohort on the removed group' do
+          @group_page.load_page @group_1
+          expect(@group_page.linked_cohort_el(@cohorts.last).exists?).to be false
+        end
+
+        it 'updates the cohort member count in the sidebar when a group is added to the cohort' do
+          @cohort_page.load_cohort @cohorts.last
+          @cohort_page.show_filters
+          @cohort_page.select_new_filter('curatedGroupIds', @group_1.id.to_s)
+          @cohort_page.wait_for_update_and_click @cohort_page.unsaved_filter_apply_button_element
+          @cohort_page.click_save_cohort_button_one
+          @cohorts.last.search_criteria.curated_groups << @group_1.id.to_s
+          test.students += group_1_students
+          @cohort_page.set_cohort_members(@cohorts.last, test)
+          @cohort_page.wait_for_sidebar_cohort_member_count @cohorts.last
+        end
+
+        it 'updates the cohort student list when a group is added to the cohort' do
+          expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
+        end
+
+        it 'updates the cohort member count on the homepage when a group is added to the cohort' do
+          @homepage.load_page
+          @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
+          @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
+            @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+          end
+        end
+
+        it 'shows a link to the cohort on the added group' do
+          @group_page.load_page @group_1
+          expect(@group_page.linked_cohort_el(@cohorts.last).exists?).to be true
+        end
+
+        it 'prevents the user deleting the linked groups' do
+          @group_page.wait_for_update_and_click @group_page.delete_cohort_button_element
+          @group_page.no_deleting_el(@cohorts.last)
         end
       end
 
-      it 'updates the cohort member count in the sidebar when students are added to the group via bulk-add' do
-        @group_page.load_page @group_1
-        @group_page.add_comma_sep_sids_to_existing_grp([@students_to_add_remove.first], @group_1)
-        test.students << @students_to_add_remove.first
-        @cohort_page.set_cohort_members(@cohorts.last, test)
-        @student_page.wait_for_sidebar_cohort_member_count @cohorts.last
-      end
+      context 'when another user views a cohort with a group filter' do
 
-      it 'updates the cohort student list when students are added to the group via bulk-add' do
-        @cohort_page.load_cohort @cohorts.last
-        expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
-      end
-
-      it 'updates the cohort member count on the homepage when students are added to the group via bulk-add' do
-        @homepage.load_page
-        @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
-        @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
-          @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+        before(:all) do
+          @homepage.hit_escape
+          @homepage.log_out
+          @homepage.dev_auth BOACUser.new(uid: Utils.super_admin_uid)
         end
-      end
 
-      it 'updates the cohort member count in the sidebar when students are added to the group via a group selector' do
-        @student_page.load_page @students_to_add_remove.last
-        @student_page.add_student_to_grp(@students_to_add_remove.last, @group_1)
-        test.students << @students_to_add_remove.last
-        @cohort_page.set_cohort_members(@cohorts.last, test)
-        @student_page.wait_for_sidebar_cohort_member_count @cohorts.last
-      end
-
-      it 'updates the cohort student list when students are added to the group via a group selector' do
-        @cohort_page.load_cohort @cohorts.last
-        expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
-      end
-
-      it 'updates the cohort member count on the homepage when students are added to the group via a group selector' do
-        @homepage.load_page
-        @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
-        @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
-          @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
+        it 'shows the user the filters' do
+          @cohort_page.load_cohort @cohorts.last
+          @cohort_page.show_filters
+          @cohort_page.existing_filter_element('My Curated Groups', @group_1.name).when_visible 1
+          @cohort_page.existing_filter_element('My Curated Groups', @group_2.name).when_visible 1
         end
+
+        it('prevents the user from editing the filters') { expect(@cohort_page.cohort_edit_button_elements.any?).to be false }
       end
-
-      it 'updates the cohort member count in the sidebar when a group is removed from the cohort' do
-        @cohort_page.load_cohort @cohorts.last
-        @cohort_page.show_filters
-        @cohort_page.remove_filter_of_type 'My Curated Groups'
-        @cohort_page.wait_for_update_and_click @cohort_page.unsaved_filter_apply_button_element
-        @cohort_page.click_save_cohort_button_one
-        @cohorts.last.search_criteria.curated_groups.delete @group_1.id.to_s
-        test.students -= group_1_students
-        @cohort_page.set_cohort_members(@cohorts.last, test)
-        @cohort_page.wait_for_sidebar_cohort_member_count @cohorts.last
-      end
-
-      it 'updates the cohort student list when a group is removed from the cohort' do
-        expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
-      end
-
-      it 'updates the cohort member count on the homepage when a group is removed from the cohort' do
-        @homepage.load_page
-        @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
-        @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
-          @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
-        end
-      end
-
-      it 'shows no link to the cohort on the removed group' do
-        @group_page.load_page @group_1
-        expect(@group_page.linked_cohort_el(@cohorts.last).exists?).to be false
-      end
-
-      it 'updates the cohort member count in the sidebar when a group is added to the cohort' do
-        @cohort_page.load_cohort @cohorts.last
-        @cohort_page.show_filters
-        @cohort_page.select_new_filter('curatedGroupIds', @group_1.id.to_s)
-        @cohort_page.wait_for_update_and_click @cohort_page.unsaved_filter_apply_button_element
-        @cohort_page.click_save_cohort_button_one
-        @cohorts.last.search_criteria.curated_groups << @group_1.id.to_s
-        test.students += group_1_students
-        @cohort_page.set_cohort_members(@cohorts.last, test)
-        @cohort_page.wait_for_sidebar_cohort_member_count @cohorts.last
-      end
-
-      it 'updates the cohort student list when a group is added to the cohort' do
-        expect(@cohort_page.visible_sids.sort).to eql(@cohorts.last.members.map(&:sis_id).sort)
-      end
-
-      it 'updates the cohort member count on the homepage when a group is added to the cohort' do
-        @homepage.load_page
-        @homepage.wait_until(Utils.medium_wait) { @homepage.filtered_cohorts.include? @cohorts.last.name }
-        @homepage.wait_until(Utils.short_wait, "Expected #{@cohorts.last.members.length} but got #{@homepage.member_count(@cohorts.last)}") do
-          @homepage.member_count(@cohorts.last) == @cohorts.last.members.length
-        end
-      end
-
-      it 'shows a link to the cohort on the added group' do
-        @group_page.load_page @group_1
-        expect(@group_page.linked_cohort_el(@cohorts.last).exists?).to be true
-      end
-
-      it 'prevents the user deleting the linked groups' do
-        @group_page.wait_for_update_and_click @group_page.delete_cohort_button_element
-        @group_page.no_deleting_el(@cohorts.last)
-      end
-    end
-
-    context 'when another user views a cohort with a group filter' do
-
-      before(:all) do
-        @homepage.hit_escape
-        @homepage.log_out
-        @homepage.dev_auth BOACUser.new(uid: Utils.super_admin_uid)
-      end
-
-      it 'shows the user the filters' do
-        @cohort_page.load_cohort @cohorts.last
-        @cohort_page.show_filters
-        @cohort_page.existing_filter_element('My Curated Groups', @group_1.name).when_visible 1
-        @cohort_page.existing_filter_element('My Curated Groups', @group_2.name).when_visible 1
-      end
-
-      it('prevents the user from editing the filters') { expect(@cohort_page.cohort_edit_button_elements.any?).to be false }
     end
   end
 end

--- a/spec/boac/boac_flight_data_recorder_spec.rb
+++ b/spec/boac/boac_flight_data_recorder_spec.rb
@@ -1,244 +1,247 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-depts = BOACDepartments::DEPARTMENTS - [BOACDepartments::ADMIN, BOACDepartments::NOTES_ONLY]
-depts.keep_if { |dept| BOACUtils.get_dept_advisors(dept).any? }
-all_users = BOACUtils.get_authorized_users.select &:active
-all_non_admin_users = all_users.reject &:is_admin
+  include Logging
 
-admin = all_users.find &:is_admin
-logger.warn "Admin UID #{admin.uid}"
+  depts = BOACDepartments::DEPARTMENTS - [BOACDepartments::ADMIN, BOACDepartments::NOTES_ONLY]
+  depts.keep_if { |dept| BOACUtils.get_dept_advisors(dept).any? }
+  all_users = BOACUtils.get_authorized_users.select &:active
+  all_non_admin_users = all_users.reject &:is_admin
 
-director = all_non_admin_users.find { |u| u.dept_memberships.find { |m| m.advisor_role == AdvisorRole::DIRECTOR } }
-director_depts = director.dept_memberships.select { |m| m.advisor_role == AdvisorRole::DIRECTOR }.map(&:dept)
-logger.warn "Director UID #{director.uid}"
+  admin = all_users.find &:is_admin
+  logger.warn "Admin UID #{admin.uid}"
 
-advisor = all_non_admin_users.find do |u|
-  u.dept_memberships.select { |m| m.advisor_role == AdvisorRole::ADVISOR }.reject { |m| m.advisor_role == AdvisorRole::DIRECTOR }.any?
-end
-logger.warn "Advisor UID #{advisor.uid}"
+  director = all_non_admin_users.find { |u| u.dept_memberships.find { |m| m.advisor_role == AdvisorRole::DIRECTOR } }
+  director_depts = director.dept_memberships.select { |m| m.advisor_role == AdvisorRole::DIRECTOR }.map(&:dept)
+  logger.warn "Director UID #{director.uid}"
 
-scheduler = all_non_admin_users.find do |u|
-  u.dept_memberships.select { |m| m.advisor_role == AdvisorRole::SCHEDULER }.reject { |m| m.advisor_role == AdvisorRole::DIRECTOR }.reject { |m| m.advisor_role == AdvisorRole::ADVISOR }.any?
-end
-logger.warn "Scheduler UID #{scheduler.uid}"
-
-
-describe 'BOA flight data recorder' do
-
-  before(:all) do
-    @advisor_data = BOACUtils.get_last_login_and_note_count
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @flight_data_recorder = BOACFlightDataRecorderPage.new @driver
+  advisor = all_non_admin_users.find do |u|
+    u.dept_memberships.select { |m| m.advisor_role == AdvisorRole::ADVISOR }.reject { |m| m.advisor_role == AdvisorRole::DIRECTOR }.any?
   end
+  logger.warn "Advisor UID #{advisor.uid}"
 
-  after(:all) { Utils.quit_browser @driver }
+  scheduler = all_non_admin_users.find do |u|
+    u.dept_memberships.select { |m| m.advisor_role == AdvisorRole::SCHEDULER }.reject { |m| m.advisor_role == AdvisorRole::DIRECTOR }.reject { |m| m.advisor_role == AdvisorRole::ADVISOR }.any?
+  end
+  logger.warn "Scheduler UID #{scheduler.uid}"
 
-  context 'when the user is an admin' do
+
+  describe 'BOA flight data recorder' do
 
     before(:all) do
-      @homepage.dev_auth admin
-      @homepage.click_flight_data_recorder_link
-      @ttl_note_count = BOACUtils.get_total_note_count
+      @advisor_data = BOACUtils.get_last_login_and_note_count
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @flight_data_recorder = BOACFlightDataRecorderPage.new @driver
     end
 
-    after(:all) { @flight_data_recorder.log_out }
+    after(:all) { Utils.quit_browser @driver }
 
-    it 'hides the complete notes report by default' do
-      @flight_data_recorder.show_hide_report_button_element.when_visible Utils.short_wait
-      expect(@flight_data_recorder.notes_count_boa_authors_element.visible?).to be false
-    end
+    context 'when the user is an admin' do
 
-    it 'allows the user to view the complete notes report' do
-      @flight_data_recorder.toggle_note_report_visibility
-      @flight_data_recorder.notes_count_sis_element.when_visible 1
-    end
-
-    it 'shows the total number of notes imported from the SIS' do
-      expect(@flight_data_recorder.notes_count_sis).to eql(Utils.int_to_s_with_commas NessieUtils.get_external_note_count('sis_advising_notes'))
-    end
-
-    it 'shows the total number of notes imported from the ASC' do
-      expect(@flight_data_recorder.notes_count_asc).to eql(Utils.int_to_s_with_commas NessieUtils.get_external_note_count('boac_advising_asc'))
-    end
-
-    it 'shows the total number of notes imported from the CEEE' do
-      expect(@flight_data_recorder.notes_count_ei).to eql(Utils.int_to_s_with_commas NessieUtils.get_external_note_count('boac_advising_e_i'))
-    end
-
-    context 'viewing the created-in-BOA notes report' do
-
-      it 'shows the total number of notes' do
-        expect(@flight_data_recorder.boa_note_count).to eql(Utils.int_to_s_with_commas @ttl_note_count)
+      before(:all) do
+        @homepage.dev_auth admin
+        @homepage.click_flight_data_recorder_link
+        @ttl_note_count = BOACUtils.get_total_note_count
       end
 
-      it 'shows the total distinct note authors' do
-        expect(@flight_data_recorder.notes_count_boa_authors).to eql(Utils.int_to_s_with_commas BOACUtils.get_distinct_note_author_count)
+      after(:all) { @flight_data_recorder.log_out }
+
+      it 'hides the complete notes report by default' do
+        @flight_data_recorder.show_hide_report_button_element.when_visible Utils.short_wait
+        expect(@flight_data_recorder.notes_count_boa_authors_element.visible?).to be false
       end
 
-      it 'shows the percentage of notes with attachments' do
-        expected = ((BOACUtils.get_notes_with_attachments_count.to_f / @ttl_note_count.to_f) * 100).round(1).to_s
-        expect(@flight_data_recorder.notes_count_boa_with_attachments).to include(expected)
+      it 'allows the user to view the complete notes report' do
+        @flight_data_recorder.toggle_note_report_visibility
+        @flight_data_recorder.notes_count_sis_element.when_visible 1
       end
 
-      it 'shows the percentage of notes with topics' do
-        expected = ((BOACUtils.get_notes_with_topics_count.to_f / @ttl_note_count.to_f) * 100).round(1).to_s
-        expect(@flight_data_recorder.notes_count_boa_with_topics).to include(expected)
-      end
-    end
-
-    depts.each do |dept|
-
-      it "allows the user to filter users by #{dept.name}" do
-        @flight_data_recorder.select_dept_report dept
+      it 'shows the total number of notes imported from the SIS' do
+        expect(@flight_data_recorder.notes_count_sis).to eql(Utils.int_to_s_with_commas NessieUtils.get_external_note_count('sis_advising_notes'))
       end
 
-      it "shows all the users in #{dept.name}" do
-        expected_uids = all_users.select { |u| u.depts.include? dept }.map(&:uid).sort
-        visible_uids = @flight_data_recorder.list_view_uids.sort
-        @flight_data_recorder.wait_until(1, "Missing: #{expected_uids - visible_uids}. Unexpected: #{visible_uids - expected_uids}") do
-          visible_uids == expected_uids
+      it 'shows the total number of notes imported from the ASC' do
+        expect(@flight_data_recorder.notes_count_asc).to eql(Utils.int_to_s_with_commas NessieUtils.get_external_note_count('boac_advising_asc'))
+      end
+
+      it 'shows the total number of notes imported from the CEEE' do
+        expect(@flight_data_recorder.notes_count_ei).to eql(Utils.int_to_s_with_commas NessieUtils.get_external_note_count('boac_advising_e_i'))
+      end
+
+      context 'viewing the created-in-BOA notes report' do
+
+        it 'shows the total number of notes' do
+          expect(@flight_data_recorder.boa_note_count).to eql(Utils.int_to_s_with_commas @ttl_note_count)
+        end
+
+        it 'shows the total distinct note authors' do
+          expect(@flight_data_recorder.notes_count_boa_authors).to eql(Utils.int_to_s_with_commas BOACUtils.get_distinct_note_author_count)
+        end
+
+        it 'shows the percentage of notes with attachments' do
+          expected = ((BOACUtils.get_notes_with_attachments_count.to_f / @ttl_note_count.to_f) * 100).round(1).to_s
+          expect(@flight_data_recorder.notes_count_boa_with_attachments).to include(expected)
+        end
+
+        it 'shows the percentage of notes with topics' do
+          expected = ((BOACUtils.get_notes_with_topics_count.to_f / @ttl_note_count.to_f) * 100).round(1).to_s
+          expect(@flight_data_recorder.notes_count_boa_with_topics).to include(expected)
         end
       end
 
-      all_users.select { |u| u.depts.include? dept }.each do |user|
+      depts.each do |dept|
 
-        it "shows the total number of BOA notes created by #{dept.name} UID #{user.uid}" do
-          count = (@advisor_data.find { |a| a[:uid] == user.uid })[:note_count]
-          expect(@flight_data_recorder.advisor_note_count user).to eql(count)
+        it "allows the user to filter users by #{dept.name}" do
+          @flight_data_recorder.select_dept_report dept
         end
 
-        it "shows the last login date for #{dept.name} UID #{user.uid}" do
-          date = if user == admin
-                   Time.now
-                 else
-                   (@advisor_data.find { |a| a[:uid] == user.uid.to_s })[:last_login]
-                 end
-          date = date ? date.strftime('%b %-d, %Y') : '—'
-          expect(@flight_data_recorder.advisor_last_login user).to eql(date)
+        it "shows all the users in #{dept.name}" do
+          expected_uids = all_users.select { |u| u.depts.include? dept }.map(&:uid).sort
+          visible_uids = @flight_data_recorder.list_view_uids.sort
+          @flight_data_recorder.wait_until(1, "Missing: #{expected_uids - visible_uids}. Unexpected: #{visible_uids - expected_uids}") do
+            visible_uids == expected_uids
+          end
         end
 
-        user.dept_memberships.each do |role|
+        all_users.select { |u| u.depts.include? dept }.each do |user|
 
-          # TODO - include the full visible role once user roles are sussed out
-          it "shows the #{dept.name} UID #{user.uid} department role #{role.inspect}" do
-            expect(@flight_data_recorder.advisor_role(user, role.dept)).to include(role.dept.name)
+          it "shows the total number of BOA notes created by #{dept.name} UID #{user.uid}" do
+            count = (@advisor_data.find { |a| a[:uid] == user.uid })[:note_count]
+            expect(@flight_data_recorder.advisor_note_count user).to eql(count)
+          end
+
+          it "shows the last login date for #{dept.name} UID #{user.uid}" do
+            date = if user == admin
+                     Time.now
+                   else
+                     (@advisor_data.find { |a| a[:uid] == user.uid.to_s })[:last_login]
+                   end
+            date = date ? date.strftime('%b %-d, %Y') : '—'
+            expect(@flight_data_recorder.advisor_last_login user).to eql(date)
+          end
+
+          user.dept_memberships.each do |role|
+
+            # TODO - include the full visible role once user roles are sussed out
+            it "shows the #{dept.name} UID #{user.uid} department role #{role.inspect}" do
+              expect(@flight_data_recorder.advisor_role(user, role.dept)).to include(role.dept.name)
+            end
           end
         end
       end
     end
-  end
 
-  context 'when the user is a director' do
+    context 'when the user is a director' do
 
-    before(:all) do
-      @homepage.dev_auth director
-      @homepage.click_flight_data_recorder_link
-    end
-
-    after(:all) { @flight_data_recorder.log_out }
-
-    it "only shows data for UID #{director.uid} departments #{director_depts.map &:name}" do
-      @flight_data_recorder.wait_until(Utils.short_wait) { @flight_data_recorder.dept_heading? || @flight_data_recorder.dept_select? }
-      if director_depts.length > 1
-        expect(@flight_data_recorder.dept_select_option_values.sort).to eql(director_depts.map(&:code).sort)
-      else
-        name = director_depts.first.export_name || director_depts.first.name
-        expect(@flight_data_recorder.dept_heading).to eql(name)
-      end
-    end
-
-    it 'hides the complete notes report by default' do
-      @flight_data_recorder.show_hide_report_button_element.when_visible Utils.short_wait
-      expect(@flight_data_recorder.notes_count_boa_authors_element.visible?).to be false
-    end
-
-    it 'allows the user to view the complete notes report' do
-      @flight_data_recorder.toggle_note_report_visibility
-      @flight_data_recorder.notes_count_boa_authors_element.when_visible 1
-    end
-
-    director_depts.each do |dept|
-
-      it "allows the user to filter users by #{dept.name}" do
-        @flight_data_recorder.select_dept_report dept if director_depts.length > 1
+      before(:all) do
+        @homepage.dev_auth director
+        @homepage.click_flight_data_recorder_link
       end
 
-      it "shows all the users in #{dept.name}" do
-        expected_uids = all_users.select { |u| u.depts.include? dept }.map(&:uid).sort
-        visible_uids = @flight_data_recorder.list_view_uids.sort
-        @flight_data_recorder.wait_until(1, "Missing: #{expected_uids - visible_uids}. Unexpected: #{visible_uids - expected_uids}") do
-          visible_uids == expected_uids
+      after(:all) { @flight_data_recorder.log_out }
+
+      it "only shows data for UID #{director.uid} departments #{director_depts.map &:name}" do
+        @flight_data_recorder.wait_until(Utils.short_wait) { @flight_data_recorder.dept_heading? || @flight_data_recorder.dept_select? }
+        if director_depts.length > 1
+          expect(@flight_data_recorder.dept_select_option_values.sort).to eql(director_depts.map(&:code).sort)
+        else
+          name = director_depts.first.export_name || director_depts.first.name
+          expect(@flight_data_recorder.dept_heading).to eql(name)
         end
       end
 
-      all_non_admin_users.select { |u| u.depts.include? dept }.each do |user|
+      it 'hides the complete notes report by default' do
+        @flight_data_recorder.show_hide_report_button_element.when_visible Utils.short_wait
+        expect(@flight_data_recorder.notes_count_boa_authors_element.visible?).to be false
+      end
 
-        it "shows the total number of BOA notes created by #{dept.name} UID #{user.uid}" do
-          count = (@advisor_data.find { |a| a[:uid] == user.uid })[:note_count]
-          expect(@flight_data_recorder.advisor_note_count user).to eql(count)
+      it 'allows the user to view the complete notes report' do
+        @flight_data_recorder.toggle_note_report_visibility
+        @flight_data_recorder.notes_count_boa_authors_element.when_visible 1
+      end
+
+      director_depts.each do |dept|
+
+        it "allows the user to filter users by #{dept.name}" do
+          @flight_data_recorder.select_dept_report dept if director_depts.length > 1
         end
 
-        it "shows the last login date for #{dept.name} UID #{user.uid}" do
-          date = if [admin, director].include? user
-                   Time.now
-                 else
-                   (@advisor_data.find { |a| a[:uid] == user.uid.to_s })[:last_login]
-                 end
-          date = date ? date.strftime('%b %-d, %Y') : '—'
-          expect(@flight_data_recorder.advisor_last_login user).to eql(date)
+        it "shows all the users in #{dept.name}" do
+          expected_uids = all_users.select { |u| u.depts.include? dept }.map(&:uid).sort
+          visible_uids = @flight_data_recorder.list_view_uids.sort
+          @flight_data_recorder.wait_until(1, "Missing: #{expected_uids - visible_uids}. Unexpected: #{visible_uids - expected_uids}") do
+            visible_uids == expected_uids
+          end
         end
+
+        all_non_admin_users.select { |u| u.depts.include? dept }.each do |user|
+
+          it "shows the total number of BOA notes created by #{dept.name} UID #{user.uid}" do
+            count = (@advisor_data.find { |a| a[:uid] == user.uid })[:note_count]
+            expect(@flight_data_recorder.advisor_note_count user).to eql(count)
+          end
+
+          it "shows the last login date for #{dept.name} UID #{user.uid}" do
+            date = if [admin, director].include? user
+                     Time.now
+                   else
+                     (@advisor_data.find { |a| a[:uid] == user.uid.to_s })[:last_login]
+                   end
+            date = date ? date.strftime('%b %-d, %Y') : '—'
+            expect(@flight_data_recorder.advisor_last_login user).to eql(date)
+          end
+        end
+      end
+
+      it 'prevents the user from reaching an unauthorized department\'s data' do
+        dept = (depts - director_depts).first
+        @flight_data_recorder.load_page dept
+        @flight_data_recorder.wait_for_title 'Page not found'
       end
     end
 
-    it 'prevents the user from reaching an unauthorized department\'s data' do
-      dept = (depts - director_depts).first
-      @flight_data_recorder.load_page dept
-      @flight_data_recorder.wait_for_title 'Page not found'
-    end
-  end
+    context 'when the user is an advisor' do
 
-  context 'when the user is an advisor' do
+      before(:all) { @homepage.dev_auth advisor }
 
-    before(:all) { @homepage.dev_auth advisor }
+      after(:all) do
+        @flight_data_recorder.hit_escape
+        @flight_data_recorder.log_out
+      end
 
-    after(:all) do
-      @flight_data_recorder.hit_escape
-      @flight_data_recorder.log_out
-    end
+      it 'prevents the user hitting the page' do
+        @flight_data_recorder.load_page advisor.depts.first
+        @flight_data_recorder.wait_for_title 'Page not found'
+      end
 
-    it 'prevents the user hitting the page' do
-      @flight_data_recorder.load_page advisor.depts.first
-      @flight_data_recorder.wait_for_title 'Page not found'
-    end
+      it 'offers no link in the header' do
+        @homepage.click_header_dropdown
+        expect(@homepage.flight_data_recorder_link?).to be false
+      end
 
-    it 'offers no link in the header' do
-      @homepage.click_header_dropdown
-      expect(@homepage.flight_data_recorder_link?).to be false
     end
 
-  end
+    context 'when the user is a scheduler' do
 
-  context 'when the user is a scheduler' do
+      before(:all) { @homepage.dev_auth scheduler }
 
-    before(:all) { @homepage.dev_auth scheduler }
+      after(:all) do
+        @flight_data_recorder.hit_escape
+        @flight_data_recorder.log_out
+      end
 
-    after(:all) do
-      @flight_data_recorder.hit_escape
-      @flight_data_recorder.log_out
+      it 'prevents the user hitting the page' do
+        @flight_data_recorder.load_page scheduler.depts.first
+        @flight_data_recorder.wait_for_title 'Not Found'
+      end
+
+      it 'offers no link in the header' do
+        @homepage.click_header_dropdown
+        expect(@homepage.flight_data_recorder_link?).to be false
+      end
+
     end
-
-    it 'prevents the user hitting the page' do
-      @flight_data_recorder.load_page scheduler.depts.first
-      @flight_data_recorder.wait_for_title 'Not Found'
-    end
-
-    it 'offers no link in the header' do
-      @homepage.click_header_dropdown
-      expect(@homepage.flight_data_recorder_link?).to be false
-    end
-
   end
 end

--- a/spec/boac/boac_inactive_students_spec.rb
+++ b/spec/boac/boac_inactive_students_spec.rb
@@ -1,148 +1,151 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOA non-current students' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  before(:all) do
-    @test = BOACTestConfig.new
-    @test.inactive_students
+  describe 'BOA non-current students' do
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @group_page = BOACGroupPage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-    @api_student_page = BOACApiStudentPage.new @driver
+    before(:all) do
+      @test = BOACTestConfig.new
+      @test.inactive_students
 
-    @homepage.dev_auth @test.advisor
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @group_page = BOACGroupPage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
+      @api_student_page = BOACApiStudentPage.new @driver
 
-    active_sids = @test.students.map &:sis_id
+      @homepage.dev_auth @test.advisor
 
-    # Get an inactive non-current student who has not yet received the VIP treatment
-    inactive_sid = (NessieUtils.hist_profile_sids_of_career_status('Inactive') - active_sids).first
-    @inactive_student = NessieUtils.get_hist_student inactive_sid
-    @inactive_api_student_page = BOACApiStudentPage.new @driver
-    @inactive_api_student_page.get_data(@driver, @inactive_student)
-    @inactive_api_student_page.set_identity @inactive_student
-    @inactive_student_profile = @inactive_api_student_page.sis_profile_data
-    @inactive_student_profile[:academic_career_status] == 'Inactive'
+      active_sids = @test.students.map &:sis_id
 
-    # Get a completed non-current student who has not yet received the VIP treatment
-    completed_sid = (NessieUtils.hist_profile_sids_of_career_status('Completed') - active_sids).first
-    @completed_student = NessieUtils.get_hist_student completed_sid
-    @completed_api_student_page = BOACApiStudentPage.new @driver
-    @completed_api_student_page.get_data(@driver, @completed_student)
-    @completed_api_student_page.set_identity @completed_student
-    @completed_student_profile = @completed_api_student_page.sis_profile_data
-    @completed_student_profile[:academic_career_status] == 'Completed'
-  end
+      # Get an inactive non-current student who has not yet received the VIP treatment
+      inactive_sid = (NessieUtils.hist_profile_sids_of_career_status('Inactive') - active_sids).first
+      @inactive_student = NessieUtils.get_hist_student inactive_sid
+      @inactive_api_student_page = BOACApiStudentPage.new @driver
+      @inactive_api_student_page.get_data(@driver, @inactive_student)
+      @inactive_api_student_page.set_identity @inactive_student
+      @inactive_student_profile = @inactive_api_student_page.sis_profile_data
+      @inactive_student_profile[:academic_career_status] == 'Inactive'
 
-  after(:all) { Utils.quit_browser @driver }
+      # Get a completed non-current student who has not yet received the VIP treatment
+      completed_sid = (NessieUtils.hist_profile_sids_of_career_status('Completed') - active_sids).first
+      @completed_student = NessieUtils.get_hist_student completed_sid
+      @completed_api_student_page = BOACApiStudentPage.new @driver
+      @completed_api_student_page.get_data(@driver, @completed_student)
+      @completed_api_student_page.set_identity @completed_student
+      @completed_student_profile = @completed_api_student_page.sis_profile_data
+      @completed_student_profile[:academic_career_status] == 'Completed'
+    end
 
-  it('are plentiful') { expect(NessieUtils.hist_profile_sids.length).to be > 275000 }
+    after(:all) { Utils.quit_browser @driver }
 
-  it('include some with an Active academic career status') { expect(NessieUtils.hist_career_status_count 'Active').to be > 0 }
-  it('include some with an Inactive academic career status') { expect(NessieUtils.hist_career_status_count 'Inactive').to be > 0 }
-  it('include some with a Completed academic career status') { expect(NessieUtils.hist_career_status_count 'Inactive').to be > 0 }
-  it('include none with an unexpected academic career status') { expect(NessieUtils.unexpected_hist_career_status_count).to be_zero }
+    it('are plentiful') { expect(NessieUtils.hist_profile_sids.length).to be > 275000 }
 
-  it('include some with an Active program status') { expect(NessieUtils.hist_prog_status_count 'Active').to be > 0 }
-  it('include some with a Cancelled program status') { expect(NessieUtils.hist_prog_status_count 'Cancelled').to be > 0 }
-  it('include some with a Completed Program program status') { expect(NessieUtils.hist_prog_status_count 'Completed Program').to be > 0 }
-  it('include some with a Discontinued program status') { expect(NessieUtils.hist_prog_status_count 'Discontinued').to be > 0 }
-  it('include some with a Dismissed program status') { expect(NessieUtils.hist_prog_status_count 'Dismissed').to be > 0 }
-  it('include some with a Suspended program status') { expect(NessieUtils.hist_prog_status_count 'Suspended').to be > 0 }
-  it('include none with an unexpected program status') { expect(NessieUtils.unexpected_hist_prog_status_count).to be_zero }
+    it('include some with an Active academic career status') { expect(NessieUtils.hist_career_status_count 'Active').to be > 0 }
+    it('include some with an Inactive academic career status') { expect(NessieUtils.hist_career_status_count 'Inactive').to be > 0 }
+    it('include some with a Completed academic career status') { expect(NessieUtils.hist_career_status_count 'Inactive').to be > 0 }
+    it('include none with an unexpected academic career status') { expect(NessieUtils.unexpected_hist_career_status_count).to be_zero }
 
-  it('include all those with historical term enrollments') { expect(NessieUtils.hist_enrollment_sids - NessieUtils.hist_profile_sids).to be_empty }
-  it('include some with null academic career status and no historical term enrollments') do
-    expect(NessieUtils.null_hist_career_status_sids - NessieUtils.hist_enrollment_sids).not_to be_empty
-  end
+    it('include some with an Active program status') { expect(NessieUtils.hist_prog_status_count 'Active').to be > 0 }
+    it('include some with a Cancelled program status') { expect(NessieUtils.hist_prog_status_count 'Cancelled').to be > 0 }
+    it('include some with a Completed Program program status') { expect(NessieUtils.hist_prog_status_count 'Completed Program').to be > 0 }
+    it('include some with a Discontinued program status') { expect(NessieUtils.hist_prog_status_count 'Discontinued').to be > 0 }
+    it('include some with a Dismissed program status') { expect(NessieUtils.hist_prog_status_count 'Dismissed').to be > 0 }
+    it('include some with a Suspended program status') { expect(NessieUtils.hist_prog_status_count 'Suspended').to be > 0 }
+    it('include none with an unexpected program status') { expect(NessieUtils.unexpected_hist_prog_status_count).to be_zero }
 
-  context 'when on the manually added advisee list' do
+    it('include all those with historical term enrollments') { expect(NessieUtils.hist_enrollment_sids - NessieUtils.hist_profile_sids).to be_empty }
+    it('include some with null academic career status and no historical term enrollments') do
+      expect(NessieUtils.null_hist_career_status_sids - NessieUtils.hist_enrollment_sids).not_to be_empty
+    end
 
-    it('have completed data') { expect(BOACUtils.deluxe_manual_advisee_sids & @test.students.map(&:sis_id)).not_to be_empty }
-  end
+    context 'when on the manually added advisee list' do
 
-  context 'when inactive' do
+      it('have completed data') { expect(BOACUtils.deluxe_manual_advisee_sids & @test.students.map(&:sis_id)).not_to be_empty }
+    end
 
-    context 'and searched for' do
+    context 'when inactive' do
 
-      before(:all) { @homepage.load_page }
+      context 'and searched for' do
 
-      it 'can be found by SID' do
-        @homepage.type_non_note_string_and_enter @inactive_student.sis_id
-        expect(@search_results_page.student_in_search_result?(@driver, @inactive_student)).to be true
+        before(:all) { @homepage.load_page }
+
+        it 'can be found by SID' do
+          @homepage.type_non_note_string_and_enter @inactive_student.sis_id
+          expect(@search_results_page.student_in_search_result?(@driver, @inactive_student)).to be true
+        end
+
+        it('are added to a queue for nightly data refresh') { expect(BOACUtils.student_in_deluxe_list? @inactive_student).to be true }
       end
 
-      it('are added to a queue for nightly data refresh') { expect(BOACUtils.student_in_deluxe_list? @inactive_student).to be true }
+      context 'and viewed on the student page' do
+
+        before(:all) do
+          @search_results_page.click_student_result @inactive_student
+          @student_page.wait_for_title @inactive_student.full_name
+          @visible_profile_data = @student_page.visible_sis_data
+        end
+
+        it('show a name') { expect(@visible_profile_data[:name]).to eql(@inactive_student.full_name) }
+        it('show an inactive indicator') { expect(@visible_profile_data[:inactive]).to be true }
+        it('show no email') { expect(@visible_profile_data[:email]).to be_nil }
+        it('show no phone') { expect(@visible_profile_data[:phone]).to be_nil }
+        it('show a GPA if one exists') { expect(@visible_profile_data[:cumulative_gpa]).to eql(@inactive_student_profile[:cumulative_gpa]) }
+        it('offer no class page links') { expect(@student_page.class_page_link_elements).to be_empty }
+      end
     end
 
-    context 'and viewed on the student page' do
+    context 'when completed' do
 
-      before(:all) do
-        @search_results_page.click_student_result @inactive_student
-        @student_page.wait_for_title @inactive_student.full_name
-        @visible_profile_data = @student_page.visible_sis_data
+      context 'and searched for' do
+
+        before(:all) { @homepage.load_page }
+
+        it 'can be found by SID' do
+          @homepage.type_non_note_string_and_enter @completed_student.sis_id
+          expect(@search_results_page.student_in_search_result?(@driver, @completed_student)).to be true
+        end
+
+        it('are added to a queue for nightly data refresh') { expect(BOACUtils.student_in_deluxe_list? @completed_student).to be true }
       end
 
-      it('show a name') { expect(@visible_profile_data[:name]).to eql(@inactive_student.full_name) }
-      it('show an inactive indicator') { expect(@visible_profile_data[:inactive]).to be true }
-      it('show no email') { expect(@visible_profile_data[:email]).to be_nil }
-      it('show no phone') { expect(@visible_profile_data[:phone]).to be_nil }
-      it('show a GPA if one exists') { expect(@visible_profile_data[:cumulative_gpa]).to eql(@inactive_student_profile[:cumulative_gpa]) }
-      it('offer no class page links') { expect(@student_page.class_page_link_elements).to be_empty }
+      context 'and viewed on the student page' do
+
+        before(:all) do
+          @search_results_page.click_student_result @completed_student
+          @student_page.wait_for_title @completed_student.full_name
+          @visible_profile_data = @student_page.visible_sis_data
+        end
+
+        it('show a name') { expect(@visible_profile_data[:name]).to eql(@completed_student.full_name) }
+        it('show no inactive indicator') { expect(@visible_profile_data[:inactive]).to be false }
+        it('show no email') { expect(@visible_profile_data[:email]).to be_nil }
+        it('show no phone') { expect(@visible_profile_data[:phone]).to be_nil }
+        it('show a GPA if one exists') { expect(@visible_profile_data[:cumulative_gpa]).to eql(@completed_student_profile[:cumulative_gpa]) }
+        it('show a degree') { expect(@visible_profile_data[:graduation_degree]).to include(@completed_student_profile[:graduation][:majors].join(', ')) }
+        it('show a graduation date') { expect(@visible_profile_data[:graduation_date]).to eql('Awarded ' + Date.parse(@completed_student_profile[:graduation][:date]).strftime('%b %e, %Y')) }
+        it('show a graduation colleges') { expect(@visible_profile_data[:graduation_colleges]).to eql(@completed_student_profile[:graduation][:colleges]) }
+        it('offer no class page links') { expect(@student_page.class_page_link_elements).to be_empty }
+      end
     end
-  end
 
-  context 'when completed' do
+    context 'on a curated group' do
 
-    context 'and searched for' do
+      before(:all) { @group = CuratedGroup.new(name: "Non-current group #{@test.id}") }
 
-      before(:all) { @homepage.load_page }
-
-      it 'can be found by SID' do
-        @homepage.type_non_note_string_and_enter @completed_student.sis_id
-        expect(@search_results_page.student_in_search_result?(@driver, @completed_student)).to be true
+      it 'can be added to a new group' do
+        @homepage.click_sidebar_create_curated_group
+        @group_page.create_group_with_bulk_sids([@inactive_student], @group)
+        @group_page.wait_for_sidebar_group @group
       end
 
-      it('are added to a queue for nightly data refresh') { expect(BOACUtils.student_in_deluxe_list? @completed_student).to be true }
-    end
-
-    context 'and viewed on the student page' do
-
-      before(:all) do
-        @search_results_page.click_student_result @completed_student
-        @student_page.wait_for_title @completed_student.full_name
-        @visible_profile_data = @student_page.visible_sis_data
+      it 'can be added from a student page' do
+        @student_page.load_page @completed_student
+        @student_page.add_student_to_grp(@completed_student, @group)
       end
-
-      it('show a name') { expect(@visible_profile_data[:name]).to eql(@completed_student.full_name) }
-      it('show no inactive indicator') { expect(@visible_profile_data[:inactive]).to be false }
-      it('show no email') { expect(@visible_profile_data[:email]).to be_nil }
-      it('show no phone') { expect(@visible_profile_data[:phone]).to be_nil }
-      it('show a GPA if one exists') { expect(@visible_profile_data[:cumulative_gpa]).to eql(@completed_student_profile[:cumulative_gpa]) }
-      it('show a degree') { expect(@visible_profile_data[:graduation_degree]).to include(@completed_student_profile[:graduation][:majors].join(', ')) }
-      it('show a graduation date') { expect(@visible_profile_data[:graduation_date]).to eql('Awarded ' + Date.parse(@completed_student_profile[:graduation][:date]).strftime('%b %e, %Y')) }
-      it('show a graduation colleges') { expect(@visible_profile_data[:graduation_colleges]).to eql(@completed_student_profile[:graduation][:colleges]) }
-      it('offer no class page links') { expect(@student_page.class_page_link_elements).to be_empty }
     end
+
   end
-
-  context 'on a curated group' do
-
-    before(:all) { @group = CuratedGroup.new(name: "Non-current group #{@test.id}") }
-
-    it 'can be added to a new group' do
-      @homepage.click_sidebar_create_curated_group
-      @group_page.create_group_with_bulk_sids([@inactive_student], @group)
-      @group_page.wait_for_sidebar_group @group
-    end
-
-    it 'can be added from a student page' do
-      @student_page.load_page @completed_student
-      @student_page.add_student_to_grp(@completed_student, @group)
-    end
-  end
-
 end

--- a/spec/boac/boac_last_activity_spec.rb
+++ b/spec/boac/boac_last_activity_spec.rb
@@ -1,357 +1,360 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    if Utils.headless?
+    begin
 
-      logger.warn 'This script requires admin Canvas access and cannot be run headless. Terminating.'
+      if Utils.headless?
 
-    else
+        logger.warn 'This script requires admin Canvas access and cannot be run headless. Terminating.'
 
-      test = BOACTestConfig.new
-      test.last_activity
-      pages_tested = []
-      testable_students = []
+      else
 
-      # Test Last Activity using the current term rather than past term
-      test.term = BOACUtils.term
-      logger.info "Checking term #{test.term}"
-      days_into_term = (Time.now - Time.strptime("#{BOACUtils.term_start_date}", '%Y-%m-%d')) / 86400
-      logger.info "Checking term #{test.term}, which began #{days_into_term} days ago"
+        test = BOACTestConfig.new
+        test.last_activity
+        pages_tested = []
+        testable_students = []
 
-      heading = %w(Term Course SiteId TtlStudents TtlLogins UID CanvasLastActivity CaliperLastActivity NessieLastActivity StudentPageActivity CanvasContext StudentPageContext)
-      last_activity_csv = Utils.create_test_output_csv('boac-last-activity.csv', heading)
+        # Test Last Activity using the current term rather than past term
+        test.term = BOACUtils.term
+        logger.info "Checking term #{test.term}"
+        days_into_term = (Time.now - Time.strptime("#{BOACUtils.term_start_date}", '%Y-%m-%d')) / 86400
+        logger.info "Checking term #{test.term}, which began #{days_into_term} days ago"
 
-      caliper_error_csv = Utils.create_test_output_csv('caliper-errors.csv', %w(SiteId CanvasId UID CanvasLastActivity CaliperLastActivity DiffSeconds P/F))
+        heading = %w(Term Course SiteId TtlStudents TtlLogins UID CanvasLastActivity CaliperLastActivity NessieLastActivity StudentPageActivity CanvasContext StudentPageContext)
+        last_activity_csv = Utils.create_test_output_csv('boac-last-activity.csv', heading)
 
-      @driver = Utils.launch_browser test.chrome_profile
-      @homepage = BOACHomePage.new @driver
-      @cal_net_page = Page::CalNetPage.new @driver
-      @canvas_page = Page::CanvasPage.new @driver
-      @student_page = BOACStudentPage.new @driver
+        caliper_error_csv = Utils.create_test_output_csv('caliper-errors.csv', %w(SiteId CanvasId UID CanvasLastActivity CaliperLastActivity DiffSeconds P/F))
 
-      @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password, 'https://bcourses.berkeley.edu')
-      @homepage.dev_auth test.advisor
+        @driver = Utils.launch_browser test.chrome_profile
+        @homepage = BOACHomePage.new @driver
+        @cal_net_page = Page::CalNetPage.new @driver
+        @canvas_page = Page::CanvasPage.new @driver
+        @student_page = BOACStudentPage.new @driver
 
-      test.test_students.each do |test_student|
-        begin
+        @canvas_page.log_in(@cal_net_page, Utils.super_admin_username, Utils.super_admin_password, 'https://bcourses.berkeley.edu')
+        @homepage.dev_auth test.advisor
 
-          # Get the user API data for the test student to determine which courses to check
-          api_student_page = BOACApiStudentPage.new @driver
-          api_student_page.get_data(@driver, test_student)
-          term = api_student_page.terms.find { |t| api_student_page.term_name(t) == test.term }
-          if term
-            term_id = api_student_page.term_id term
+        test.test_students.each do |test_student|
+          begin
 
-            courses = api_student_page.courses term
-            courses.delete_if { |c| api_student_page.course_display_name(c).include? 'PHYS ED' }
-            courses.each do |course|
+            # Get the user API data for the test student to determine which courses to check
+            api_student_page = BOACApiStudentPage.new @driver
+            api_student_page.get_data(@driver, test_student)
+            term = api_student_page.terms.find { |t| api_student_page.term_name(t) == test.term }
+            if term
+              term_id = api_student_page.term_id term
 
-              course_sis_data = api_student_page.sis_course_data course
-              has_grade = course_sis_data[:grade] && !course_sis_data[:grade].empty?
-              logger.info "Checking course #{course_sis_data[:code]}"
+              courses = api_student_page.courses term
+              courses.delete_if { |c| api_student_page.course_display_name(c).include? 'PHYS ED' }
+              courses.each do |course|
 
-              api_student_page.sections(course).each do |section|
-                begin
+                course_sis_data = api_student_page.sis_course_data course
+                has_grade = course_sis_data[:grade] && !course_sis_data[:grade].empty?
+                logger.info "Checking course #{course_sis_data[:code]}"
 
-                  # Only test a primary section that hasn't been tested already
-                  section_data = api_student_page.sis_section_data section
-                  if api_student_page.sis_section_data(section)[:primary] && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
-                    pages_tested << "#{term_id} #{section_data[:ccn]}"
+                api_student_page.sections(course).each do |section|
+                  begin
 
-                    # Get all the students in the course who will be visible in BOAC
-                    api_section_page = BOACApiSectionPage.new @driver
-                    api_section_page.get_data(@driver, term_id, section_data[:ccn])
-                    visible_classmates = test.students.select { |s| api_section_page.student_uids.include? s.uid }
+                    # Only test a primary section that hasn't been tested already
+                    section_data = api_student_page.sis_section_data section
+                    if api_student_page.sis_section_data(section)[:primary] && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
+                      pages_tested << "#{term_id} #{section_data[:ccn]}"
 
-                    # Only test courses with sites
-                    if api_section_page.student_site_ids(visible_classmates.first).any?
+                      # Get all the students in the course who will be visible in BOAC
+                      api_section_page = BOACApiSectionPage.new @driver
+                      api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                      visible_classmates = test.students.select { |s| api_section_page.student_uids.include? s.uid }
 
-                      testable_students << test_student
-                      visible_student_data = []
-                      all_sites_data = []
+                      # Only test courses with sites
+                      if api_section_page.student_site_ids(visible_classmates.first).any?
 
-                      # Collect all the Canvas sites associated with each student who's visible in BOAC
-                      visible_classmates.each do |classmate|
-                        begin
+                        testable_students << test_student
+                        visible_student_data = []
+                        all_sites_data = []
 
-                          api_classmate_page = BOACApiStudentPage.new @driver
-                          api_classmate_page.get_data(@driver, classmate)
-                          term = api_classmate_page.terms.find { |t| api_classmate_page.term_name(t) == test.term }
-                          classmate_course = api_classmate_page.courses(term).find { |c| api_classmate_page.course_section_ccns(c).include? section_data[:ccn] }
-                          classmate_section = api_classmate_page.sections(classmate_course).find { |s| api_classmate_page.sis_section_data(s)[:ccn] == section_data[:ccn] }
-                          classmate_sites = api_classmate_page.course_sites classmate_course
-                          classmate_data = {
-                            :student => classmate,
-                            :course_code => api_classmate_page.course_display_name(classmate_course),
-                            :section_format => "#{api_classmate_page.sis_section_data(classmate_section)[:component]} #{api_classmate_page.sis_section_data(classmate_section)[:number]}",
-                            :sites => (classmate_sites.map do |site|
-                              {
-                                :site_id => api_classmate_page.site_metadata(site)[:site_id],
-                                :site_code => api_classmate_page.site_metadata(site)[:code],
-                                :last_activity_nessie => ((score = api_classmate_page.nessie_last_activity(site)[:score].to_i).zero? ? nil : Time.at(score).utc)}
-                            end)
-                          }
-                          visible_student_data << classmate_data
-                        end
-                      end
+                        # Collect all the Canvas sites associated with each student who's visible in BOAC
+                        visible_classmates.each do |classmate|
+                          begin
 
-                      # Get the unique sites associated with the course
-                      site_ids = visible_student_data.map { |d| d[:sites].map { |s| s[:site_id] } }
-                      site_ids.flatten!
-                      site_ids.uniq!
-                      logger.info "Canvas course site IDs associated with this course are #{site_ids}"
-
-                      # Load the student page for each student, and collect all the last activity info shown for each site
-                      visible_student_data.each do |d|
-                        @student_page.load_page d[:student]
-                        @student_page.scroll_to_bottom
-                        @student_page.expand_course_data(test.term, d[:course_code])
-                        d[:sites].each do |s|
-                          s.merge!(:last_activity_student_page => @student_page.visible_last_activity(test.term, d[:course_code], d[:sites].index(s)))
-                        end
-                      end
-
-                      # Load each course site, and collect the last activity shown for every student visible in BOAC
-                      site_ids.each do |site_id|
-                        all_site_students = @canvas_page.get_students(Course.new({:site_id => site_id}), nil, 'https://bcourses.berkeley.edu')
-                        visible_student_data.each do |student_data|
-                          if (student_data[:sites].map { |s| s[:site_id] }).include? site_id
-                            matching_student = all_site_students.find { |s| s.uid == student_data[:student].uid }
-                            student_data[:student].canvas_id = matching_student.canvas_id
-                            student_last_activity = @canvas_page.roster_user_last_activity student_data[:student].uid
-                            site_to_update = student_data[:sites].find { |site| site[:site_id] == site_id }
-                            site_to_update.merge!(:last_activity_canvas => (Time.parse(student_last_activity).utc if student_last_activity))
+                            api_classmate_page = BOACApiStudentPage.new @driver
+                            api_classmate_page.get_data(@driver, classmate)
+                            term = api_classmate_page.terms.find { |t| api_classmate_page.term_name(t) == test.term }
+                            classmate_course = api_classmate_page.courses(term).find { |c| api_classmate_page.course_section_ccns(c).include? section_data[:ccn] }
+                            classmate_section = api_classmate_page.sections(classmate_course).find { |s| api_classmate_page.sis_section_data(s)[:ccn] == section_data[:ccn] }
+                            classmate_sites = api_classmate_page.course_sites classmate_course
+                            classmate_data = {
+                                :student => classmate,
+                                :course_code => api_classmate_page.course_display_name(classmate_course),
+                                :section_format => "#{api_classmate_page.sis_section_data(classmate_section)[:component]} #{api_classmate_page.sis_section_data(classmate_section)[:number]}",
+                                :sites => (classmate_sites.map do |site|
+                                  {
+                                      :site_id => api_classmate_page.site_metadata(site)[:site_id],
+                                      :site_code => api_classmate_page.site_metadata(site)[:code],
+                                      :last_activity_nessie => ((score = api_classmate_page.nessie_last_activity(site)[:score].to_i).zero? ? nil : Time.at(score).utc)}
+                                end)
+                            }
+                            visible_student_data << classmate_data
                           end
                         end
 
-                        # Collect the last activity shown for students not visible in BOAC
-                        invisible_student_site_data = []
-                        invisible_students = all_site_students.reject { |student| visible_classmates.map(&:uid).include? student.uid }
-                        invisible_students.each do |invisible_student|
-                          last_activity = @canvas_page.roster_user_last_activity invisible_student.uid
-                          student_data = {
-                            :student => invisible_student,
-                            :sites => [
-                              {
-                                :site_id => site_id,
-                                :last_activity_canvas => (Time.parse(last_activity).utc if last_activity)
-                              }
-                            ]
+                        # Get the unique sites associated with the course
+                        site_ids = visible_student_data.map { |d| d[:sites].map { |s| s[:site_id] } }
+                        site_ids.flatten!
+                        site_ids.uniq!
+                        logger.info "Canvas course site IDs associated with this course are #{site_ids}"
+
+                        # Load the student page for each student, and collect all the last activity info shown for each site
+                        visible_student_data.each do |d|
+                          @student_page.load_page d[:student]
+                          @student_page.scroll_to_bottom
+                          @student_page.expand_course_data(test.term, d[:course_code])
+                          d[:sites].each do |s|
+                            s.merge!(:last_activity_student_page => @student_page.visible_last_activity(test.term, d[:course_code], d[:sites].index(s)))
+                          end
+                        end
+
+                        # Load each course site, and collect the last activity shown for every student visible in BOAC
+                        site_ids.each do |site_id|
+                          all_site_students = @canvas_page.get_students(Course.new({:site_id => site_id}), nil, 'https://bcourses.berkeley.edu')
+                          visible_student_data.each do |student_data|
+                            if (student_data[:sites].map { |s| s[:site_id] }).include? site_id
+                              matching_student = all_site_students.find { |s| s.uid == student_data[:student].uid }
+                              student_data[:student].canvas_id = matching_student.canvas_id
+                              student_last_activity = @canvas_page.roster_user_last_activity student_data[:student].uid
+                              site_to_update = student_data[:sites].find { |site| site[:site_id] == site_id }
+                              site_to_update.merge!(:last_activity_canvas => (Time.parse(student_last_activity).utc if student_last_activity))
+                            end
+                          end
+
+                          # Collect the last activity shown for students not visible in BOAC
+                          invisible_student_site_data = []
+                          invisible_students = all_site_students.reject { |student| visible_classmates.map(&:uid).include? student.uid }
+                          invisible_students.each do |invisible_student|
+                            last_activity = @canvas_page.roster_user_last_activity invisible_student.uid
+                            student_data = {
+                                :student => invisible_student,
+                                :sites => [
+                                    {
+                                        :site_id => site_id,
+                                        :last_activity_canvas => (Time.parse(last_activity).utc if last_activity)
+                                    }
+                                ]
+                            }
+                            invisible_student_site_data << student_data
+                          end
+
+                          # Aggregate the Canvas data for the site
+                          all_last_activities = all_site_students.map do |student|
+                            student_data = (visible_student_data + invisible_student_site_data).find { |data| data[:student].uid == student.uid }
+                            site = student_data[:sites].find { |s| s[:site_id] == site_id }
+                            site[:last_activity_canvas]
+                          end
+                          all_site_data = {
+                              :site_id => site_id,
+                              :student_count => all_site_students.length,
+                              :last_activity_dates => all_last_activities
                           }
-                          invisible_student_site_data << student_data
-                        end
+                          all_sites_data << all_site_data
 
-                        # Aggregate the Canvas data for the site
-                        all_last_activities = all_site_students.map do |student|
-                          student_data = (visible_student_data + invisible_student_site_data).find { |data| data[:student].uid == student.uid }
-                          site = student_data[:sites].find { |s| s[:site_id] == site_id }
-                          site[:last_activity_canvas]
-                        end
-                        all_site_data = {
-                          :site_id => site_id,
-                          :student_count => all_site_students.length,
-                          :last_activity_dates => all_last_activities
-                        }
-                        all_sites_data << all_site_data
+                          # CALIPER DATA
 
-                        # CALIPER DATA
+                          (visible_student_data + invisible_student_site_data).each do |student_data|
 
-                        (visible_student_data + invisible_student_site_data).each do |student_data|
+                            student_data[:sites].each do |student_site|
+                              student_site.merge!(:last_activity_caliper => NessieUtils.get_caliper_last_activity(student_data[:student], student_site[:site_id]))
 
-                          student_data[:sites].each do |student_site|
-                            student_site.merge!(:last_activity_caliper => NessieUtils.get_caliper_last_activity(student_data[:student], student_site[:site_id]))
+                              if NessieUtils.include_caliper_tests
 
-                            if NessieUtils.include_caliper_tests
-
-                              if student_site[:last_activity_canvas].nil?
-                                it "Caliper has no last activity data for site #{student_site[:site_id]}, UID #{student_data[:student].uid}, Canvas ID #{student_data[:student].canvas_id}" do
-                                  expect(student_site[:last_activity_caliper]).to be_nil
-                                end
-
-                              else
-                                if student_site[:last_activity_caliper].nil?
-                                  it("Caliper has no last activity data for site #{student_site[:site_id]}, UID #{student_data[:student].uid}, Canvas ID #{student_data[:student].canvas_id}, but it should") { fail }
+                                if student_site[:last_activity_canvas].nil?
+                                  it "Caliper has no last activity data for site #{student_site[:site_id]}, UID #{student_data[:student].uid}, Canvas ID #{student_data[:student].canvas_id}" do
+                                    expect(student_site[:last_activity_caliper]).to be_nil
+                                  end
 
                                 else
-                                  hours_since = (Time.now.utc - student_site[:last_activity_canvas]) / 3600
-                                  if hours_since < NessieUtils.canvas_data_lag_hours
-                                    logger.warn "Skipping Caliper last activity check for UID #{student_data[:student].uid} in site ID #{student_site[:site_id]} since it was #{hours_since.round 1} hours ago"
+                                  if student_site[:last_activity_caliper].nil?
+                                    it("Caliper has no last activity data for site #{student_site[:site_id]}, UID #{student_data[:student].uid}, Canvas ID #{student_data[:student].canvas_id}, but it should") { fail }
 
                                   else
-                                    diff = (student_site[:last_activity_caliper] - student_site[:last_activity_canvas]).abs
-                                    it "Caliper has the right last activity data for site #{student_site[:site_id]}, UID #{student_data[:student].uid}, Canvas ID #{student_data[:student].canvas_id}" do
-                                      expect(diff).to be < NessieUtils.caliper_time_margin
-                                    end
+                                    hours_since = (Time.now.utc - student_site[:last_activity_canvas]) / 3600
+                                    if hours_since < NessieUtils.canvas_data_lag_hours
+                                      logger.warn "Skipping Caliper last activity check for UID #{student_data[:student].uid} in site ID #{student_site[:site_id]} since it was #{hours_since.round 1} hours ago"
 
-                                    result = (diff > NessieUtils.caliper_time_margin) ? 'Fail' : 'Pass'
-                                    error_data = [student_site[:site_id], student_data[:student].canvas_id, student_data[:student].uid,
-                                                  student_site[:last_activity_canvas], student_site[:last_activity_caliper], (student_site[:last_activity_caliper] - student_site[:last_activity_canvas]), result]
-                                    Utils.add_csv_row(caliper_error_csv, error_data)
-                                    logger.debug "Canvas vs Caliper diff is #{diff} on site #{student_site[:site_id]} UID #{student_data[:student].uid}"
+                                    else
+                                      diff = (student_site[:last_activity_caliper] - student_site[:last_activity_canvas]).abs
+                                      it "Caliper has the right last activity data for site #{student_site[:site_id]}, UID #{student_data[:student].uid}, Canvas ID #{student_data[:student].canvas_id}" do
+                                        expect(diff).to be < NessieUtils.caliper_time_margin
+                                      end
+
+                                      result = (diff > NessieUtils.caliper_time_margin) ? 'Fail' : 'Pass'
+                                      error_data = [student_site[:site_id], student_data[:student].canvas_id, student_data[:student].uid,
+                                                    student_site[:last_activity_canvas], student_site[:last_activity_caliper], (student_site[:last_activity_caliper] - student_site[:last_activity_canvas]), result]
+                                      Utils.add_csv_row(caliper_error_csv, error_data)
+                                      logger.debug "Canvas vs Caliper diff is #{diff} on site #{student_site[:site_id]} UID #{student_data[:student].uid}"
+                                    end
                                   end
                                 end
                               end
                             end
                           end
                         end
-                      end
 
-                      visible_student_data.each do |student_data|
-                        begin
+                        visible_student_data.each do |student_data|
+                          begin
 
-                          student_data[:sites].each do |student_site|
+                            student_data[:sites].each do |student_site|
 
-                            test_case = "UID #{student_data[:student].uid} in Canvas site ID #{student_site[:site_id]}"
-                            logger.info "Checking last activity for #{student_site}"
+                              test_case = "UID #{student_data[:student].uid} in Canvas site ID #{student_site[:site_id]}"
+                              logger.info "Checking last activity for #{student_site}"
 
-                            it("last activity date is not older than the Caliper date for UID #{student_data[:student].uid} in Canvas site ID #{student_site[:site_id]}") do
-                              if student_site[:last_activity_caliper].nil?
-                                expect(student_site[:last_activity_nessie]).to be_nil
-                              else
-                                expect(student_site[:last_activity_nessie]).to be >= student_site[:last_activity_caliper]
-                              end
-                            end
-
-                            # Record the activity data to a CSV
-                            site = all_sites_data.find { |s| s[:site_id] == student_site[:site_id] }
-                            total_logins = site[:last_activity_dates].compact.length
-                            more_recent_logins = student_site[:last_activity_canvas] ? site[:last_activity_dates].compact.select { |date| date > student_site[:last_activity_canvas] } : []
-
-                            data_to_record = [test.term, course_sis_data[:code], site[:site_id], site[:last_activity_dates].length, total_logins,
-                                              student_data[:student].uid, student_site[:last_activity_canvas], student_site[:last_activity_caliper],
-                                              student_site[:last_activity_nessie], student_site[:last_activity_student_page][:days],
-                                              (("#{more_recent_logins.length} out of #{site[:last_activity_dates].length} enrolled students have done so more recently.") if more_recent_logins),
-                                              student_site[:last_activity_student_page][:context]]
-                            Utils.add_csv_row(last_activity_csv, data_to_record)
-
-                            # SITE DETAIL
-
-                            if student_site[:last_activity_canvas].nil?
-                              it("shows 'never' Last Activity in the BOAC student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include('never') }
-
-                              # Note if the site could trigger a 'no activity' alert
-                              # TODO - account for 'start of session'
-                              student_site.merge!(:no_activity_alert => true) if total_logins.to_f / site[:last_activity_dates].length.to_f >= 0.8
-
-                            else
-
-                              day_count = (Date.today - Date.parse(student_site[:last_activity_canvas].localtime.to_s)).to_i
-                              hours_since = (Time.now.utc - student_site[:last_activity_canvas]) / 3600
-                              if  hours_since < NessieUtils.canvas_data_lag_hours
-                                logger.warn "Skipping Caliper last activity check for #{test_case} since it was #{hours_since.round 1} hours ago"
-
-                              else
-
-                                (day_count == 1) ?
-                                    (it("shows 'yesterday' Last Activity on the student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include('yesterday') }) :
-                                    (it("shows '#{day_count} days ago' Last Activity on the student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include("#{day_count} days ago") })
-
-                                if BOACUtils.last_activity_context
-                                  it("shows #{site[:last_activity_dates].length} total students for #{test_case}") { expect(student_site[:last_activity_student_page][:context]).to include("out of #{site[:last_activity_dates].length} enrolled students") }
+                              it("last activity date is not older than the Caliper date for UID #{student_data[:student].uid} in Canvas site ID #{student_site[:site_id]}") do
+                                if student_site[:last_activity_caliper].nil?
+                                  expect(student_site[:last_activity_nessie]).to be_nil
+                                else
+                                  expect(student_site[:last_activity_nessie]).to be >= student_site[:last_activity_caliper]
                                 end
                               end
 
-                              # Note if the site could trigger an 'infrequent activity' alert
-                              student_site.merge!(:infrequent_activity_alert => true) if (day_count >= 14) && (more_recent_logins.length.to_f / site[:last_activity_dates].length.to_f >= 0.8)
+                              # Record the activity data to a CSV
+                              site = all_sites_data.find { |s| s[:site_id] == student_site[:site_id] }
+                              total_logins = site[:last_activity_dates].compact.length
+                              more_recent_logins = student_site[:last_activity_canvas] ? site[:last_activity_dates].compact.select { |date| date > student_site[:last_activity_canvas] } : []
 
+                              data_to_record = [test.term, course_sis_data[:code], site[:site_id], site[:last_activity_dates].length, total_logins,
+                                                student_data[:student].uid, student_site[:last_activity_canvas], student_site[:last_activity_caliper],
+                                                student_site[:last_activity_nessie], student_site[:last_activity_student_page][:days],
+                                                (("#{more_recent_logins.length} out of #{site[:last_activity_dates].length} enrolled students have done so more recently.") if more_recent_logins),
+                                                student_site[:last_activity_student_page][:context]]
+                              Utils.add_csv_row(last_activity_csv, data_to_record)
+
+                              # SITE DETAIL
+
+                              if student_site[:last_activity_canvas].nil?
+                                it("shows 'never' Last Activity in the BOAC student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include('never') }
+
+                                # Note if the site could trigger a 'no activity' alert
+                                # TODO - account for 'start of session'
+                                student_site.merge!(:no_activity_alert => true) if total_logins.to_f / site[:last_activity_dates].length.to_f >= 0.8
+
+                              else
+
+                                day_count = (Date.today - Date.parse(student_site[:last_activity_canvas].localtime.to_s)).to_i
+                                hours_since = (Time.now.utc - student_site[:last_activity_canvas]) / 3600
+                                if hours_since < NessieUtils.canvas_data_lag_hours
+                                  logger.warn "Skipping Caliper last activity check for #{test_case} since it was #{hours_since.round 1} hours ago"
+
+                                else
+
+                                  (day_count == 1) ?
+                                      (it("shows 'yesterday' Last Activity on the student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include('yesterday') }) :
+                                      (it("shows '#{day_count} days ago' Last Activity on the student page for #{test_case}") { expect(student_site[:last_activity_student_page][:days]).to include("#{day_count} days ago") })
+
+                                  if BOACUtils.last_activity_context
+                                    it("shows #{site[:last_activity_dates].length} total students for #{test_case}") { expect(student_site[:last_activity_student_page][:context]).to include("out of #{site[:last_activity_dates].length} enrolled students") }
+                                  end
+                                end
+
+                                # Note if the site could trigger an 'infrequent activity' alert
+                                student_site.merge!(:infrequent_activity_alert => true) if (day_count >= 14) && (more_recent_logins.length.to_f / site[:last_activity_dates].length.to_f >= 0.8)
+
+                              end
                             end
-                          end
 
-                          # ALERTS
+                            # ALERTS
 
-                          # To verify that an inactivity alert does NOT exist, compare without the 'x days' portion of the alerts
-                          user_alert_msgs = BOACUtils.get_students_alerts([student_data[:student]]).map &:message
-                          truncated_alert_msgs = user_alert_msgs.map { |msg| msg.gsub(/( was )\d+( days ago.)/, '') }
-                          logger.debug "UID #{student_data[:student].uid} alerts: #{user_alert_msgs}"
+                            # To verify that an inactivity alert does NOT exist, compare without the 'x days' portion of the alerts
+                            user_alert_msgs = BOACUtils.get_students_alerts([student_data[:student]]).map &:message
+                            truncated_alert_msgs = user_alert_msgs.map { |msg| msg.gsub(/( was )\d+( days ago.)/, '') }
+                            logger.debug "UID #{student_data[:student].uid} alerts: #{user_alert_msgs}"
 
-                          test_case = "UID #{student_data[:student].uid} in #{student_data[:course_code]}"
-                          logger.debug "Checking #{test_case}"
+                            test_case = "UID #{student_data[:student].uid} in #{student_data[:course_code]}"
+                            logger.debug "Checking #{test_case}"
 
-                          # Don't show any activity alerts before at least 14 days into term, show no alerts during summer, and show no alerts if a grade exists
-                          if (days_into_term < BOACUtils.no_activity_alert_threshold) || (BOACUtils.term.include? 'Summer') || has_grade
+                            # Don't show any activity alerts before at least 14 days into term, show no alerts during summer, and show no alerts if a grade exists
+                            if (days_into_term < BOACUtils.no_activity_alert_threshold) || (BOACUtils.term.include? 'Summer') || has_grade
 
-                            it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
-                            it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
-
-                          else
-
-                            # Never show alerts for DeCal courses
-                            if (/\A[A-Z\s]+1?9[89][A-Z]?[A-Z]?/ === student_data[:course_code].gsub("#{student_data[:section_format]}", '').strip) && !student_data[:section_format].include?('LEC')
                               it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
                               it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
 
                             else
-                              # Alerts are not shown for sites below an activity threshold, so get the student's 'active' sites
-                              active_student_sites = student_data[:sites].select do |student_site|
-                                course_site = all_sites_data.find { |course_site| course_site[:site_id] == student_site[:site_id] }
-                                logger.debug "Site #{course_site[:site_id]} has #{course_site[:last_activity_dates].compact.length.to_f} active users out of #{course_site[:student_count].to_f} enrollments"
-                                (course_site[:last_activity_dates].compact.length.to_f / course_site[:student_count].to_f > 0.8)
-                              end
-                              logger.debug "Active sites are #{active_student_sites}"
 
-                              # Get the sites that could trigger an alert
-                              infrequent_alert_triggers = active_student_sites.select { |site| site[:infrequent_activity_alert] }
-                              no_activity_alert_triggers = active_student_sites.select { |site| site[:no_activity_alert] }
-
-                              # If all the active sites could trigger 'no activity' alerts for the student, then show a 'no activity' alert
-                              if no_activity_alert_triggers.any? && no_activity_alert_triggers.length == active_student_sites.length
-                                it("shows a 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
-                                it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
-
-                                # If all the active sites could trigger an alert and some could trigger an 'infrequent activity' alert,
-                                # then show an 'infrequent' alert for the one with the most recent activity
-                              elsif infrequent_alert_triggers.any? && (no_activity_alert_triggers.length + infrequent_alert_triggers.length == active_student_sites.length)
-                                most_recent = infrequent_alert_triggers.max_by { |site| site[:last_activity_canvas] }
-                                day_count = (Date.today - Date.parse(most_recent[:last_activity_canvas].to_s)).to_i
-                                it("shows an infrequent activity alert for #{test_case}") { expect(user_alert_msgs).to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity was #{day_count} days ago.") }
+                              # Never show alerts for DeCal courses
+                              if (/\A[A-Z\s]+1?9[89][A-Z]?[A-Z]?/ === student_data[:course_code].gsub("#{student_data[:section_format]}", '').strip) && !student_data[:section_format].include?('LEC')
                                 it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+                                it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
 
                               else
-                                it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
-                                it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
+                                # Alerts are not shown for sites below an activity threshold, so get the student's 'active' sites
+                                active_student_sites = student_data[:sites].select do |student_site|
+                                  course_site = all_sites_data.find { |course_site| course_site[:site_id] == student_site[:site_id] }
+                                  logger.debug "Site #{course_site[:site_id]} has #{course_site[:last_activity_dates].compact.length.to_f} active users out of #{course_site[:student_count].to_f} enrollments"
+                                  (course_site[:last_activity_dates].compact.length.to_f / course_site[:student_count].to_f > 0.8)
+                                end
+                                logger.debug "Active sites are #{active_student_sites}"
+
+                                # Get the sites that could trigger an alert
+                                infrequent_alert_triggers = active_student_sites.select { |site| site[:infrequent_activity_alert] }
+                                no_activity_alert_triggers = active_student_sites.select { |site| site[:no_activity_alert] }
+
+                                # If all the active sites could trigger 'no activity' alerts for the student, then show a 'no activity' alert
+                                if no_activity_alert_triggers.any? && no_activity_alert_triggers.length == active_student_sites.length
+                                  it("shows a 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+                                  it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
+
+                                  # If all the active sites could trigger an alert and some could trigger an 'infrequent activity' alert,
+                                  # then show an 'infrequent' alert for the one with the most recent activity
+                                elsif infrequent_alert_triggers.any? && (no_activity_alert_triggers.length + infrequent_alert_triggers.length == active_student_sites.length)
+                                  most_recent = infrequent_alert_triggers.max_by { |site| site[:last_activity_canvas] }
+                                  day_count = (Date.today - Date.parse(most_recent[:last_activity_canvas].to_s)).to_i
+                                  it("shows an infrequent activity alert for #{test_case}") { expect(user_alert_msgs).to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity was #{day_count} days ago.") }
+                                  it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+
+                                else
+                                  it("shows no 'No activity!' alert for #{test_case}") { expect(user_alert_msgs).not_to include("No activity! Student has never visited the #{student_data[:course_code]} bCourses site for #{BOACUtils.term}.") }
+                                  it("shows no infrequent activity alert for #{test_case}") { expect(truncated_alert_msgs).not_to include("Infrequent activity! Last #{student_data[:course_code]} bCourses activity") }
+                                end
                               end
                             end
+
+                          rescue => e
+                            Utils.log_error e
+                            it("hit an error with #{student_data[:student].uid}") { fail }
                           end
-
-                        rescue => e
-                          Utils.log_error e
-                          it("hit an error with #{student_data[:student].uid}") { fail }
                         end
+
+                      else
+                        logger.warn "There are no Canvas sites to check for term #{test.term} CCN #{section_data[:ccn]}, skipping"
                       end
-
-                    else
-                      logger.warn "There are no Canvas sites to check for term #{test.term} CCN #{section_data[:ccn]}, skipping"
                     end
-                  end
 
-                rescue => e
-                  Utils.log_error e
-                  it("hit an error with term #{test.term} CCN #{section_data[:ccn]}") { fail }
+                  rescue => e
+                    Utils.log_error e
+                    it("hit an error with term #{test.term} CCN #{section_data[:ccn]}") { fail }
+                  end
                 end
               end
+            else
+              logger.warn "UID #{test_student.uid} has no enrollments in #{test.term}"
             end
-          else
-            logger.warn "UID #{test_student.uid} has no enrollments in #{test.term}"
-          end
 
-        rescue => e
-          Utils.log_error e
-          it("hit an error with #{test.default_cohort.name} UID #{test_student.uid}") { fail }
+          rescue => e
+            Utils.log_error e
+            it("hit an error with #{test.default_cohort.name} UID #{test_student.uid}") { fail }
+          end
         end
+
+        it('has at least one student with Canvas sites') { expect(testable_students).not_to be_empty }
       end
 
-      it('has at least one student with Canvas sites') { expect(testable_students).not_to be_empty }
+    rescue => e
+      Utils.log_error e
+      it('hit an error') { fail }
+    ensure
+      Utils.quit_browser @driver
     end
-
-  rescue => e
-    Utils.log_error e
-    it('hit an error') { fail }
-  ensure
-    Utils.quit_browser @driver
   end
 end

--- a/spec/boac/boac_navigation_spec.rb
+++ b/spec/boac/boac_navigation_spec.rb
@@ -1,37 +1,39 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    test = BOACTestConfig.new
-    test.navigation
-    pages_tested = []
-    bubbles_tested = []
+    begin
 
-    @driver = Utils.launch_browser test.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @class_list_page = BOACClassListViewPage.new @driver
-    @class_matrix_page = BOACClassMatrixViewPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @homepage.dev_auth test.advisor
+      test = BOACTestConfig.new
+      test.navigation
+      pages_tested = []
+      bubbles_tested = []
 
-    test.test_students.each do |student|
-      begin
+      @driver = Utils.launch_browser test.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @class_list_page = BOACClassListViewPage.new @driver
+      @class_matrix_page = BOACClassMatrixViewPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @homepage.dev_auth test.advisor
 
-        api_user_page = BOACApiStudentPage.new @driver
-        api_user_page.get_data(@driver, student)
+      test.test_students.each do |student|
+        begin
 
-        terms = api_user_page.terms
-        if terms.any?
-          @student_page.load_page student
-          @student_page.click_view_previous_semesters if terms.length > 1
-          logger.debug "There are #{terms.length} terms"
-          logger.debug "The first term is #{api_user_page.term_name terms.first}"
+          api_user_page = BOACApiStudentPage.new @driver
+          api_user_page.get_data(@driver, student)
 
-          term = terms.first
+          terms = api_user_page.terms
+          if terms.any?
+            @student_page.load_page student
+            @student_page.click_view_previous_semesters if terms.length > 1
+            logger.debug "There are #{terms.length} terms"
+            logger.debug "The first term is #{api_user_page.term_name terms.first}"
+
+            term = terms.first
             begin
 
               term_name = api_user_page.term_name term
@@ -40,110 +42,111 @@ describe 'BOAC' do
 
               courses = api_user_page.courses term
               courses.each do |course|
-              begin
+                begin
 
-                course_sis_data = api_user_page.sis_course_data course
-                logger.info "Checking course #{course_sis_data[:code]}"
-                sections = api_user_page.sections course
-                sections.each do |section|
-                  begin
+                  course_sis_data = api_user_page.sis_course_data course
+                  logger.info "Checking course #{course_sis_data[:code]}"
+                  sections = api_user_page.sections course
+                  sections.each do |section|
+                    begin
 
-                    section_data = api_user_page.sis_section_data section
-                    api_section_page = BOACApiSectionPage.new @driver
-                    api_section_page.get_data(@driver, term_id, section_data[:ccn])
-                    class_test_case = "term #{term_name} course #{course_sis_data[:code]} section #{section_data[:component]} #{section_data[:number]} #{section_data[:ccn]}"
-                    logger.info "Checking #{class_test_case}"
+                      section_data = api_user_page.sis_section_data section
+                      api_section_page = BOACApiSectionPage.new @driver
+                      api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                      class_test_case = "term #{term_name} course #{course_sis_data[:code]} section #{section_data[:component]} #{section_data[:number]} #{section_data[:ccn]}"
+                      logger.info "Checking #{class_test_case}"
 
-                    @student_page.load_page student
-                    @student_page.click_view_previous_semesters if terms.length > 1
-                    if @student_page.class_page_link(term_id, section_data[:ccn]).exists? && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
-                      @student_page.click_class_page_link(term_id, section_data[:ccn])
-                      pages_tested << "#{term_id} #{section_data[:ccn]}"
+                      @student_page.load_page student
+                      @student_page.click_view_previous_semesters if terms.length > 1
+                      if @student_page.class_page_link(term_id, section_data[:ccn]).exists? && !pages_tested.include?("#{term_id} #{section_data[:ccn]}")
+                        @student_page.click_class_page_link(term_id, section_data[:ccn])
+                        pages_tested << "#{term_id} #{section_data[:ccn]}"
 
-                      # CLASS PAGE - List View
+                        # CLASS PAGE - List View
 
-                      visible_sids = @class_list_page.visible_sids.sort.uniq
-                      expected_sids = api_section_page.student_sids.sort
-                      it("shows all the expected list view students in #{class_test_case}") { expect(visible_sids).to eql(expected_sids) }
+                        visible_sids = @class_list_page.visible_sids.sort.uniq
+                        expected_sids = api_section_page.student_sids.sort
+                        it("shows all the expected list view students in #{class_test_case}") { expect(visible_sids).to eql(expected_sids) }
 
-                      # Visit student
-                      @class_list_page.click_student_link BOACUser.new({:uid => @class_list_page.list_view_uids.last})
-                      list_to_student = @student_page.verify_block { @student_page.sid_element.when_visible Utils.short_wait }
-                      it("links student pages from the list view of #{class_test_case}") { expect(list_to_student).to be true }
+                        # Visit student
+                        @class_list_page.click_student_link BOACUser.new({:uid => @class_list_page.list_view_uids.last})
+                        list_to_student = @student_page.verify_block { @student_page.sid_element.when_visible Utils.short_wait }
+                        it("links student pages from the list view of #{class_test_case}") { expect(list_to_student).to be true }
 
-                      # Back to list view
-                      @driver.navigate.back
-                      student_to_list = @class_list_page.verify_block { @class_list_page.wait_until(Utils.short_wait) { @class_list_page.course_title == course_sis_data[:title] } }
-                      it("returns to the list view of #{class_test_case}") { expect(student_to_list).to be true }
+                        # Back to list view
+                        @driver.navigate.back
+                        student_to_list = @class_list_page.verify_block { @class_list_page.wait_until(Utils.short_wait) { @class_list_page.course_title == course_sis_data[:title] } }
+                        it("returns to the list view of #{class_test_case}") { expect(student_to_list).to be true }
 
-                      # CLASS PAGE - Matrix View
+                        # CLASS PAGE - Matrix View
 
-                      if @class_matrix_page.matrix_view_button_element.attribute 'disabled'
-                        logger.warn "Skipping matrix view testing since there is no matrix view for #{class_test_case}"
-                      else
-
-                        @class_list_page.click_matrix_view
-                        @class_matrix_page.wait_for_matrix
-                        student_expanded = @class_matrix_page.bubble_expanded? student
-                        it("shows the student's bubble expanded in #{class_test_case}") { expect(student_expanded).to be true }
-
-                        all_students_present = @class_matrix_page.verify_all_students_present expected_sids.length
-                        it("shows all the expected matrix view students in #{class_test_case}") { expect(all_students_present).to be true }
-
-                        # Visit student. Clicking a matrix bubble will throw an error if another bubble obscures it, so only proceed if the bubble is clickable.
-                        student_page_testable = if @class_matrix_page.matrix_bubbles.any?
-                                                  begin
-                                                    @class_matrix_page.click_last_student_bubble
-                                                    bubbles_tested << class_test_case
-                                                    true
-                                                  rescue => e
-                                                    logger.error "#{e.message}"
-                                                    false
-                                                  end
-                                                else
-                                                  @class_matrix_page.click_last_no_data_student
-                                                  true
-                                                end
-
-                        if student_page_testable
-                          matrix_to_student = @student_page.verify_block { @student_page.sid_element.when_visible Utils.short_wait }
-                          it("links student pages from the matrix view of #{class_test_case}") { expect(matrix_to_student).to be true }
-
-                          # Back to matrix view
-                          @driver.navigate.back
-                          student_to_matrix = @class_matrix_page.verify_block { @class_matrix_page.wait_for_matrix }
-                          it("returns to the matrix view of #{class_test_case}") { expect(student_to_matrix).to be_truthy }
+                        if @class_matrix_page.matrix_view_button_element.attribute 'disabled'
+                          logger.warn "Skipping matrix view testing since there is no matrix view for #{class_test_case}"
                         else
-                          logger.warn "Skipping matrix to student page tests because the bubbles are all bunched up for #{class_test_case}"
+
+                          @class_list_page.click_matrix_view
+                          @class_matrix_page.wait_for_matrix
+                          student_expanded = @class_matrix_page.bubble_expanded? student
+                          it("shows the student's bubble expanded in #{class_test_case}") { expect(student_expanded).to be true }
+
+                          all_students_present = @class_matrix_page.verify_all_students_present expected_sids.length
+                          it("shows all the expected matrix view students in #{class_test_case}") { expect(all_students_present).to be true }
+
+                          # Visit student. Clicking a matrix bubble will throw an error if another bubble obscures it, so only proceed if the bubble is clickable.
+                          student_page_testable = if @class_matrix_page.matrix_bubbles.any?
+                                                    begin
+                                                      @class_matrix_page.click_last_student_bubble
+                                                      bubbles_tested << class_test_case
+                                                      true
+                                                    rescue => e
+                                                      logger.error "#{e.message}"
+                                                      false
+                                                    end
+                                                  else
+                                                    @class_matrix_page.click_last_no_data_student
+                                                    true
+                                                  end
+
+                          if student_page_testable
+                            matrix_to_student = @student_page.verify_block { @student_page.sid_element.when_visible Utils.short_wait }
+                            it("links student pages from the matrix view of #{class_test_case}") { expect(matrix_to_student).to be true }
+
+                            # Back to matrix view
+                            @driver.navigate.back
+                            student_to_matrix = @class_matrix_page.verify_block { @class_matrix_page.wait_for_matrix }
+                            it("returns to the matrix view of #{class_test_case}") { expect(student_to_matrix).to be_truthy }
+                          else
+                            logger.warn "Skipping matrix to student page tests because the bubbles are all bunched up for #{class_test_case}"
+                          end
                         end
                       end
+                    rescue => e
+                      BOACUtils.log_error e
+                      it("caused an error with UID #{student.uid} #{class_test_case}") { fail }
                     end
-                  rescue => e
-                    BOACUtils.log_error e
-                    it("caused an error with UID #{student.uid} #{class_test_case}") { fail }
                   end
+                rescue => e
+                  BOACUtils.log_error e
+                  it("caused an error with UID #{student.uid} term #{term_id} course #{course_sis_data[:code]}") { fail }
                 end
-              rescue => e
-                BOACUtils.log_error e
-                it("caused an error with UID #{student.uid} term #{term_id} course #{course_sis_data[:code]}") { fail }
               end
+            rescue => e
+              BOACUtils.log_error e
+              it("caused an error with UID #{student.uid} term #{term_id}") { fail }
             end
-          rescue => e
-            BOACUtils.log_error e
-            it("caused an error with UID #{student.uid} term #{term_id}") { fail }
           end
+        rescue => e
+          BOACUtils.log_error e
+          it("caused an error with UID #{student.uid}") { fail }
         end
-      rescue => e
-        BOACUtils.log_error e
-        it("caused an error with UID #{student.uid}") { fail }
       end
-    end
 
-  rescue => e
-    BOACUtils.log_error e
-    it('has at least one testable matrix bubble') { expect(bubbles_tested).not_to be_empty }
-    it('threw an error') { fail }
-  ensure
-    Utils.quit_browser @driver
+    rescue => e
+      BOACUtils.log_error e
+      it('has at least one testable matrix bubble') { expect(bubbles_tested).not_to be_empty }
+      it('threw an error') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end

--- a/spec/boac/boac_note_batch_spec.rb
+++ b/spec/boac/boac_note_batch_spec.rb
@@ -1,182 +1,185 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-test = BOACTestConfig.new
-test.batch_note_management
+  include Logging
 
-# TODO - get real array of advisor dept mappings when we have them
-test.advisor.depts = [test.dept.name]
+  test = BOACTestConfig.new
+  test.batch_note_management
 
-if test.dept == BOACDepartments::ADMIN
+  # TODO - get real array of advisor dept mappings when we have them
+  test.advisor.depts = [test.dept.name]
 
-  logger.error 'Tests cannot be run for the Admin dept'
+  if test.dept == BOACDepartments::ADMIN
 
-else
+    logger.error 'Tests cannot be run for the Admin dept'
 
-  batch_notes = []
-  batch_notes << (batch_note_1 = NoteBatch.new({advisor: test.advisor, subject: "Batch note 1 subject #{Utils.get_test_id}"}))
-  batch_notes << (batch_note_2 = NoteBatch.new({advisor: test.advisor, subject: "Batch note 2 subject #{Utils.get_test_id}"}))
+  else
 
-  students = test.students.first BOACUtils.config['notes_batch_students_count']
-  cohorts = []
-  curated_groups = []
-  curated_group_members = test.students.shuffle.last BOACUtils.config['notes_batch_curated_group_count']
-  curated_group_1 = CuratedGroup.new({:name => "Group 1 - #{test.id}"})
-  curated_group_2 = CuratedGroup.new({:name => "Group 2 - #{test.id}"})
+    batch_notes = []
+    batch_notes << (batch_note_1 = NoteBatch.new({advisor: test.advisor, subject: "Batch note 1 subject #{Utils.get_test_id}"}))
+    batch_notes << (batch_note_2 = NoteBatch.new({advisor: test.advisor, subject: "Batch note 2 subject #{Utils.get_test_id}"}))
 
-  describe 'A BOAC', order: :defined do
+    students = test.students.first BOACUtils.config['notes_batch_students_count']
+    cohorts = []
+    curated_groups = []
+    curated_group_members = test.students.shuffle.last BOACUtils.config['notes_batch_curated_group_count']
+    curated_group_1 = CuratedGroup.new({:name => "Group 1 - #{test.id}"})
+    curated_group_2 = CuratedGroup.new({:name => "Group 2 - #{test.id}"})
 
-    include Logging
+    describe 'A BOAC', order: :defined do
 
-    before(:all) do
-      @driver = Utils.launch_browser
-      @homepage = BOACHomePage.new @driver
-      @cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
-      @curated_group_page = BOACGroupPage.new @driver
-      @student_page = BOACStudentPage.new @driver
-      @search_results_page = BOACSearchResultsPage.new @driver
+      include Logging
 
-      @homepage.dev_auth test.advisor
-    end
+      before(:all) do
+        @driver = Utils.launch_browser
+        @homepage = BOACHomePage.new @driver
+        @cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
+        @curated_group_page = BOACGroupPage.new @driver
+        @student_page = BOACStudentPage.new @driver
+        @search_results_page = BOACSearchResultsPage.new @driver
 
-    after(:all) { Utils.quit_browser @driver }
-
-    describe 'advisor' do
-
-      context 'with no cohorts or groups' do
-
-        before(:all) do
-          pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
-          pre_existing_cohorts.each do |c|
-            @cohort_page.load_cohort c
-            @cohort_page.delete_cohort c
-          end
-
-          pre_existing_groups = BOACUtils.get_user_curated_groups test.advisor
-          pre_existing_groups.each do |g|
-            @curated_group_page.load_page g
-            @curated_group_page.delete_cohort g
-          end
-          @homepage.click_create_note_batch
-          @homepage.batch_note_add_student_input_element.when_visible Utils.short_wait
-        end
-
-        it('sees no cohort button on the batch note modal') { expect(@homepage.batch_note_add_cohort_button_element.visible?).to be false }
-        it('sees no group button on the batch note modal') { expect(@homepage.batch_note_add_curated_group_button_element.visible?).to be false }
+        @homepage.dev_auth test.advisor
       end
 
-      context 'creating a new batch of notes' do
+      after(:all) { Utils.quit_browser @driver }
 
-        before(:all) do
+      describe 'advisor' do
 
-          # Create cohort
-          @homepage.load_page
-          @cohort_page.search_and_create_new_cohort(test.default_cohort, default: true)
-          test.default_cohort.members = test.cohort_members
-          test.default_cohort.member_count = test.cohort_members.length
-          cohorts << test.default_cohort
+        context 'with no cohorts or groups' do
 
-          # Create curated_groups
-          [curated_group_1, curated_group_2].each do |curated_group|
-            @homepage.click_sidebar_create_curated_group
-            @curated_group_page.create_group_with_bulk_sids(curated_group_members, curated_group)
-            @curated_group_page.wait_for_sidebar_group curated_group
-            curated_groups << curated_group
+          before(:all) do
+            pre_existing_cohorts = BOACUtils.get_user_filtered_cohorts test.advisor, default: true
+            pre_existing_cohorts.each do |c|
+              @cohort_page.load_cohort c
+              @cohort_page.delete_cohort c
+            end
+
+            pre_existing_groups = BOACUtils.get_user_curated_groups test.advisor
+            pre_existing_groups.each do |g|
+              @curated_group_page.load_page g
+              @curated_group_page.delete_cohort g
+            end
+            @homepage.click_create_note_batch
+            @homepage.batch_note_add_student_input_element.when_visible Utils.short_wait
           end
 
-          @batch_1_expected_students = @homepage.unique_students_in_batch(students, cohorts, curated_groups)
-          logger.debug "Expected batch SIDs #{(@batch_1_expected_students.map &:sis_id).sort}"
+          it('sees no cohort button on the batch note modal') { expect(@homepage.batch_note_add_cohort_button_element.visible?).to be false }
+          it('sees no group button on the batch note modal') { expect(@homepage.batch_note_add_curated_group_button_element.visible?).to be false }
         end
 
-        it 'cannot create a batch of notes without a subject' do
-          @homepage.click_create_note_batch
-          @homepage.new_note_save_button_element.when_present 1
-          expect(@homepage.new_note_save_button_element.disabled?).to be true
-        end
+        context 'creating a new batch of notes' do
 
-        it 'can cancel an unsaved batch of notes' do
-          @homepage.hit_escape
-          @homepage.click_create_note_batch
-          @homepage.wait_for_element_and_type(@homepage.note_body_text_area_elements[1], 'Discard me!')
-          @homepage.click_cancel_new_note
-          @homepage.confirm_delete_or_discard
-          @homepage.wait_until(1) { @homepage.note_body_text_area_elements.empty? }
-        end
+          before(:all) do
 
-        it 'can add students' do
-          @homepage.click_create_note_batch
-          @homepage.add_students_to_batch(batch_note_1, students)
-        end
+            # Create cohort
+            @homepage.load_page
+            @cohort_page.search_and_create_new_cohort(test.default_cohort, default: true)
+            test.default_cohort.members = test.cohort_members
+            test.default_cohort.member_count = test.cohort_members.length
+            cohorts << test.default_cohort
 
-        it('can add cohorts') { @homepage.add_cohorts_to_batch(batch_note_1, cohorts) }
+            # Create curated_groups
+            [curated_group_1, curated_group_2].each do |curated_group|
+              @homepage.click_sidebar_create_curated_group
+              @curated_group_page.create_group_with_bulk_sids(curated_group_members, curated_group)
+              @curated_group_page.wait_for_sidebar_group curated_group
+              curated_groups << curated_group
+            end
 
-        it('can add groups') { @homepage.add_curated_groups_to_batch(batch_note_1, curated_groups) }
-
-        it('can remove students') { @homepage.remove_students_from_batch(batch_note_1, students) }
-
-        it('can remove cohorts') { @homepage.remove_cohorts_from_batch(batch_note_1, cohorts) }
-
-        it('can remove groups') { @homepage.remove_groups_from_batch(batch_note_1, curated_groups) }
-
-        it 'requires at least one student' do
-          @homepage.enter_new_note_subject batch_note_1
-          expect(@homepage.new_note_save_button_element.disabled?).to be true
-        end
-
-        it 'sees how many notes will be created' do
-          @homepage.add_students_to_batch(batch_note_1, students)
-          @homepage.add_cohorts_to_batch(batch_note_1, cohorts)
-          @homepage.add_curated_groups_to_batch(batch_note_1, curated_groups)
-          expected_student_count = @batch_1_expected_students.length
-          @homepage.wait_until(1, "Expected #{expected_student_count} notes, got #{@homepage.batch_note_student_count_alert}") do
-            @homepage.batch_note_student_count_alert.include? "Note will be added to #{expected_student_count}"
+            @batch_1_expected_students = @homepage.unique_students_in_batch(students, cohorts, curated_groups)
+            logger.debug "Expected batch SIDs #{(@batch_1_expected_students.map &:sis_id).sort}"
           end
-        end
 
-        it 'can save a new note' do
-          @homepage.click_cancel_new_note
-          @homepage.confirm_delete_or_discard
-          @homepage.wait_until(1) { @homepage.note_body_text_area_elements.empty? }
-          @homepage.create_batch_of_notes(batch_note_1, [Topic::PROBATION, Topic::ACADEMIC_PROGRESS], test.attachments[0..1], students, cohorts, curated_groups)
-        end
-
-        it 'creates notes for all the right students' do
-          expected_sids = @batch_1_expected_students.map(&:sis_id).sort
-          @homepage.wait_until(Utils.short_wait, "Expected by not present: #{expected_sids - BOACUtils.get_note_sids_by_subject(batch_note_1)}, present but not expected: #{BOACUtils.get_note_sids_by_subject(batch_note_1) - expected_sids}") do
-            BOACUtils.get_note_sids_by_subject(batch_note_1) == expected_sids
+          it 'cannot create a batch of notes without a subject' do
+            @homepage.click_create_note_batch
+            @homepage.new_note_save_button_element.when_present 1
+            expect(@homepage.new_note_save_button_element.disabled?).to be true
           end
-        end
 
-        it 'creates notes with the right content for each student' do
-          @homepage.unique_students_in_batch(students, cohorts, curated_groups).first(5).each do |student|
-            @student_page.set_new_note_id(batch_note_1, student)
+          it 'can cancel an unsaved batch of notes' do
+            @homepage.hit_escape
+            @homepage.click_create_note_batch
+            @homepage.wait_for_element_and_type(@homepage.note_body_text_area_elements[1], 'Discard me!')
+            @homepage.click_cancel_new_note
+            @homepage.confirm_delete_or_discard
+            @homepage.wait_until(1) { @homepage.note_body_text_area_elements.empty? }
+          end
+
+          it 'can add students' do
+            @homepage.click_create_note_batch
+            @homepage.add_students_to_batch(batch_note_1, students)
+          end
+
+          it('can add cohorts') { @homepage.add_cohorts_to_batch(batch_note_1, cohorts) }
+
+          it('can add groups') { @homepage.add_curated_groups_to_batch(batch_note_1, curated_groups) }
+
+          it('can remove students') { @homepage.remove_students_from_batch(batch_note_1, students) }
+
+          it('can remove cohorts') { @homepage.remove_cohorts_from_batch(batch_note_1, cohorts) }
+
+          it('can remove groups') { @homepage.remove_groups_from_batch(batch_note_1, curated_groups) }
+
+          it 'requires at least one student' do
+            @homepage.enter_new_note_subject batch_note_1
+            expect(@homepage.new_note_save_button_element.disabled?).to be true
+          end
+
+          it 'sees how many notes will be created' do
+            @homepage.add_students_to_batch(batch_note_1, students)
+            @homepage.add_cohorts_to_batch(batch_note_1, cohorts)
+            @homepage.add_curated_groups_to_batch(batch_note_1, curated_groups)
+            expected_student_count = @batch_1_expected_students.length
+            @homepage.wait_until(1, "Expected #{expected_student_count} notes, got #{@homepage.batch_note_student_count_alert}") do
+              @homepage.batch_note_student_count_alert.include? "Note will be added to #{expected_student_count}"
+            end
+          end
+
+          it 'can save a new note' do
+            @homepage.click_cancel_new_note
+            @homepage.confirm_delete_or_discard
+            @homepage.wait_until(1) { @homepage.note_body_text_area_elements.empty? }
+            @homepage.create_batch_of_notes(batch_note_1, [Topic::PROBATION, Topic::ACADEMIC_PROGRESS], test.attachments[0..1], students, cohorts, curated_groups)
+          end
+
+          it 'creates notes for all the right students' do
+            expected_sids = @batch_1_expected_students.map(&:sis_id).sort
+            @homepage.wait_until(Utils.short_wait, "Expected by not present: #{expected_sids - BOACUtils.get_note_sids_by_subject(batch_note_1)}, present but not expected: #{BOACUtils.get_note_sids_by_subject(batch_note_1) - expected_sids}") do
+              BOACUtils.get_note_sids_by_subject(batch_note_1) == expected_sids
+            end
+          end
+
+          it 'creates notes with the right content for each student' do
+            @homepage.unique_students_in_batch(students, cohorts, curated_groups).first(5).each do |student|
+              @student_page.set_new_note_id(batch_note_1, student)
+              @student_page.load_page student
+              @student_page.expand_item batch_note_1
+              @student_page.verify_note batch_note_1
+            end
+          end
+
+          it 'immediately shows new note on student profile if student is in curated group of batch note creation' do
+            student = curated_groups[0].members.last
             @student_page.load_page student
-            @student_page.expand_item batch_note_1
-            @student_page.verify_note batch_note_1
+            @homepage.create_batch_of_notes(batch_note_2, [], [], [], [], curated_groups)
+            @student_page.expand_note_by_subject batch_note_2.subject
+          end
+
+        end
+
+        context 'searching for newly created batch notes' do
+
+          it 'can find them by student and subject' do
+            student = @homepage.unique_students_in_batch(students, cohorts, curated_groups).last
+            @homepage.set_new_note_id(batch_note_1, student)
+            @homepage.set_notes_student student
+            @homepage.enter_string_and_hit_enter batch_note_1.subject
+            expect(@search_results_page.note_in_search_result? batch_note_1).to be true
           end
         end
 
-        it 'immediately shows new note on student profile if student is in curated group of batch note creation' do
-          student = curated_groups[0].members.last
-          @student_page.load_page student
-          @homepage.create_batch_of_notes(batch_note_2, [], [], [], [], curated_groups)
-          @student_page.expand_note_by_subject batch_note_2.subject
-        end
-
       end
-
-      context 'searching for newly created batch notes' do
-
-        it 'can find them by student and subject' do
-          student = @homepage.unique_students_in_batch(students, cohorts, curated_groups).last
-          @homepage.set_new_note_id(batch_note_1, student)
-          @homepage.set_notes_student student
-          @homepage.enter_string_and_hit_enter batch_note_1.subject
-          expect(@search_results_page.note_in_search_result? batch_note_1).to be true
-        end
-      end
-
     end
   end
 end

--- a/spec/boac/boac_note_content_spec.rb
+++ b/spec/boac/boac_note_content_spec.rb
@@ -1,298 +1,301 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-describe 'BOAC' do
+  include Logging
 
-  begin
-    test = BOACTestConfig.new
-    test.note_content
-    downloadable_attachments = []
-    advisor_link_tested = false
-    max_note_count_per_src = BOACUtils.notes_max_notes - 1
+  describe 'BOAC' do
 
-    notes_data_heading = %w(UID SID NoteId Created Updated CreatedBy Advisor AdvisorRole AdvisorDepts HasBody Topics Attachments)
-    notes_data = Utils.create_test_output_csv('boac-notes.csv', notes_data_heading)
+    begin
+      test = BOACTestConfig.new
+      test.note_content
+      downloadable_attachments = []
+      advisor_link_tested = false
+      max_note_count_per_src = BOACUtils.notes_max_notes - 1
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @api_notes_page = BOACApiNotesPage.new @driver
+      notes_data_heading = %w(UID SID NoteId Created Updated CreatedBy Advisor AdvisorRole AdvisorDepts HasBody Topics Attachments)
+      notes_data = Utils.create_test_output_csv('boac-notes.csv', notes_data_heading)
 
-    @homepage.dev_auth test.advisor
-    test.test_students.each do |student|
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @api_notes_page = BOACApiNotesPage.new @driver
 
-      begin
-        @student_page.load_page student
-        expected_asc_notes = NessieUtils.get_asc_notes student
-        expected_boa_notes = BOACUtils.get_student_notes(student).delete_if &:deleted_date
-        expected_data_notes = NessieUtils.get_data_sci_notes student
-        expected_ei_notes = NessieUtils.get_e_and_i_notes student
-        expected_sis_notes = NessieUtils.get_sis_notes student
-        logger.warn "UID #{student.uid} has #{expected_sis_notes.length} SIS notes, #{expected_asc_notes.length} ASC notes,
+      @homepage.dev_auth test.advisor
+      test.test_students.each do |student|
+
+        begin
+          @student_page.load_page student
+          expected_asc_notes = NessieUtils.get_asc_notes student
+          expected_boa_notes = BOACUtils.get_student_notes(student).delete_if &:deleted_date
+          expected_data_notes = NessieUtils.get_data_sci_notes student
+          expected_ei_notes = NessieUtils.get_e_and_i_notes student
+          expected_sis_notes = NessieUtils.get_sis_notes student
+          logger.warn "UID #{student.uid} has #{expected_sis_notes.length} SIS notes, #{expected_asc_notes.length} ASC notes,
                               #{expected_ei_notes.length} E&I notes, #{expected_boa_notes.length} BOA notes and
                               #{expected_data_notes.length} Data Science notes"
 
-        expected_notes = expected_sis_notes + expected_ei_notes + expected_boa_notes + expected_asc_notes + expected_data_notes
+          expected_notes = expected_sis_notes + expected_ei_notes + expected_boa_notes + expected_asc_notes + expected_data_notes
 
-        @student_page.show_notes
+          @student_page.show_notes
 
-        visible_note_count = @student_page.note_msg_row_elements.length
-        it("shows the right number of notes for UID #{student.uid}") { expect(visible_note_count).to eql((expected_notes).length) }
+          visible_note_count = @student_page.note_msg_row_elements.length
+          it("shows the right number of notes for UID #{student.uid}") { expect(visible_note_count).to eql((expected_notes).length) }
 
-        expected_sort_order = @student_page.expected_note_id_sort_order(expected_notes)
-        visible_sort_order = @student_page.visible_collapsed_note_ids
-        it("shows the notes in the right order for UID #{student.uid}") { expect(visible_sort_order).to eql(expected_sort_order) }
+          expected_sort_order = @student_page.expected_note_id_sort_order(expected_notes)
+          visible_sort_order = @student_page.visible_collapsed_note_ids
+          it("shows the notes in the right order for UID #{student.uid}") { expect(visible_sort_order).to eql(expected_sort_order) }
 
-        @student_page.expand_all_notes
-        expected_notes.each do |note|
-          note_expanded = @student_page.item_expanded? note
-          it("expand-all-notes button expands note ID #{note.id} for UID #{student.uid}") { expect(note_expanded).to be true }
-        end
+          @student_page.expand_all_notes
+          expected_notes.each do |note|
+            note_expanded = @student_page.item_expanded? note
+            it("expand-all-notes button expands note ID #{note.id} for UID #{student.uid}") { expect(note_expanded).to be true }
+          end
 
-        @student_page.collapse_all_notes
-        expected_notes.each do |note|
-          note_expanded = @student_page.item_expanded? note
-          it("collapse-all-notes-button collapses note ID #{note.id} for UID #{student.uid}") { expect(note_expanded).to be false }
-        end
+          @student_page.collapse_all_notes
+          expected_notes.each do |note|
+            note_expanded = @student_page.item_expanded? note
+            it("collapse-all-notes-button collapses note ID #{note.id} for UID #{student.uid}") { expect(note_expanded).to be false }
+          end
 
-        # Test a representative subset of the total notes
-        test_notes = expected_sis_notes.shuffle[0..max_note_count_per_src] + expected_ei_notes.shuffle[0..max_note_count_per_src] +
-            expected_boa_notes.shuffle[0..max_note_count_per_src] + expected_asc_notes.shuffle[0..max_note_count_per_src] +
-            expected_data_notes.shuffle[0..max_note_count_per_src]
+          # Test a representative subset of the total notes
+          test_notes = expected_sis_notes.shuffle[0..max_note_count_per_src] + expected_ei_notes.shuffle[0..max_note_count_per_src] +
+              expected_boa_notes.shuffle[0..max_note_count_per_src] + expected_asc_notes.shuffle[0..max_note_count_per_src] +
+              expected_data_notes.shuffle[0..max_note_count_per_src]
 
-        test_notes.each do |note|
+          test_notes.each do |note|
 
-          begin
-            test_case = "note ID #{note.id} for UID #{student.uid}"
-            logger.info "Checking #{test_case}"
+            begin
+              test_case = "note ID #{note.id} for UID #{student.uid}"
+              logger.info "Checking #{test_case}"
 
-            if note.subject && note.subject.include?('QA Test')
-              logger.warn "Skipping note ID #{note.id} for UID #{student.uid} because it is a testing artifact"
+              if note.subject && note.subject.include?('QA Test')
+                logger.warn "Skipping note ID #{note.id} for UID #{student.uid} because it is a testing artifact"
 
-            else
-
-              # COLLAPSED NOTE
-
-              @student_page.show_notes
-              visible_collapsed_note_data = @student_page.visible_collapsed_note_data note
-
-              # Note updated date
-
-              updated_date_expected = note.updated_date &&
-                  note.updated_date.strftime('%b %-d, %Y %l:%M%P') != note.created_date.strftime('%b %-d, %Y %l:%M%P') &&
-                  note.advisor.uid != 'UCBCONVERSION'
-              expected_date = updated_date_expected ? note.updated_date : note.created_date
-              expected_date_text = "Last updated on #{@student_page.expected_item_short_date_format expected_date}"
-              visible_date = @student_page.visible_collapsed_item_data(note)[:date]
-              it("shows '#{expected_date_text}' on collapsed #{test_case}") { expect(visible_date).to eql(expected_date_text) }
-
-              # EXPANDED NOTE
-
-              @student_page.expand_item note
-              visible_expanded_note_data = @student_page.visible_expanded_note_data note
-
-              # Note subject and body (NB: migrated SIS notes have no subject, so the body is shown as the subject; migrated ASC notes have no subject
-              # or body, so the general topic is shown as the subject)
-
-              if note.subject
-                it("shows the subject on #{test_case}") { expect(visible_collapsed_note_data[:subject] == note.subject.strip).to be true }
-                it("shows the body on #{test_case}") { expect(visible_expanded_note_data[:body].strip == "#{note.body}").to be true }
-              elsif expected_sis_notes.include? note
-                it("shows the body as the subject on #{test_case}") { expect(visible_collapsed_note_data[:subject].gsub(/\W/, '') == note.body.gsub(/\W/, '')).to be true }
-                it("shows no body on #{test_case}") { expect(visible_expanded_note_data[:body].strip.empty?).to be true }
-              elsif expected_data_notes.include?(note)
-                if note.body && !note.body.empty?
-                  it("shows the body as the subject on #{test_case}") { expect(visible_collapsed_note_data[:subject].gsub(/\W/, '') == note.body.gsub(/\W/, '')).to be true }
-                end
               else
-                subj_dept = expected_ei_notes.include?(note) ? 'Centers for Educational Equity and Excellence advisor' : 'Athletic Study Center advisor'
-                it("shows the department as part of the subject on #{test_case}") { expect(visible_collapsed_note_data[:category]).to include(subj_dept) }
-                it("shows the advisor first name as part of the subject on #{test_case}") do
-                  expect(expect(visible_collapsed_note_data[:category].downcase).to include(note.advisor.first_name.downcase))
+
+                # COLLAPSED NOTE
+
+                @student_page.show_notes
+                visible_collapsed_note_data = @student_page.visible_collapsed_note_data note
+
+                # Note updated date
+
+                updated_date_expected = note.updated_date &&
+                    note.updated_date.strftime('%b %-d, %Y %l:%M%P') != note.created_date.strftime('%b %-d, %Y %l:%M%P') &&
+                    note.advisor.uid != 'UCBCONVERSION'
+                expected_date = updated_date_expected ? note.updated_date : note.created_date
+                expected_date_text = "Last updated on #{@student_page.expected_item_short_date_format expected_date}"
+                visible_date = @student_page.visible_collapsed_item_data(note)[:date]
+                it("shows '#{expected_date_text}' on collapsed #{test_case}") { expect(visible_date).to eql(expected_date_text) }
+
+                # EXPANDED NOTE
+
+                @student_page.expand_item note
+                visible_expanded_note_data = @student_page.visible_expanded_note_data note
+
+                # Note subject and body (NB: migrated SIS notes have no subject, so the body is shown as the subject; migrated ASC notes have no subject
+                # or body, so the general topic is shown as the subject)
+
+                if note.subject
+                  it("shows the subject on #{test_case}") { expect(visible_collapsed_note_data[:subject] == note.subject.strip).to be true }
+                  it("shows the body on #{test_case}") { expect(visible_expanded_note_data[:body].strip == "#{note.body}").to be true }
+                elsif expected_sis_notes.include? note
+                  it("shows the body as the subject on #{test_case}") { expect(visible_collapsed_note_data[:subject].gsub(/\W/, '') == note.body.gsub(/\W/, '')).to be true }
+                  it("shows no body on #{test_case}") { expect(visible_expanded_note_data[:body].strip.empty?).to be true }
+                elsif expected_data_notes.include?(note)
+                  if note.body && !note.body.empty?
+                    it("shows the body as the subject on #{test_case}") { expect(visible_collapsed_note_data[:subject].gsub(/\W/, '') == note.body.gsub(/\W/, '')).to be true }
+                  end
+                else
+                  subj_dept = expected_ei_notes.include?(note) ? 'Centers for Educational Equity and Excellence advisor' : 'Athletic Study Center advisor'
+                  it("shows the department as part of the subject on #{test_case}") { expect(visible_collapsed_note_data[:category]).to include(subj_dept) }
+                  it("shows the advisor first name as part of the subject on #{test_case}") do
+                    expect(expect(visible_collapsed_note_data[:category].downcase).to include(note.advisor.first_name.downcase))
+                  end
+                  it("shows the advisor last name as part of the subject on #{test_case}") do
+                    expect(expect(visible_collapsed_note_data[:category].downcase).to include(note.advisor.last_name.downcase))
+                  end
+                  it("shows no body on #{test_case}") { expect(visible_expanded_note_data[:body].strip.empty?).to be true }
                 end
-                it("shows the advisor last name as part of the subject on #{test_case}") do
-                  expect(expect(visible_collapsed_note_data[:category].downcase).to include(note.advisor.last_name.downcase))
-                end
-                it("shows no body on #{test_case}") { expect(visible_expanded_note_data[:body].strip.empty?).to be true }
-              end
 
-              # Note advisor
+                # Note advisor
 
-              if note.advisor
-                if note.advisor.uid
-                  logger.warn "No advisor shown for UID #{note.advisor.uid} on #{test_case}" unless visible_expanded_note_data[:advisor]
+                if note.advisor
+                  if note.advisor.uid
+                    logger.warn "No advisor shown for UID #{note.advisor.uid} on #{test_case}" unless visible_expanded_note_data[:advisor]
 
-                  if visible_expanded_note_data[:advisor] && !advisor_link_tested
-                    if visible_expanded_note_data[:advisor].include? 'Graduate Intern'
-                      has_link = (@student_page.note_advisor_el(note).tag_name == 'a')
-                      it("offers no link to the Berkeley directory for advisor 'Graduate Intern' on #{test_case}") { expect(has_link).to be false }
+                    if visible_expanded_note_data[:advisor] && !advisor_link_tested
+                      if visible_expanded_note_data[:advisor].include? 'Graduate Intern'
+                        has_link = (@student_page.note_advisor_el(note).tag_name == 'a')
+                        it("offers no link to the Berkeley directory for advisor 'Graduate Intern' on #{test_case}") { expect(has_link).to be false }
+                      else
+                        advisor_link_works = @student_page.external_link_valid?(@student_page.note_advisor_el(note), 'Campus Directory | University of California, Berkeley')
+                        advisor_link_tested = true
+                        it("offers a link to the Berkeley directory for advisor #{note.advisor.uid} on #{test_case}") { expect(advisor_link_works).to be true }
+                      end
+                    end
+
+                  else
+                    if note.advisor.last_name && !note.advisor.last_name.empty?
+                      it("shows an advisor on #{test_case}") { expect(visible_expanded_note_data[:advisor]).not_to be_nil }
                     else
-                      advisor_link_works = @student_page.external_link_valid?(@student_page.note_advisor_el(note), 'Campus Directory | University of California, Berkeley')
-                      advisor_link_tested = true
-                      it("offers a link to the Berkeley directory for advisor #{note.advisor.uid} on #{test_case}") { expect(advisor_link_works).to be true }
+                      it("shows Graduate Intern or Peer Advisor on #{test_case}") { expect(['Graduate Intern', 'Peer Advisor']).to include(visible_expanded_note_data[:advisor]) }
+                    end
+                  end
+                elsif expected_data_notes.include? note
+                  it("shows an advisor on #{test_case}") { expect(visible_expanded_note_data[:advisor]).not_to be_nil }
+                end
+
+                # Note source
+
+                if note.note_source
+                  shows_src = visible_expanded_note_data[:note_src] == "(note imported from #{note.note_source.name})"
+                  it("shows the note source '#{note.note_source.name}' on #{test_case}") { expect(shows_src).to be true }
+                else
+                  it("shows no note source for BOA #{test_case}") { expect(visible_expanded_note_data[:note_src]).to be_nil }
+                end
+
+                # Note topics
+
+                if note.topics.any?
+                  topics = note.topics.map(&:upcase).uniq
+                  topics.sort! if expected_boa_notes.include? note
+                  (it("shows the right topics on #{test_case}") { expect(visible_expanded_note_data[:topics]).to eql(topics) })
+                else
+                  (it("shows no topics on #{test_case}") { expect(visible_expanded_note_data[:topics]).to be_empty })
+                end
+
+                # Note dates
+
+                if updated_date_expected
+                  expected_update_date_text = @student_page.expected_item_long_date_format note.updated_date
+                  it("shows update date #{expected_update_date_text} on expanded #{test_case}") { expect(visible_expanded_note_data[:updated_date]).to eql(expected_update_date_text) }
+                else
+                  it("shows no updated date #{note.updated_date} on expanded #{test_case}") { expect(visible_expanded_note_data[:updated_date]).to be_nil }
+                end
+
+                expected_create_date_text = (note.advisor&.uid == 'UCBCONVERSION') ?
+                                                @student_page.expected_item_short_date_format(note.created_date) :
+                                                @student_page.expected_item_long_date_format(note.created_date)
+                it("shows creation date #{expected_create_date_text} on expanded #{test_case}") { expect(visible_expanded_note_data[:created_date]).to eql(expected_create_date_text) }
+
+                # Note attachments
+
+                if note.attachments.any?
+                  non_deleted_attachments = note.attachments.reject &:deleted_at
+                  attachment_file_names = non_deleted_attachments.map &:file_name
+                  it("shows the right attachment file names on #{test_case}") { expect(visible_expanded_note_data[:attachments].sort).to eql(attachment_file_names.sort) }
+
+                  non_deleted_attachments.each do |attach|
+                    if attach.sis_file_name
+                      has_delete_button = @student_page.delete_note_button(note).exists?
+                      it("shows no delete button for imported #{test_case}") { expect(has_delete_button).to be false }
+                    end
+
+                    # TODO - get downloads working on Firefox, since the profile prefs aren't having the desired effect; plus headless downloads don't work on Chrome
+                    if @student_page.item_attachment_el(note, attach.file_name).tag_name == 'a' && "#{@driver.browser}" != 'firefox' && !Utils.headless?
+                      begin
+                        file_size = @student_page.download_attachment(note, attach, student)
+                        if file_size
+                          attachment_downloads = file_size > 0
+                          downloadable_attachments << attach
+                          it("allows attachment ID #{attach.id} to be downloaded from #{test_case}") { expect(attachment_downloads).to be true }
+                        end
+                      rescue => e
+                        Utils.log_error e
+                        it("encountered an error downloading attachment ID #{attach.id} from #{test_case}") { fail }
+
+                        # If the note download fails, the browser might no longer be on the student page so reload it.
+                        @student_page.load_page student
+                        @student_page.show_notes
+                      end
+
+                    else
+                      logger.warn "Skipping download test for note ID #{note.id} attachment ID #{attach.id} since it cannot be downloaded"
                     end
                   end
 
                 else
-                  if note.advisor.last_name && !note.advisor.last_name.empty?
-                    it("shows an advisor on #{test_case}") { expect(visible_expanded_note_data[:advisor]).not_to be_nil }
-                  else
-                    it("shows Graduate Intern or Peer Advisor on #{test_case}") { expect(['Graduate Intern', 'Peer Advisor']).to include(visible_expanded_note_data[:advisor]) }
-                  end
-                end
-              elsif expected_data_notes.include? note
-                it("shows an advisor on #{test_case}") { expect(visible_expanded_note_data[:advisor]).not_to be_nil }
-              end
-
-              # Note source
-
-              if note.note_source
-                shows_src = visible_expanded_note_data[:note_src] == "(note imported from #{note.note_source.name})"
-                it("shows the note source '#{note.note_source.name}' on #{test_case}") { expect(shows_src).to be true }
-              else
-                it("shows no note source for BOA #{test_case}") { expect(visible_expanded_note_data[:note_src]).to be_nil }
-              end
-
-              # Note topics
-
-              if note.topics.any?
-                topics = note.topics.map(&:upcase).uniq
-                topics.sort! if expected_boa_notes.include? note
-                (it("shows the right topics on #{test_case}") { expect(visible_expanded_note_data[:topics]).to eql(topics) })
-              else
-                (it("shows no topics on #{test_case}") { expect(visible_expanded_note_data[:topics]).to be_empty })
-              end
-
-              # Note dates
-
-              if updated_date_expected
-                expected_update_date_text = @student_page.expected_item_long_date_format note.updated_date
-                it("shows update date #{expected_update_date_text} on expanded #{test_case}") { expect(visible_expanded_note_data[:updated_date]).to eql(expected_update_date_text) }
-              else
-                it("shows no updated date #{note.updated_date} on expanded #{test_case}") { expect(visible_expanded_note_data[:updated_date]).to be_nil }
-              end
-
-              expected_create_date_text = (note.advisor&.uid == 'UCBCONVERSION') ?
-                  @student_page.expected_item_short_date_format(note.created_date) :
-                  @student_page.expected_item_long_date_format(note.created_date)
-              it("shows creation date #{expected_create_date_text} on expanded #{test_case}") { expect(visible_expanded_note_data[:created_date]).to eql(expected_create_date_text) }
-
-              # Note attachments
-
-              if note.attachments.any?
-                non_deleted_attachments = note.attachments.reject &:deleted_at
-                attachment_file_names = non_deleted_attachments.map &:file_name
-                it("shows the right attachment file names on #{test_case}") { expect(visible_expanded_note_data[:attachments].sort).to eql(attachment_file_names.sort) }
-
-                non_deleted_attachments.each do |attach|
-                  if attach.sis_file_name
-                    has_delete_button = @student_page.delete_note_button(note).exists?
-                    it("shows no delete button for imported #{test_case}") { expect(has_delete_button).to be false }
-                  end
-
-                  # TODO - get downloads working on Firefox, since the profile prefs aren't having the desired effect; plus headless downloads don't work on Chrome
-                  if @student_page.item_attachment_el(note, attach.file_name).tag_name == 'a' && "#{@driver.browser}" != 'firefox' && !Utils.headless?
-                    begin
-                      file_size = @student_page.download_attachment(note, attach, student)
-                      if file_size
-                        attachment_downloads = file_size > 0
-                        downloadable_attachments << attach
-                        it("allows attachment ID #{attach.id} to be downloaded from #{test_case}") { expect(attachment_downloads).to be true }
-                      end
-                    rescue => e
-                      Utils.log_error e
-                      it("encountered an error downloading attachment ID #{attach.id} from #{test_case}") { fail }
-
-                      # If the note download fails, the browser might no longer be on the student page so reload it.
-                      @student_page.load_page student
-                      @student_page.show_notes
-                    end
-
-                  else
-                    logger.warn "Skipping download test for note ID #{note.id} attachment ID #{attach.id} since it cannot be downloaded"
-                  end
+                  it("shows no attachment file names on #{test_case}") { expect(visible_expanded_note_data[:attachments]).to be_empty }
                 end
 
-              else
-                it("shows no attachment file names on #{test_case}") { expect(visible_expanded_note_data[:attachments]).to be_empty }
-              end
+                # Note search
 
-              # Note search
+                if (query = BOACUtils.generate_note_search_query(student, note))
+                  @student_page.show_notes
+                  initial_msg_count = @student_page.visible_message_ids.length
+                  @student_page.search_within_timeline_notes(query[:string])
+                  message_ids = @student_page.visible_message_ids
 
-              if (query = BOACUtils.generate_note_search_query(student, note))
-                @student_page.show_notes
-                initial_msg_count = @student_page.visible_message_ids.length
-                @student_page.search_within_timeline_notes(query[:string])
-                message_ids = @student_page.visible_message_ids
+                  it("searches within academic timeline for #{query[:test_case]}") do
+                    expect(message_ids.length).to be < (initial_msg_count) unless initial_msg_count == 1
+                    expect(message_ids).to include(query[:note].id)
+                  end
 
-                it("searches within academic timeline for #{query[:test_case]}") do
-                  expect(message_ids.length).to be < (initial_msg_count) unless initial_msg_count == 1
-                  expect(message_ids).to include(query[:note].id)
+                  @student_page.clear_timeline_notes_search
                 end
 
-                @student_page.clear_timeline_notes_search
+                # Permalink
+
+                logger.info "Checking permalink: '#{visible_expanded_note_data[:permalink_url]}'"
+                @homepage.load_page
+                @student_page.navigate_to visible_expanded_note_data[:permalink_url]
+                permalink_works = @student_page.verify_block do
+                  @student_page.wait_until(Utils.short_wait) { @student_page.item_expanded? note }
+                end
+
+                it("offers a permalink on #{test_case}") { expect(permalink_works).to be true }
+
               end
-
-              # Permalink
-
-              logger.info "Checking permalink: '#{visible_expanded_note_data[:permalink_url]}'"
-              @homepage.load_page
-              @student_page.navigate_to visible_expanded_note_data[:permalink_url]
-              permalink_works = @student_page.verify_block do
-                @student_page.wait_until(Utils.short_wait) { @student_page.item_expanded? note }
-              end
-
-              it("offers a permalink on #{test_case}") { expect(permalink_works).to be true }
-
+            rescue => e
+              Utils.log_error e
+              it("hit an error with #{test_case}") { fail }
+            ensure
+              row = [student.uid, student.sis_id, note.id, note.created_date, note.updated_date, note.advisor&.uid,
+                     (visible_expanded_note_data[:advisor] if visible_expanded_note_data),
+                     (visible_expanded_note_data[:advisor_role] if visible_expanded_note_data),
+                     (visible_expanded_note_data[:advisor_depts] if visible_expanded_note_data),
+                     !note.body.nil?, note.topics.length, note.attachments.length]
+              Utils.add_csv_row(notes_data, row)
             end
-          rescue => e
-            Utils.log_error e
-            it("hit an error with #{test_case}") { fail }
-          ensure
-            row = [student.uid, student.sis_id, note.id, note.created_date, note.updated_date, note.advisor&.uid,
-                   (visible_expanded_note_data[:advisor] if visible_expanded_note_data),
-                   (visible_expanded_note_data[:advisor_role] if visible_expanded_note_data),
-                   (visible_expanded_note_data[:advisor_depts] if visible_expanded_note_data),
-                   !note.body.nil?, note.topics.length, note.attachments.length]
-            Utils.add_csv_row(notes_data, row)
           end
+
+        rescue => e
+          Utils.log_error e
+          it("hit an error with UID #{student.uid}") { fail }
+        ensure
+          # Make sure no attachment is left on the test machine
+          Utils.prepare_download_dir
         end
-
-      rescue => e
-        Utils.log_error e
-        it("hit an error with UID #{student.uid}") { fail }
-      ensure
-        # Make sure no attachment is left on the test machine
-        Utils.prepare_download_dir
       end
-    end
 
-    if downloadable_attachments.any?
+      if downloadable_attachments.any?
 
-      @homepage.load_page
-      @homepage.log_out
+        @homepage.load_page
+        @homepage.log_out
 
-      downloadable_attachments.each do |attach|
+        downloadable_attachments.each do |attach|
 
-        identifier = attach.sis_file_name || attach.id
-        Utils.prepare_download_dir
-        @api_notes_page.load_attachment_page identifier
-        no_access = @api_notes_page.verify_block { @api_notes_page.unauth_msg_element.when_visible Utils.short_wait }
-        it("blocks an anonymous user from hitting the attachment download endpoint for #{identifier}") { expect(no_access).to be true }
+          identifier = attach.sis_file_name || attach.id
+          Utils.prepare_download_dir
+          @api_notes_page.load_attachment_page identifier
+          no_access = @api_notes_page.verify_block { @api_notes_page.unauth_msg_element.when_visible Utils.short_wait }
+          it("blocks an anonymous user from hitting the attachment download endpoint for #{identifier}") { expect(no_access).to be true }
 
-        no_file = Utils.downloads_empty?
-        it("delivers no file to an anonymous user when hitting the attachment download endpoint for #{identifier}") { expect(no_file).to be true }
+          no_file = Utils.downloads_empty?
+          it("delivers no file to an anonymous user when hitting the attachment download endpoint for #{identifier}") { expect(no_file).to be true }
+        end
+      else
+        it('found no downloadable attachments') { fail }
       end
-    else
-      it('found no downloadable attachments') { fail }
-    end
 
-  rescue => e
-    Utils.log_error e
-    it('hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
+    rescue => e
+      Utils.log_error e
+      it('hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end

--- a/spec/boac/boac_note_mgmt_spec.rb
+++ b/spec/boac/boac_note_mgmt_spec.rb
@@ -1,534 +1,537 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-test = BOACTestConfig.new
-test.note_management
+  include Logging
 
-# TODO - get real array of advisor dept mappings when we have them
-test.advisor.depts = [test.dept.name]
+  test = BOACTestConfig.new
+  test.note_management
 
-director = BOACUtils.get_authorized_users.find do |a|
-  a.dept_memberships.find { |m| m.advisor_role == AdvisorRole::DIRECTOR }
-end
-other_advisor = BOACUtils.get_dept_advisors(test.dept).find { |a| a.uid != test.advisor.uid }
+  # TODO - get real array of advisor dept mappings when we have them
+  test.advisor.depts = [test.dept.name]
 
-if test.dept == BOACDepartments::ADMIN
+  director = BOACUtils.get_authorized_users.find do |a|
+    a.dept_memberships.find { |m| m.advisor_role == AdvisorRole::DIRECTOR }
+  end
+  other_advisor = BOACUtils.get_dept_advisors(test.dept).find { |a| a.uid != test.advisor.uid }
 
-  logger.error 'Tests cannot be run for the Admin dept'
+  if test.dept == BOACDepartments::ADMIN
 
-elsif !other_advisor
+    logger.error 'Tests cannot be run for the Admin dept'
 
-  logger.error "This script will fail because #{test.dept.name} has only one advisor"
+  elsif !other_advisor
 
-else
+    logger.error "This script will fail because #{test.dept.name} has only one advisor"
 
-  test_student = test.students.shuffle.first
-  notes = []
-  notes << (note_1 = Note.new({:advisor => test.advisor}))
-  notes << (note_2 = Note.new({:advisor => test.advisor}))
-  notes << (note_3 = Note.new({:advisor => test.advisor}))
-  notes << (note_4 = Note.new({:advisor => test.advisor}))
-  notes << (note_5 = Note.new({:advisor => test.advisor}))
-  notes << (note_6 = Note.new({:advisor => test.advisor}))
-  notes << (note_7 = Note.new({:advisor => test.advisor}))
-  notes << (note_8 = Note.new({:advisor => test.advisor}))
+  else
 
-  # Get the largest attachments for testing max attachments uploads
-  attachments_by_size = test.attachments.sort_by(&:file_size).delete_if { |a| a.file_size > 20000000 }
-  big_attachments = attachments_by_size.first 10
+    test_student = test.students.shuffle.first
+    notes = []
+    notes << (note_1 = Note.new({:advisor => test.advisor}))
+    notes << (note_2 = Note.new({:advisor => test.advisor}))
+    notes << (note_3 = Note.new({:advisor => test.advisor}))
+    notes << (note_4 = Note.new({:advisor => test.advisor}))
+    notes << (note_5 = Note.new({:advisor => test.advisor}))
+    notes << (note_6 = Note.new({:advisor => test.advisor}))
+    notes << (note_7 = Note.new({:advisor => test.advisor}))
+    notes << (note_8 = Note.new({:advisor => test.advisor}))
 
-  deleted_attachments = []
+    # Get the largest attachments for testing max attachments uploads
+    attachments_by_size = test.attachments.sort_by(&:file_size).delete_if { |a| a.file_size > 20000000 }
+    big_attachments = attachments_by_size.first 10
 
-  describe 'A BOAC', order: :defined do
+    deleted_attachments = []
 
-    include Logging
+    describe 'A BOAC', order: :defined do
 
-    before(:all) do
-      @driver = Utils.launch_browser
-      @homepage = BOACHomePage.new @driver
-      @student_page = BOACStudentPage.new @driver
-      @search_results_page = BOACSearchResultsPage.new @driver
-      @api_notes_page = BOACApiNotesPage.new @driver
-    end
-
-    after(:all) {Utils.quit_browser @driver}
-
-    describe 'advisor' do
+      include Logging
 
       before(:all) do
-        @homepage.dev_auth test.advisor
-        @student_page.load_page test_student
+        @driver = Utils.launch_browser
+        @homepage = BOACHomePage.new @driver
+        @student_page = BOACStudentPage.new @driver
+        @search_results_page = BOACSearchResultsPage.new @driver
+        @api_notes_page = BOACApiNotesPage.new @driver
       end
 
-      after(:all) do
-        @homepage.load_page
-        @homepage.log_out
-      end
+      after(:all) { Utils.quit_browser @driver }
 
-      context 'creating a new note' do
+      describe 'advisor' do
 
-        it 'cannot create a note without a subject' do
-          @student_page.click_create_new_note
-          @student_page.new_note_save_button_element.when_present 1
-          expect(@student_page.new_note_save_button_element.disabled?).to be true
-        end
-
-        it 'can cancel an unsaved new note' do
-          @student_page.click_cancel_new_note
-          @student_page.click_create_new_note
-          @student_page.wait_for_element_and_type(@student_page.note_body_text_area_elements[1], 'An edit to forget')
-          @student_page.click_cancel_new_note
-          @student_page.confirm_delete_or_discard
-          @student_page.wait_until(1) { @student_page.note_body_text_area_elements.empty? }
-        end
-
-        it 'can create a note with a subject' do
-          note_1.subject = "Note 1 subject #{Utils.get_test_id}"
-          @student_page.create_note(note_1, [], [])
-          @student_page.verify_note note_1
-        end
-
-        it 'can create a note with a subject and a body' do
-          note_2.subject = "Note 2 subject #{Utils.get_test_id}"
-          note_2.body = "Note 2 body #{test.id}" unless "#{@driver.browser}" == 'firefox'
-          @student_page.create_note(note_2, [], [])
-          @student_page.verify_note note_2
-        end
-
-        it 'can create a long note with special characters' do
-          note_3.subject = "Σημείωση θέμα 3 #{Utils.get_test_id}"
-          note_3.body = 'ノート本体4' * 100 unless "#{@driver.browser}" == 'firefox'
-          @student_page.create_note(note_3, [], [])
-          @student_page.verify_note note_3
-        end
-
-        it 'can add and remove attachments before saving' do
-          note_4.subject = "Note 4 subject #{Utils.get_test_id}"
-          @student_page.click_create_new_note
-          @student_page.enter_new_note_subject note_4
-          @student_page.add_attachments_to_new_note(note_4, test.attachments[0..1])
-          @student_page.remove_attachments_from_new_note(note_4, test.attachments[0..1])
-          @student_page.click_save_new_note
-          @student_page.set_new_note_id note_4
-          @student_page.verify_note note_4
-        end
-
-        it 'can create a note with attachments' do
-          note_5.subject = "Note 5 subject #{Utils.get_test_id}"
-          @student_page.create_note(note_5, [], test.attachments[0..1])
-          @student_page.verify_note note_5
-        end
-
-        it 'can create a note with a maximum of 10 attachments' do
-          note_6.subject = "Note 6 subject #{Utils.get_test_id}"
-          @student_page.click_create_new_note
-          @student_page.enter_new_note_subject note_6
-          @student_page.add_attachments_to_new_note(note_6, big_attachments)
-          @student_page.existing_note_attachment_input(note_6).when_not_visible 1
-          @student_page.click_save_new_note
-          @student_page.set_new_note_id note_6
-          @student_page.collapsed_item_el(note_6).when_visible Utils.short_wait
-          @student_page.verify_note note_6
-        end
-
-        it 'cannot create a note with an individual attachment larger than 20MB' do
-          too_big_attachment = test.attachments.find { |a| a.file_size > 20000000 }
-          @student_page.click_create_new_note
-          @student_page.new_note_attach_input_element.when_present 1
-          @student_page.new_note_attach_input_element.send_keys Utils.asset_file_path(too_big_attachment.file_name)
-          @student_page.note_attachment_size_msg_element.when_visible Utils.short_wait
-        end
-
-        it 'can add and remove topics before saving' do
-          note_7.subject = "Note 7 subject #{Utils.get_test_id}"
-          note_topics = [Topic::COURSE_ADD, Topic::COURSE_DROP]
+        before(:all) do
+          @homepage.dev_auth test.advisor
           @student_page.load_page test_student
-          @student_page.click_create_new_note
-          @student_page.enter_new_note_subject note_7
-          @student_page.add_topics(note_7, note_topics)
-          @student_page.remove_topics(note_7, note_topics)
-          @student_page.click_save_new_note
-          @student_page.set_new_note_id note_7
-          @student_page.verify_note note_7
         end
 
-        it 'is offered a list of note topics' do
-          @student_page.click_create_new_note
-          expected_topics = Topic::TOPICS.select(&:for_notes).map &:name
-          @student_page.wait_until(1, "Expected #{expected_topics}, got #{@student_page.topic_options}") do
-            @student_page.topic_options == expected_topics
+        after(:all) do
+          @homepage.load_page
+          @homepage.log_out
+        end
+
+        context 'creating a new note' do
+
+          it 'cannot create a note without a subject' do
+            @student_page.click_create_new_note
+            @student_page.new_note_save_button_element.when_present 1
+            expect(@student_page.new_note_save_button_element.disabled?).to be true
+          end
+
+          it 'can cancel an unsaved new note' do
+            @student_page.click_cancel_new_note
+            @student_page.click_create_new_note
+            @student_page.wait_for_element_and_type(@student_page.note_body_text_area_elements[1], 'An edit to forget')
+            @student_page.click_cancel_new_note
+            @student_page.confirm_delete_or_discard
+            @student_page.wait_until(1) { @student_page.note_body_text_area_elements.empty? }
+          end
+
+          it 'can create a note with a subject' do
+            note_1.subject = "Note 1 subject #{Utils.get_test_id}"
+            @student_page.create_note(note_1, [], [])
+            @student_page.verify_note note_1
+          end
+
+          it 'can create a note with a subject and a body' do
+            note_2.subject = "Note 2 subject #{Utils.get_test_id}"
+            note_2.body = "Note 2 body #{test.id}" unless "#{@driver.browser}" == 'firefox'
+            @student_page.create_note(note_2, [], [])
+            @student_page.verify_note note_2
+          end
+
+          it 'can create a long note with special characters' do
+            note_3.subject = "Σημείωση θέμα 3 #{Utils.get_test_id}"
+            note_3.body = 'ノート本体4' * 100 unless "#{@driver.browser}" == 'firefox'
+            @student_page.create_note(note_3, [], [])
+            @student_page.verify_note note_3
+          end
+
+          it 'can add and remove attachments before saving' do
+            note_4.subject = "Note 4 subject #{Utils.get_test_id}"
+            @student_page.click_create_new_note
+            @student_page.enter_new_note_subject note_4
+            @student_page.add_attachments_to_new_note(note_4, test.attachments[0..1])
+            @student_page.remove_attachments_from_new_note(note_4, test.attachments[0..1])
+            @student_page.click_save_new_note
+            @student_page.set_new_note_id note_4
+            @student_page.verify_note note_4
+          end
+
+          it 'can create a note with attachments' do
+            note_5.subject = "Note 5 subject #{Utils.get_test_id}"
+            @student_page.create_note(note_5, [], test.attachments[0..1])
+            @student_page.verify_note note_5
+          end
+
+          it 'can create a note with a maximum of 10 attachments' do
+            note_6.subject = "Note 6 subject #{Utils.get_test_id}"
+            @student_page.click_create_new_note
+            @student_page.enter_new_note_subject note_6
+            @student_page.add_attachments_to_new_note(note_6, big_attachments)
+            @student_page.existing_note_attachment_input(note_6).when_not_visible 1
+            @student_page.click_save_new_note
+            @student_page.set_new_note_id note_6
+            @student_page.collapsed_item_el(note_6).when_visible Utils.short_wait
+            @student_page.verify_note note_6
+          end
+
+          it 'cannot create a note with an individual attachment larger than 20MB' do
+            too_big_attachment = test.attachments.find { |a| a.file_size > 20000000 }
+            @student_page.click_create_new_note
+            @student_page.new_note_attach_input_element.when_present 1
+            @student_page.new_note_attach_input_element.send_keys Utils.asset_file_path(too_big_attachment.file_name)
+            @student_page.note_attachment_size_msg_element.when_visible Utils.short_wait
+          end
+
+          it 'can add and remove topics before saving' do
+            note_7.subject = "Note 7 subject #{Utils.get_test_id}"
+            note_topics = [Topic::COURSE_ADD, Topic::COURSE_DROP]
+            @student_page.load_page test_student
+            @student_page.click_create_new_note
+            @student_page.enter_new_note_subject note_7
+            @student_page.add_topics(note_7, note_topics)
+            @student_page.remove_topics(note_7, note_topics)
+            @student_page.click_save_new_note
+            @student_page.set_new_note_id note_7
+            @student_page.verify_note note_7
+          end
+
+          it 'is offered a list of note topics' do
+            @student_page.click_create_new_note
+            expected_topics = Topic::TOPICS.select(&:for_notes).map &:name
+            @student_page.wait_until(1, "Expected #{expected_topics}, got #{@student_page.topic_options}") do
+              @student_page.topic_options == expected_topics
+            end
+          end
+
+          it 'can create a note with topics' do
+            note_8.subject = "Note 8 subject #{Utils.get_test_id}"
+            @student_page.load_page test_student
+            @student_page.create_note(note_8, [Topic::EAP, Topic::SAT_ACAD_PROGRESS_APPEAL, Topic::PASS_NO_PASS, Topic::PROBATION], [])
+            @student_page.verify_note note_8
           end
         end
 
-        it 'can create a note with topics' do
-          note_8.subject = "Note 8 subject #{Utils.get_test_id}"
-          @student_page.load_page test_student
-          @student_page.create_note(note_8, [Topic::EAP, Topic::SAT_ACAD_PROGRESS_APPEAL, Topic::PASS_NO_PASS, Topic::PROBATION], [])
-          @student_page.verify_note note_8
+        context 'searching for a newly created note' do
+
+          before(:all) do
+            @student_page.expand_search_options
+            @student_page.uncheck_include_students_cbx
+            @student_page.uncheck_include_classes_cbx
+            sleep Utils.short_wait
+          end
+
+          shared_examples 'searching for your own note' do
+            it 'can find a note by subject' do
+              @student_page.type_note_appt_string_and_enter note_1.subject
+              @search_results_page.wait_for_note_search_result_rows
+              expect(@search_results_page.note_link(note_1).exists?).to be true
+            end
+
+            it 'can find a note by body' do
+              unless "#{@driver.browser}" == 'firefox'
+                @student_page.type_note_appt_string_and_enter note_2.body
+                @search_results_page.wait_for_note_search_result_rows
+                expect(@search_results_page.note_link(note_2).exists?).to be true
+              end
+            end
+
+            it 'can find a note with special characters' do
+              @student_page.type_note_appt_string_and_enter note_3.subject
+              @search_results_page.wait_for_note_search_result_rows
+              expect(@search_results_page.note_link(note_3).exists?).to be true
+            end
+          end
+
+          describe 'when searching for "anyone"' do
+            before { @student_page.select_notes_posted_by_anyone }
+            include_examples 'searching for your own note'
+          end
+
+          describe 'when searching for "only you"' do
+            before { @student_page.select_notes_posted_by_you }
+            after { @student_page.select_notes_posted_by_anyone }
+            include_examples 'searching for your own note'
+          end
         end
-      end
 
-      context 'searching for a newly created note' do
+        context 'viewing a newly created note' do
 
-        before(:all) do
-          @student_page.expand_search_options
-          @student_page.uncheck_include_students_cbx
-          @student_page.uncheck_include_classes_cbx
-          sleep Utils.short_wait
+          before(:all) do
+            @student_page.load_page test_student
+            @student_page.show_notes
+            @student_page.expand_item note_5
+          end
+
+          it 'can download note attachments' do
+            if Utils.headless?
+              logger.warn 'Skipping attachment download tests in headless mode'
+              skip
+            else
+              note_5.attachments.each { |attach| @student_page.download_attachment(note_5, attach) }
+            end
+          end
+
+          it 'can visit the note permalink' do
+            @student_page.navigate_to @student_page.visible_expanded_note_data(note_5)[:permalink_url]
+            @student_page.wait_until(Utils.short_wait) { @student_page.item_expanded? note_5 }
+          end
         end
 
-        shared_examples 'searching for your own note' do
-          it 'can find a note by subject' do
+        context 'viewing newly created notes' do
+
+          it 'shows the notes in the right order' do
+            @student_page.load_page test_student
+            @student_page.show_notes
+            new_note_ids = notes.map &:id
+            visible_new_note_ids = @student_page.visible_collapsed_note_ids.keep_if { |id| new_note_ids.include? id }
+            expect(visible_new_note_ids).to eql(@student_page.expected_note_id_sort_order notes)
+          end
+
+          it('sees no download link') { expect(@student_page.notes_download_link?).to be false }
+
+          it 'cannot hit the download endpoint' do
+            Utils.prepare_download_dir
+            @api_notes_page.load_download_page test_student
+            @api_notes_page.unauth_msg_element.when_visible Utils.short_wait
+            expect(Utils.downloads_empty?).to be true
+          end
+        end
+
+        context 'editing an existing note' do
+
+          before(:each) do
+            @student_page.load_page test_student
+            @student_page.show_notes
+          end
+
+          it 'can cancel the edit' do
+            original_subject = note_1.subject
+            note_1.subject = 'An edit to forget'
+            @student_page.expand_item note_1
+            @student_page.click_edit_note_button note_1
+            @student_page.enter_edit_note_subject note_1
+            @student_page.click_cancel_note_edit
+            @student_page.confirm_delete_or_discard
+            @student_page.wait_until(1) { @student_page.note_body_text_area_elements.empty? }
+            note_1.subject = original_subject
+            @student_page.verify_note note_1
+          end
+
+          it 'can change the subject' do
+            note_1.subject = "#{note_1.subject} - EDITED"
+            @student_page.edit_note_subject_and_save note_1
+            @student_page.verify_note note_1
+          end
+
+          it 'can add attachments' do
+            @student_page.expand_item note_4
+            @student_page.add_attachments_to_existing_note(note_4, test.attachments[5..6])
+            @student_page.verify_note note_4
+          end
+
+          it 'can add up to a maximum of 10 attachments' do
+            @student_page.expand_item note_6
+            expect(@student_page.existing_note_attachment_input(note_6).exists?).to be false
+          end
+
+          it 'can remove an existing attachment' do
+            @student_page.expand_item note_5
+            attach_to_delete = note_5.attachments.first
+            attach_to_delete.id = BOACUtils.get_attachment_id_by_file_name(note_5, attach_to_delete)
+            deleted_attachments << attach_to_delete
+            @student_page.remove_attachments_from_existing_note(note_5, [note_5.attachments.first])
+            @student_page.verify_note note_5
+          end
+
+          it 'can add topics' do
+            @student_page.expand_item note_7
+            @student_page.click_edit_note_button note_7
+            @student_page.add_topics(note_7, [Topic::LATE_ENROLLMENT, Topic::RETROACTIVE_ADD])
+            @student_page.click_save_note_edit
+            @student_page.edit_note_save_button_element.when_not_present Utils.short_wait
+            note_7.updated_date = Time.now
+            @student_page.verify_note note_7
+          end
+
+          it 'can remove topics' do
+            @student_page.expand_item note_8
+            @student_page.click_edit_note_button note_8
+            @student_page.remove_topics(note_8, [Topic::EAP, Topic::PASS_NO_PASS])
+            @student_page.click_save_note_edit
+            @student_page.edit_note_save_button_element.when_not_present Utils.short_wait
+            note_8.updated_date = Time.now
+            @student_page.verify_note note_8
+          end
+
+          it 'can only create or edit one note at a time' do
+            @student_page.expand_item note_1
+            @student_page.edit_note_button(note_1).when_visible 1
+            @student_page.expand_item note_2
+            @student_page.edit_note_button(note_2).when_visible 1
+            @student_page.click_edit_note_button note_1
+            expect(@student_page.edit_note_button(note_2).exists?).to be false
+            expect(@student_page.new_note_button_element.disabled?).to be true
+          end
+
+          it 'can cancel the edit' do
+            @student_page.expand_item note_2
+            @student_page.click_edit_note_button note_2
+            @student_page.wait_for_element_and_type(@student_page.note_body_text_area_elements[1], 'An edit to forget')
+            @student_page.click_cancel_note_edit
+            @student_page.confirm_delete_or_discard
+            @student_page.verify_note note_2
+          end
+
+          it 'cannot remove the subject' do
+            @student_page.expand_item note_2
+            @student_page.click_edit_note_button note_2
+            @student_page.wait_for_element_and_type(@student_page.edit_note_subject_input_element, ' ')
+            @student_page.click_save_note_edit
+            @student_page.subj_required_msg_element.when_visible 1
+            @student_page.click_cancel_note_edit
+            @student_page.wait_for_update_and_click @student_page.confirm_delete_or_discard_button_element
+          end
+
+          it 'cannot add an attachment with the same file name as an existing attachment' do
+            @student_page.expand_item note_4
+            @student_page.existing_note_attachment_input(note_4).when_present 1
+            @student_page.existing_note_attachment_input(note_4).send_keys Utils.asset_file_path(test.attachments[5].file_name)
+            @student_page.note_dupe_attachment_msg_element.when_present Utils.short_wait
+          end
+
+          it 'cannot add an individual attachment larger than 20MB' do
+            too_big_attachment = test.attachments.find { |a| a.file_size > 20000000 }
+            @student_page.expand_item note_2
+            @student_page.existing_note_attachment_input(note_2).when_present 1
+            @student_page.existing_note_attachment_input(note_2).send_keys Utils.asset_file_path(too_big_attachment.file_name)
+            @student_page.note_attachment_size_msg_element.when_visible Utils.short_wait
+          end
+        end
+
+        context 'viewing edited notes' do
+
+          it 'shows the notes in the right order' do
+            @student_page.load_page test_student
+            @student_page.show_notes
+            note_ids = notes.map &:id
+            visible_new_note_ids = @student_page.visible_collapsed_note_ids.keep_if { |id| note_ids.include? id }
+            expect(visible_new_note_ids).to eql(@student_page.expected_note_id_sort_order notes)
+          end
+        end
+
+        context 'attempting to delete a note' do
+
+          it 'cannot do so' do
+            @student_page.expand_item note_1
+            expect(@student_page.delete_note_button(note_1).visible?).to be false
+          end
+        end
+
+        context 'searching for an edited note' do
+
+          it 'can find a note by edited content' do
             @student_page.type_note_appt_string_and_enter note_1.subject
             @search_results_page.wait_for_note_search_result_rows
             expect(@search_results_page.note_link(note_1).exists?).to be true
           end
 
-          it 'can find a note by body' do
-            unless "#{@driver.browser}" == 'firefox'
-              @student_page.type_note_appt_string_and_enter note_2.body
-              @search_results_page.wait_for_note_search_result_rows
-              expect(@search_results_page.note_link(note_2).exists?).to be true
-            end
+          it 'cannot download a deleted attachment' do
+            Utils.prepare_download_dir
+            @api_notes_page.load_attachment_page deleted_attachments.first.id
+            @api_notes_page.not_found_msg_element.when_visible Utils.short_wait
+            expect(Utils.downloads_empty?).to be true
           end
+        end
+      end
 
-          it 'can find a note with special characters' do
-            @student_page.type_note_appt_string_and_enter note_3.subject
-            @search_results_page.wait_for_note_search_result_rows
-            expect(@search_results_page.note_link(note_3).exists?).to be true
-          end
+      describe 'advisor other than the note creator but in the same department' do
+
+        before(:all) do
+          @homepage.dev_auth other_advisor
+          @student_page.load_page test_student
+        end
+
+        after(:all) do
+          @student_page.select_notes_posted_by_anyone
+          @homepage.load_page
+          @homepage.log_out
         end
 
         describe 'when searching for "anyone"' do
           before { @student_page.select_notes_posted_by_anyone }
-          include_examples 'searching for your own note'
+          it 'can find the other user\'s note' do
+            @student_page.type_note_appt_string_and_enter note_1.subject
+            @search_results_page.wait_for_note_search_result_rows
+            expect(@search_results_page.note_link(note_1).exists?).to be true
+          end
         end
 
         describe 'when searching for "only you"' do
           before { @student_page.select_notes_posted_by_you }
           after { @student_page.select_notes_posted_by_anyone }
-          include_examples 'searching for your own note'
+          it 'cannot find the other user\'s note' do
+            @student_page.type_note_appt_string_and_enter note_1.subject
+            expect(@search_results_page.note_results_count).to be_zero
+          end
         end
-      end
 
-      context 'viewing a newly created note' do
-
-        before(:all) do
-          @student_page.load_page test_student
-          @student_page.show_notes
+        it 'cannot edit the other user\'s note' do
           @student_page.expand_item note_5
+          expect(@student_page.edit_note_button(note_5).exists?).to be false
         end
 
-        it 'can download note attachments' do
+        it 'cannot delete attachments on the other user\'s note' do
+          @student_page.expand_item note_5
+          note_5.attachments.reject(&:deleted_at).each { |attach| expect(@student_page.existing_note_attachment_delete_button(note_5, attach).exists?).to be false }
+        end
+
+        it 'can download non-deleted attachments' do
           if Utils.headless?
             logger.warn 'Skipping attachment download tests in headless mode'
             skip
           else
-            note_5.attachments.each { |attach| @student_page.download_attachment(note_5, attach) }
+            note_5.attachments.reject(&:deleted_at).each { |attach| @student_page.download_attachment(note_5, attach) }
           end
         end
-
-        it 'can visit the note permalink' do
-          @student_page.navigate_to @student_page.visible_expanded_note_data(note_5)[:permalink_url]
-          @student_page.wait_until(Utils.short_wait) { @student_page.item_expanded? note_5 }
-        end
       end
 
-      context 'viewing newly created notes' do
+      describe 'director' do
 
-        it 'shows the notes in the right order' do
-          @student_page.load_page test_student
-          @student_page.show_notes
-          new_note_ids = notes.map &:id
-          visible_new_note_ids = @student_page.visible_collapsed_note_ids.keep_if { |id| new_note_ids.include? id }
-          expect(visible_new_note_ids).to eql(@student_page.expected_note_id_sort_order notes)
-        end
-
-        it('sees no download link') { expect(@student_page.notes_download_link?).to be false }
-
-        it 'cannot hit the download endpoint' do
-          Utils.prepare_download_dir
-          @api_notes_page.load_download_page test_student
-          @api_notes_page.unauth_msg_element.when_visible Utils.short_wait
-          expect(Utils.downloads_empty?).to be true
-        end
-      end
-
-      context 'editing an existing note' do
-
-        before(:each) do
+        before do
+          @homepage.dev_auth director
           @student_page.load_page test_student
           @student_page.show_notes
         end
 
-        it 'can cancel the edit' do
-          original_subject = note_1.subject
-          note_1.subject = 'An edit to forget'
-          @student_page.expand_item note_1
-          @student_page.click_edit_note_button note_1
-          @student_page.enter_edit_note_subject note_1
-          @student_page.click_cancel_note_edit
-          @student_page.confirm_delete_or_discard
-          @student_page.wait_until(1) { @student_page.note_body_text_area_elements.empty? }
-          note_1.subject = original_subject
-          @student_page.verify_note note_1
-        end
-
-        it 'can change the subject' do
-          note_1.subject = "#{note_1.subject} - EDITED"
-          @student_page.edit_note_subject_and_save note_1
-          @student_page.verify_note note_1
-        end
-
-        it 'can add attachments' do
-          @student_page.expand_item note_4
-          @student_page.add_attachments_to_existing_note(note_4, test.attachments[5..6])
-          @student_page.verify_note note_4
-        end
-
-        it 'can add up to a maximum of 10 attachments' do
-          @student_page.expand_item note_6
-          expect(@student_page.existing_note_attachment_input(note_6).exists?).to be false
-        end
-
-        it 'can remove an existing attachment' do
-          @student_page.expand_item note_5
-          attach_to_delete = note_5.attachments.first
-          attach_to_delete.id = BOACUtils.get_attachment_id_by_file_name(note_5, attach_to_delete)
-          deleted_attachments << attach_to_delete
-          @student_page.remove_attachments_from_existing_note(note_5, [note_5.attachments.first])
-          @student_page.verify_note note_5
-        end
-
-        it 'can add topics' do
-          @student_page.expand_item note_7
-          @student_page.click_edit_note_button note_7
-          @student_page.add_topics(note_7, [Topic::LATE_ENROLLMENT, Topic::RETROACTIVE_ADD])
-          @student_page.click_save_note_edit
-          @student_page.edit_note_save_button_element.when_not_present Utils.short_wait
-          note_7.updated_date = Time.now
-          @student_page.verify_note note_7
-        end
-
-        it 'can remove topics' do
-          @student_page.expand_item note_8
-          @student_page.click_edit_note_button note_8
-          @student_page.remove_topics(note_8, [Topic::EAP, Topic::PASS_NO_PASS])
-          @student_page.click_save_note_edit
-          @student_page.edit_note_save_button_element.when_not_present Utils.short_wait
-          note_8.updated_date = Time.now
-          @student_page.verify_note note_8
-        end
-
-        it 'can only create or edit one note at a time' do
-          @student_page.expand_item note_1
-          @student_page.edit_note_button(note_1).when_visible 1
-          @student_page.expand_item note_2
-          @student_page.edit_note_button(note_2).when_visible 1
-          @student_page.click_edit_note_button note_1
-          expect(@student_page.edit_note_button(note_2).exists?).to be false
-          expect(@student_page.new_note_button_element.disabled?).to be true
-        end
-
-        it 'can cancel the edit' do
-          @student_page.expand_item note_2
-          @student_page.click_edit_note_button note_2
-          @student_page.wait_for_element_and_type(@student_page.note_body_text_area_elements[1], 'An edit to forget')
-          @student_page.click_cancel_note_edit
-          @student_page.confirm_delete_or_discard
-          @student_page.verify_note note_2
-        end
-
-        it 'cannot remove the subject' do
-          @student_page.expand_item note_2
-          @student_page.click_edit_note_button note_2
-          @student_page.wait_for_element_and_type(@student_page.edit_note_subject_input_element, ' ')
-          @student_page.click_save_note_edit
-          @student_page.subj_required_msg_element.when_visible 1
-          @student_page.click_cancel_note_edit
-          @student_page.wait_for_update_and_click @student_page.confirm_delete_or_discard_button_element
-        end
-
-        it 'cannot add an attachment with the same file name as an existing attachment' do
-          @student_page.expand_item note_4
-          @student_page.existing_note_attachment_input(note_4).when_present 1
-          @student_page.existing_note_attachment_input(note_4).send_keys Utils.asset_file_path(test.attachments[5].file_name)
-          @student_page.note_dupe_attachment_msg_element.when_present Utils.short_wait
-        end
-
-        it 'cannot add an individual attachment larger than 20MB' do
-          too_big_attachment = test.attachments.find { |a| a.file_size > 20000000 }
-          @student_page.expand_item note_2
-          @student_page.existing_note_attachment_input(note_2).when_present 1
-          @student_page.existing_note_attachment_input(note_2).send_keys Utils.asset_file_path(too_big_attachment.file_name)
-          @student_page.note_attachment_size_msg_element.when_visible Utils.short_wait
-        end
-      end
-
-      context 'viewing edited notes' do
-
-        it 'shows the notes in the right order' do
-          @student_page.load_page test_student
-          @student_page.show_notes
-          note_ids = notes.map &:id
-          visible_new_note_ids = @student_page.visible_collapsed_note_ids.keep_if { |id| note_ids.include? id }
-          expect(visible_new_note_ids).to eql(@student_page.expected_note_id_sort_order notes)
-        end
-      end
-
-      context 'attempting to delete a note' do
-
-        it 'cannot do so' do
-          @student_page.expand_item note_1
-          expect(@student_page.delete_note_button(note_1).visible?).to be false
-        end
-      end
-
-      context 'searching for an edited note' do
-
-        it 'can find a note by edited content' do
-          @student_page.type_note_appt_string_and_enter note_1.subject
-          @search_results_page.wait_for_note_search_result_rows
-          expect(@search_results_page.note_link(note_1).exists?).to be true
-        end
-
-        it 'cannot download a deleted attachment' do
-          Utils.prepare_download_dir
-          @api_notes_page.load_attachment_page deleted_attachments.first.id
-          @api_notes_page.not_found_msg_element.when_visible Utils.short_wait
-          expect(Utils.downloads_empty?).to be true
-        end
-      end
-    end
-
-    describe 'advisor other than the note creator but in the same department' do
-
-      before(:all) do
-        @homepage.dev_auth other_advisor
-        @student_page.load_page test_student
-      end
-
-      after(:all) do
-        @student_page.select_notes_posted_by_anyone
-        @homepage.load_page
-        @homepage.log_out
-      end
-
-      describe 'when searching for "anyone"' do
-        before { @student_page.select_notes_posted_by_anyone }
-        it 'can find the other user\'s note' do
-          @student_page.type_note_appt_string_and_enter note_1.subject
-          @search_results_page.wait_for_note_search_result_rows
-          expect(@search_results_page.note_link(note_1).exists?).to be true
-        end
-      end
-
-      describe 'when searching for "only you"' do
-        before { @student_page.select_notes_posted_by_you }
-        after { @student_page.select_notes_posted_by_anyone }
-        it 'cannot find the other user\'s note' do
-          @student_page.type_note_appt_string_and_enter note_1.subject
-          expect(@search_results_page.note_results_count).to be_zero
-        end
-      end
-
-      it 'cannot edit the other user\'s note' do
-        @student_page.expand_item note_5
-        expect(@student_page.edit_note_button(note_5).exists?).to be false
-      end
-
-      it 'cannot delete attachments on the other user\'s note' do
-        @student_page.expand_item note_5
-        note_5.attachments.reject(&:deleted_at).each { |attach| expect(@student_page.existing_note_attachment_delete_button(note_5, attach).exists?).to be false }
-      end
-
-      it 'can download non-deleted attachments' do
-        if Utils.headless?
-          logger.warn 'Skipping attachment download tests in headless mode'
-          skip
-        else
-          note_5.attachments.reject(&:deleted_at).each { |attach| @student_page.download_attachment(note_5, attach) }
-        end
-      end
-    end
-
-    describe 'director' do
-
-      before do
-        @homepage.dev_auth director
-        @student_page.load_page test_student
-        @student_page.show_notes
-      end
-
-      after do
-        @homepage.load_page
-        @homepage.log_out
-      end
-
-      it('can download notes') { @student_page.notes_download_link_element.when_visible Utils.short_wait }
-    end
-
-    describe 'admin' do
-
-      before(:all) do
-        @homepage.dev_auth
-        @student_page.load_page test_student
-        @student_page.show_notes
-      end
-
-      after(:all) do
-        @homepage.load_page
-        @homepage.log_out
-      end
-
-      it('cannot create a note') { expect(@student_page.new_note_button?).to be false }
-
-      it('cannot create a batch note') { expect(@student_page.batch_note_button?).to be false }
-
-      it('can download notes') { @student_page.notes_download_link_element.when_visible Utils.short_wait }
-
-      notes.each do |note|
-        it 'cannot edit a note' do
-          @student_page.expand_item note
-          expect(@student_page.edit_note_button(note).exists?).to be false
-        end
-
-        it 'can delete a note' do
-          @student_page.delete_note note
-          @student_page.collapsed_item_el(note).when_not_visible Utils.short_wait
-          deleted = BOACUtils.get_note_delete_status note
-          expect(deleted).to_not be_nil
-        end
-      end
-    end
-
-    describe 'advisor' do
-
-      before(:all) do
-        @homepage.dev_auth test.advisor
-        @student_page.expand_search_options
-        @student_page.uncheck_include_students_cbx
-        @student_page.uncheck_include_classes_cbx
-      end
-
-      notes.each do |note|
-        it 'cannot find a deleted note' do
-          logger.info "Searching for deleted note ID #{note.id} by subject '#{note.subject}'"
+        after do
           @homepage.load_page
-          @student_page.type_note_appt_string_and_enter note.subject
-          expect(@search_results_page.note_results_count).to be_zero
+          @homepage.log_out
         end
 
-        it 'cannot download a deleted note\'s attachments' do
-          if note.attachments.any?
-            note.attachments.each do |attach|
-              Utils.prepare_download_dir
-              @homepage.load_page
-              id = BOACUtils.get_attachment_id_by_file_name(note, attach)
-              @api_notes_page.load_attachment_page id
-              @api_notes_page.not_found_msg_element.when_visible Utils.short_wait
-              expect(Utils.downloads_empty?).to be true
+        it('can download notes') { @student_page.notes_download_link_element.when_visible Utils.short_wait }
+      end
+
+      describe 'admin' do
+
+        before(:all) do
+          @homepage.dev_auth
+          @student_page.load_page test_student
+          @student_page.show_notes
+        end
+
+        after(:all) do
+          @homepage.load_page
+          @homepage.log_out
+        end
+
+        it('cannot create a note') { expect(@student_page.new_note_button?).to be false }
+
+        it('cannot create a batch note') { expect(@student_page.batch_note_button?).to be false }
+
+        it('can download notes') { @student_page.notes_download_link_element.when_visible Utils.short_wait }
+
+        notes.each do |note|
+          it 'cannot edit a note' do
+            @student_page.expand_item note
+            expect(@student_page.edit_note_button(note).exists?).to be false
+          end
+
+          it 'can delete a note' do
+            @student_page.delete_note note
+            @student_page.collapsed_item_el(note).when_not_visible Utils.short_wait
+            deleted = BOACUtils.get_note_delete_status note
+            expect(deleted).to_not be_nil
+          end
+        end
+      end
+
+      describe 'advisor' do
+
+        before(:all) do
+          @homepage.dev_auth test.advisor
+          @student_page.expand_search_options
+          @student_page.uncheck_include_students_cbx
+          @student_page.uncheck_include_classes_cbx
+        end
+
+        notes.each do |note|
+          it 'cannot find a deleted note' do
+            logger.info "Searching for deleted note ID #{note.id} by subject '#{note.subject}'"
+            @homepage.load_page
+            @student_page.type_note_appt_string_and_enter note.subject
+            expect(@search_results_page.note_results_count).to be_zero
+          end
+
+          it 'cannot download a deleted note\'s attachments' do
+            if note.attachments.any?
+              note.attachments.each do |attach|
+                Utils.prepare_download_dir
+                @homepage.load_page
+                id = BOACUtils.get_attachment_id_by_file_name(note, attach)
+                @api_notes_page.load_attachment_page id
+                @api_notes_page.not_found_msg_element.when_visible Utils.short_wait
+                expect(Utils.downloads_empty?).to be true
+              end
             end
           end
         end

--- a/spec/boac/boac_note_templates_spec.rb
+++ b/spec/boac/boac_note_templates_spec.rb
@@ -1,313 +1,316 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOA note templates' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOA note templates' do
 
-  before(:all) do
-    @test = BOACTestConfig.new
-    @test.note_templates
-
-    @student = @test.students.last
-    @user_templates = NoteTemplate.get_user_note_templates @test.advisor
-    logger.debug "User templates are #{@user_templates.map &:id}"
-    @template_1 = NoteTemplate.new(title: "Template #{@test.id}")
-    @template_2 = NoteTemplate.new(title: "Batch template #{@test.id}")
-    @attachments = @test.attachments.sort_by(&:file_size).delete_if { |a| a.file_size > 20000000 }
-    @attachments = @attachments.first 10
-
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-    @curated_group_page = BOACGroupPage.new @driver
-
-    @homepage.dev_auth @test.advisor
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  it 'can be deleted' do
-    if @user_templates.any?
-      @homepage.click_create_note_batch
-      @user_templates.each { |template| @homepage.delete_template template }
-    else
-      logger.warn "Skipping test for deleting all templates because UID #{@test.advisor.uid} has no templates."
-    end
-  end
-
-  context 'when an advisor has no templates' do
-
-    before do
-      @student_page.load_page @student
-      @student_page.click_create_new_note
-      @student_page.click_templates_button
-    end
-
-    it('show a "You have no saved templates" message') { @student_page.no_templates_msg_element.when_visible 1 }
-  end
-
-  context 'on the student page create-note modal' do
-
-    context 'when an advisor creates a new template' do
-
-      before(:all) { @note = Note.new(subject: "Note student-page-create #{@test.id}", advisor: @test.advisor) }
-
-      it('require a note subject') { expect(@student_page.create_template_button_element.disabled?).to be true }
-
-      it 'can be cancelled' do
-        @student_page.enter_new_note_subject @note
-        @student_page.click_create_template
-        @student_page.click_cancel_template
-        @student_page.template_title_input_element.when_not_present 1
-      end
-
-      it 'can be created' do
-        @student_page.enter_note_body @note
-        @student_page.add_topics(@note, [Topic::ACADEMIC_PROGRESS_RPT, Topic::DEGREE_CHECK])
-        @student_page.add_attachments_to_new_note(@note, @attachments.first(6))
-        @student_page.create_template(@template_1, @note)
-      end
-
-      it 'add the template to the available templates' do
-        @student_page.click_templates_button
-        @student_page.wait_until(1) { @student_page.template_option(@template_1).exists? }
-      end
-
-      it 'require a title' do
-        @student_page.click_create_template
-        expect(@student_page.create_template_confirm_button_element.disabled?).to be true
-      end
-
-      it 'require a unique title' do
-        @student_page.click_cancel_template
-        @student_page.click_create_template
-        @student_page.enter_template_title @template_1
-        @student_page.click_save_template
-        @student_page.dupe_template_title_msg_element.when_visible 1
-      end
-
-      it 'can be applied to a new note' do
-        @student_page.click_cancel_template
-        @student_page.click_save_new_note
-        @student_page.set_new_note_id(@note, @student)
-        @student_page.verify_note @note
-      end
-    end
-
-    context 'when an advisor edits an existing template' do
-
-      before(:all) do
-        @note = Note.new(subject: "Note student-page-edit #{@test.id}", advisor: @test.advisor)
-        @student_page.load_page @student
-        @student_page.click_create_new_note
-      end
-
-      it 'can be cancelled' do
-        @student_page.click_edit_template @template_1
-        @student_page.click_cancel_new_note
-        @student_page.edit_template_heading_element.when_not_visible 1
-      end
-
-      it 'can be edited' do
-        @template_1.subject = "Template #{@test.id} - edited"
-
-        new_topics = [Topic::ACADEMIC_PROGRESS_RPT, Topic::EAP]
-        topics_to_remove = @template_1.topics - new_topics
-        topics_to_add = new_topics - @template_1.topics
-
-        attachments_to_remove = @template_1.attachments
-        attachments_to_add = @attachments.last 4
-
-        @student_page.click_edit_template @template_1
-        @student_page.enter_new_note_subject @template_1
-        @student_page.enter_note_body @template_1
-        @student_page.remove_topics(@template_1, topics_to_remove)
-        @student_page.add_topics(@template_1, topics_to_add)
-        @student_page.remove_attachments_from_new_note(@template_1, attachments_to_remove)
-        @student_page.add_attachments_to_new_note(@template_1, attachments_to_add)
-        @student_page.click_update_template
-      end
-
-      it 'can be applied to a new note' do
-        @student_page.apply_template(@template_1, @note)
-        @student_page.click_save_new_note
-        @student_page.set_new_note_id(@note, @student)
-        @student_page.verify_note @note
-      end
-
-      it 'can be renamed but cancelled' do
-        @student_page.click_create_new_note
-        @student_page.click_rename_template @template_1
-        @student_page.click_cancel_template_rename
-        @student_page.rename_template_input_element.when_not_visible 1
-      end
-
-      it 'can be renamed' do
-        @template_1.title = "S T #{@test.id}"
-        @student_page.rename_template @template_1
-        @student_page.click_templates_button
-        @student_page.template_option(@template_1).when_visible 1
-      end
-
-      it 'can be deleted but cancelled' do
-        @student_page.click_delete_template @template_1
-        @student_page.cancel_delete_or_discard
-        @student_page.cancel_delete_or_discard_button_element.when_not_visible 1
-      end
-
-      it 'can be deleted' do
-        @student_page.delete_template @template_1
-        @student_page.click_templates_button
-        expect(@student_page.template_options).not_to include(@template_1.title)
-      end
-    end
-  end
-
-  context 'on the batch note modal' do
+    include Logging
 
     before(:all) do
-      # Get students to add one-by-one
-      @students = @test.students.first 2
+      @test = BOACTestConfig.new
+      @test.note_templates
 
-      # Create cohort to add
-      @homepage.load_page
-      @cohort_page.search_and_create_new_cohort(@test.default_cohort, default: true)
-      @test.default_cohort.members = @test.cohort_members
+      @student = @test.students.last
+      @user_templates = NoteTemplate.get_user_note_templates @test.advisor
+      logger.debug "User templates are #{@user_templates.map &:id}"
+      @template_1 = NoteTemplate.new(title: "Template #{@test.id}")
+      @template_2 = NoteTemplate.new(title: "Batch template #{@test.id}")
+      @attachments = @test.attachments.sort_by(&:file_size).delete_if { |a| a.file_size > 20000000 }
+      @attachments = @attachments.first 10
 
-      # Create group to add
-      group_members = @test.students.shuffle.last BOACUtils.config['notes_batch_curated_group_count']
-      @group = CuratedGroup.new(name: "Group 1 - #{@test.id}")
-      @homepage.click_sidebar_create_curated_group
-      @curated_group_page.create_group_with_bulk_sids(group_members, @group)
-      @curated_group_page.wait_for_sidebar_group @group
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
+      @curated_group_page = BOACGroupPage.new @driver
+
+      @homepage.dev_auth @test.advisor
     end
 
-    context 'when an advisor creates a new template' do
+    after(:all) { Utils.quit_browser @driver }
 
-      before(:all) do
-        @note_batch = NoteBatch.new(subject: "Note batch-create #{@test.id}", body: "Body #{@test.id}", advisor: @test.advisor)
+    it 'can be deleted' do
+      if @user_templates.any?
         @homepage.click_create_note_batch
-      end
-
-      it('require a note subject') { expect(@homepage.create_template_button_element.disabled?).to be true }
-
-      it 'can be cancelled' do
-        @homepage.enter_new_note_subject @note_batch
-        @homepage.click_create_template
-        @homepage.click_cancel_template
-        @homepage.template_title_input_element.when_not_present 1
-      end
-
-      it 'can be created' do
-        @homepage.add_students_to_batch(@note_batch, @students)
-        @homepage.add_cohorts_to_batch(@note_batch, [@test.default_cohort])
-        @homepage.add_curated_groups_to_batch(@note_batch, [@group])
-        @homepage.enter_note_body @note_batch
-        @homepage.add_topics(@note_batch, [Topic::ACADEMIC_PROGRESS_RPT, Topic::DEGREE_CHECK])
-        @homepage.add_attachments_to_new_note(@note_batch, @attachments.first(6))
-        @homepage.create_template(@template_2, @note_batch)
-      end
-
-      it 'add the template to the available templates' do
-        @homepage.click_templates_button
-        @homepage.wait_until(1) { @homepage.template_option @template_2 }
-      end
-
-      it 'require a title' do
-        @homepage.click_create_template
-        expect(@homepage.create_template_confirm_button_element.disabled?).to be true
-      end
-
-      it 'require_a_unique_title' do
-        @homepage.click_cancel_template
-        @homepage.click_create_template
-        @homepage.enter_template_title @template_2
-        @homepage.click_save_template
-        @homepage.dupe_template_title_msg_element.when_visible 1
-      end
-      
-      it 'can be applied to a new note' do
-        @homepage.click_cancel_template
-        @homepage.click_save_new_note
-        batch_student = @homepage.unique_students_in_batch(@students, [@test.default_cohort], [@group]).first
-        @student_page.set_new_note_id(@note_batch, batch_student)
-        @student_page.load_page batch_student
-        @student_page.verify_note @note_batch
+        @user_templates.each { |template| @homepage.delete_template template }
+      else
+        logger.warn "Skipping test for deleting all templates because UID #{@test.advisor.uid} has no templates."
       end
     end
 
-    context 'when an advisor edits an existing template' do
+    context 'when an advisor has no templates' do
+
+      before do
+        @student_page.load_page @student
+        @student_page.click_create_new_note
+        @student_page.click_templates_button
+      end
+
+      it('show a "You have no saved templates" message') { @student_page.no_templates_msg_element.when_visible 1 }
+    end
+
+    context 'on the student page create-note modal' do
+
+      context 'when an advisor creates a new template' do
+
+        before(:all) { @note = Note.new(subject: "Note student-page-create #{@test.id}", advisor: @test.advisor) }
+
+        it('require a note subject') { expect(@student_page.create_template_button_element.disabled?).to be true }
+
+        it 'can be cancelled' do
+          @student_page.enter_new_note_subject @note
+          @student_page.click_create_template
+          @student_page.click_cancel_template
+          @student_page.template_title_input_element.when_not_present 1
+        end
+
+        it 'can be created' do
+          @student_page.enter_note_body @note
+          @student_page.add_topics(@note, [Topic::ACADEMIC_PROGRESS_RPT, Topic::DEGREE_CHECK])
+          @student_page.add_attachments_to_new_note(@note, @attachments.first(6))
+          @student_page.create_template(@template_1, @note)
+        end
+
+        it 'add the template to the available templates' do
+          @student_page.click_templates_button
+          @student_page.wait_until(1) { @student_page.template_option(@template_1).exists? }
+        end
+
+        it 'require a title' do
+          @student_page.click_create_template
+          expect(@student_page.create_template_confirm_button_element.disabled?).to be true
+        end
+
+        it 'require a unique title' do
+          @student_page.click_cancel_template
+          @student_page.click_create_template
+          @student_page.enter_template_title @template_1
+          @student_page.click_save_template
+          @student_page.dupe_template_title_msg_element.when_visible 1
+        end
+
+        it 'can be applied to a new note' do
+          @student_page.click_cancel_template
+          @student_page.click_save_new_note
+          @student_page.set_new_note_id(@note, @student)
+          @student_page.verify_note @note
+        end
+      end
+
+      context 'when an advisor edits an existing template' do
+
+        before(:all) do
+          @note = Note.new(subject: "Note student-page-edit #{@test.id}", advisor: @test.advisor)
+          @student_page.load_page @student
+          @student_page.click_create_new_note
+        end
+
+        it 'can be cancelled' do
+          @student_page.click_edit_template @template_1
+          @student_page.click_cancel_new_note
+          @student_page.edit_template_heading_element.when_not_visible 1
+        end
+
+        it 'can be edited' do
+          @template_1.subject = "Template #{@test.id} - edited"
+
+          new_topics = [Topic::ACADEMIC_PROGRESS_RPT, Topic::EAP]
+          topics_to_remove = @template_1.topics - new_topics
+          topics_to_add = new_topics - @template_1.topics
+
+          attachments_to_remove = @template_1.attachments
+          attachments_to_add = @attachments.last 4
+
+          @student_page.click_edit_template @template_1
+          @student_page.enter_new_note_subject @template_1
+          @student_page.enter_note_body @template_1
+          @student_page.remove_topics(@template_1, topics_to_remove)
+          @student_page.add_topics(@template_1, topics_to_add)
+          @student_page.remove_attachments_from_new_note(@template_1, attachments_to_remove)
+          @student_page.add_attachments_to_new_note(@template_1, attachments_to_add)
+          @student_page.click_update_template
+        end
+
+        it 'can be applied to a new note' do
+          @student_page.apply_template(@template_1, @note)
+          @student_page.click_save_new_note
+          @student_page.set_new_note_id(@note, @student)
+          @student_page.verify_note @note
+        end
+
+        it 'can be renamed but cancelled' do
+          @student_page.click_create_new_note
+          @student_page.click_rename_template @template_1
+          @student_page.click_cancel_template_rename
+          @student_page.rename_template_input_element.when_not_visible 1
+        end
+
+        it 'can be renamed' do
+          @template_1.title = "S T #{@test.id}"
+          @student_page.rename_template @template_1
+          @student_page.click_templates_button
+          @student_page.template_option(@template_1).when_visible 1
+        end
+
+        it 'can be deleted but cancelled' do
+          @student_page.click_delete_template @template_1
+          @student_page.cancel_delete_or_discard
+          @student_page.cancel_delete_or_discard_button_element.when_not_visible 1
+        end
+
+        it 'can be deleted' do
+          @student_page.delete_template @template_1
+          @student_page.click_templates_button
+          expect(@student_page.template_options).not_to include(@template_1.title)
+        end
+      end
+    end
+
+    context 'on the batch note modal' do
 
       before(:all) do
-        @note_batch = NoteBatch.new(subject: "Note batch edit #{@test.id}", advisor: @test.advisor)
-        @homepage.click_create_note_batch
-        @homepage.add_students_to_batch(@note_batch, @students)
-        @homepage.add_cohorts_to_batch(@note_batch, [@test.default_cohort])
-        @homepage.add_curated_groups_to_batch(@note_batch, [@group])
+        # Get students to add one-by-one
+        @students = @test.students.first 2
+
+        # Create cohort to add
+        @homepage.load_page
+        @cohort_page.search_and_create_new_cohort(@test.default_cohort, default: true)
+        @test.default_cohort.members = @test.cohort_members
+
+        # Create group to add
+        group_members = @test.students.shuffle.last BOACUtils.config['notes_batch_curated_group_count']
+        @group = CuratedGroup.new(name: "Group 1 - #{@test.id}")
+        @homepage.click_sidebar_create_curated_group
+        @curated_group_page.create_group_with_bulk_sids(group_members, @group)
+        @curated_group_page.wait_for_sidebar_group @group
       end
 
-      it 'can be cancelled' do
-        @homepage.click_edit_template @template_2
-        @homepage.click_cancel_new_note
-        @homepage.edit_template_heading_element.when_not_visible 1
+      context 'when an advisor creates a new template' do
+
+        before(:all) do
+          @note_batch = NoteBatch.new(subject: "Note batch-create #{@test.id}", body: "Body #{@test.id}", advisor: @test.advisor)
+          @homepage.click_create_note_batch
+        end
+
+        it('require a note subject') { expect(@homepage.create_template_button_element.disabled?).to be true }
+
+        it 'can be cancelled' do
+          @homepage.enter_new_note_subject @note_batch
+          @homepage.click_create_template
+          @homepage.click_cancel_template
+          @homepage.template_title_input_element.when_not_present 1
+        end
+
+        it 'can be created' do
+          @homepage.add_students_to_batch(@note_batch, @students)
+          @homepage.add_cohorts_to_batch(@note_batch, [@test.default_cohort])
+          @homepage.add_curated_groups_to_batch(@note_batch, [@group])
+          @homepage.enter_note_body @note_batch
+          @homepage.add_topics(@note_batch, [Topic::ACADEMIC_PROGRESS_RPT, Topic::DEGREE_CHECK])
+          @homepage.add_attachments_to_new_note(@note_batch, @attachments.first(6))
+          @homepage.create_template(@template_2, @note_batch)
+        end
+
+        it 'add the template to the available templates' do
+          @homepage.click_templates_button
+          @homepage.wait_until(1) { @homepage.template_option @template_2 }
+        end
+
+        it 'require a title' do
+          @homepage.click_create_template
+          expect(@homepage.create_template_confirm_button_element.disabled?).to be true
+        end
+
+        it 'require_a_unique_title' do
+          @homepage.click_cancel_template
+          @homepage.click_create_template
+          @homepage.enter_template_title @template_2
+          @homepage.click_save_template
+          @homepage.dupe_template_title_msg_element.when_visible 1
+        end
+
+        it 'can be applied to a new note' do
+          @homepage.click_cancel_template
+          @homepage.click_save_new_note
+          batch_student = @homepage.unique_students_in_batch(@students, [@test.default_cohort], [@group]).first
+          @student_page.set_new_note_id(@note_batch, batch_student)
+          @student_page.load_page batch_student
+          @student_page.verify_note @note_batch
+        end
       end
 
-      it 'can be edited' do
-        @template_2.subject = "Template #{@test.id} - edited"
+      context 'when an advisor edits an existing template' do
 
-        new_topics = [Topic::ACADEMIC_PROGRESS_RPT, Topic::EAP]
-        topics_to_remove = @template_2.topics - new_topics
-        topics_to_add = new_topics - @template_2.topics
+        before(:all) do
+          @note_batch = NoteBatch.new(subject: "Note batch edit #{@test.id}", advisor: @test.advisor)
+          @homepage.click_create_note_batch
+          @homepage.add_students_to_batch(@note_batch, @students)
+          @homepage.add_cohorts_to_batch(@note_batch, [@test.default_cohort])
+          @homepage.add_curated_groups_to_batch(@note_batch, [@group])
+        end
 
-        attachments_to_remove = @template_2.attachments
-        attachments_to_add = @attachments.last 4
+        it 'can be cancelled' do
+          @homepage.click_edit_template @template_2
+          @homepage.click_cancel_new_note
+          @homepage.edit_template_heading_element.when_not_visible 1
+        end
 
-        @homepage.click_edit_template @template_2
-        @homepage.enter_new_note_subject @template_2
-        @homepage.enter_note_body @template_2
-        @homepage.remove_topics(@template_2, topics_to_remove)
-        @homepage.add_topics(@template_2, topics_to_add)
-        @homepage.remove_attachments_from_new_note(@template_2, attachments_to_remove)
-        @homepage.add_attachments_to_new_note(@template_2, attachments_to_add)
-        @homepage.click_update_template
+        it 'can be edited' do
+          @template_2.subject = "Template #{@test.id} - edited"
+
+          new_topics = [Topic::ACADEMIC_PROGRESS_RPT, Topic::EAP]
+          topics_to_remove = @template_2.topics - new_topics
+          topics_to_add = new_topics - @template_2.topics
+
+          attachments_to_remove = @template_2.attachments
+          attachments_to_add = @attachments.last 4
+
+          @homepage.click_edit_template @template_2
+          @homepage.enter_new_note_subject @template_2
+          @homepage.enter_note_body @template_2
+          @homepage.remove_topics(@template_2, topics_to_remove)
+          @homepage.add_topics(@template_2, topics_to_add)
+          @homepage.remove_attachments_from_new_note(@template_2, attachments_to_remove)
+          @homepage.add_attachments_to_new_note(@template_2, attachments_to_add)
+          @homepage.click_update_template
+        end
+
+        it 'can be applied to a new note' do
+          @homepage.click_save_new_note
+          @homepage.apply_template(@template_2, @note_batch)
+          batch_student = @homepage.unique_students_in_batch(@students, [@test.default_cohort], [@group]).first
+          @student_page.set_new_note_id(@note_batch, batch_student)
+          @student_page.load_page batch_student
+          @student_page.verify_note @note_batch
+        end
+
+        it 'can be renamed but cancelled' do
+          @homepage.click_create_note_batch
+          @homepage.click_rename_template @template_2
+          @homepage.click_cancel_template_rename
+          @homepage.rename_template_input_element.when_not_visible 1
+        end
+
+        it 'can be renamed' do
+          @template_2.title = "B T #{@test.id}"
+          @homepage.rename_template @template_2
+          @homepage.click_templates_button
+          @homepage.template_option(@template_2).when_visible 1
+        end
+
+        it 'can be deleted but cancelled' do
+          @homepage.click_delete_template @template_2
+          @homepage.cancel_delete_or_discard
+          @homepage.cancel_delete_or_discard_button_element.when_not_visible 1
+        end
+
+        it 'can be deleted' do
+          @homepage.delete_template @template_2
+          @homepage.click_templates_button
+          expect(@homepage.template_options).not_to include(@template_2.title)
+        end
+
       end
-
-      it 'can be applied to a new note' do
-        @homepage.click_save_new_note
-        @homepage.apply_template(@template_2, @note_batch)
-        batch_student = @homepage.unique_students_in_batch(@students, [@test.default_cohort], [@group]).first
-        @student_page.set_new_note_id(@note_batch, batch_student)
-        @student_page.load_page batch_student
-        @student_page.verify_note @note_batch
-      end
-
-      it 'can be renamed but cancelled' do
-        @homepage.click_create_note_batch
-        @homepage.click_rename_template @template_2
-        @homepage.click_cancel_template_rename
-        @homepage.rename_template_input_element.when_not_visible 1
-      end
-
-      it 'can be renamed' do
-        @template_2.title = "B T #{@test.id}"
-        @homepage.rename_template @template_2
-        @homepage.click_templates_button
-        @homepage.template_option(@template_2).when_visible 1
-      end
-
-      it 'can be deleted but cancelled' do
-        @homepage.click_delete_template @template_2
-        @homepage.cancel_delete_or_discard
-        @homepage.cancel_delete_or_discard_button_element.when_not_visible 1
-      end
-
-      it 'can be deleted' do
-        @homepage.delete_template @template_2
-        @homepage.click_templates_button
-        expect(@homepage.template_options).not_to include(@template_2.title)
-      end
-
     end
   end
 end

--- a/spec/boac/boac_search_admit_spec.rb
+++ b/spec/boac/boac_search_admit_spec.rb
@@ -1,143 +1,146 @@
 require_relative '../../util/spec_helper'
 
-test = BOACTestConfig.new
-test.search_admits
-auth_users = BOACUtils.get_authorized_users.select { |a| a.active && !a.is_blocked }
-latest_update_date = NessieUtils.get_admit_data_update_date
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-describe 'CE3 admit search' do
+  test = BOACTestConfig.new
+  test.search_admits
+  auth_users = BOACUtils.get_authorized_users.select { |a| a.active && !a.is_blocked }
+  latest_update_date = NessieUtils.get_admit_data_update_date
 
-  include Logging
+  describe 'CE3 admit search' do
 
-  begin
+    include Logging
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @admit_page = BOACAdmitPage.new @driver
+    begin
 
-    advisor = auth_users.find { |u| !u.is_admin && !u.depts.include?(BOACDepartments::ZCEEE) }
-    @homepage.dev_auth advisor
-    @homepage.expand_search_options
-    non_ce3_cbx_visible = @homepage.include_admits_cbx?
-    it('is not available to a non-CE3, non-admin user') { expect(non_ce3_cbx_visible).to be false }
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @admit_page = BOACAdmitPage.new @driver
 
-    admin = auth_users.find { |u| u.is_admin && !u.depts.include?(BOACDepartments::ZCEEE) }
-    @homepage.log_out
-    @homepage.dev_auth admin
-    @homepage.expand_search_options
-    admin_cbx_visible = @homepage.verify_block { @homepage.include_admits_cbx_element.when_visible Utils.short_wait }
-    it('is available to an admin user') { expect(admin_cbx_visible).to be true }
+      advisor = auth_users.find { |u| !u.is_admin && !u.depts.include?(BOACDepartments::ZCEEE) }
+      @homepage.dev_auth advisor
+      @homepage.expand_search_options
+      non_ce3_cbx_visible = @homepage.include_admits_cbx?
+      it('is not available to a non-CE3, non-admin user') { expect(non_ce3_cbx_visible).to be false }
 
-    @homepage.log_out
-    @homepage.dev_auth test.advisor
-    @homepage.expand_search_options
-    ce3_cbx_visible = @homepage.verify_block { @homepage.include_admits_cbx_element.when_visible Utils.short_wait }
-    it('is available to a CE3 user') { expect(ce3_cbx_visible).to be true }
+      admin = auth_users.find { |u| u.is_admin && !u.depts.include?(BOACDepartments::ZCEEE) }
+      @homepage.log_out
+      @homepage.dev_auth admin
+      @homepage.expand_search_options
+      admin_cbx_visible = @homepage.verify_block { @homepage.include_admits_cbx_element.when_visible Utils.short_wait }
+      it('is available to an admin user') { expect(admin_cbx_visible).to be true }
 
-    @homepage.exclude_admits
-    @homepage.type_non_note_string_and_enter test.test_students.first.sis_id
-    @homepage.wait_for_spinner
-    ce3_excluded = @search_results_page.verify_block do
-      !@search_results_page.admit_results_count?
-      @search_results_page.search_result_all_row_cs_ids.empty?
-    end
-    it('can be excluded from results') { expect(ce3_excluded).to be true }
+      @homepage.log_out
+      @homepage.dev_auth test.advisor
+      @homepage.expand_search_options
+      ce3_cbx_visible = @homepage.verify_block { @homepage.include_admits_cbx_element.when_visible Utils.short_wait }
+      it('is available to a CE3 user') { expect(ce3_cbx_visible).to be true }
 
-    @homepage.include_admits
-    test.test_students.each do |admit|
-
-      begin
-
-        # SEARCHES
-
-        @homepage.type_non_note_string_and_enter admit.first_name
-        complete_first_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with the complete first name") { expect(complete_first_results).to be true }
-
-        @homepage.type_non_note_string_and_enter admit.first_name[0..2]
-        partial_first_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with a partial first name") { expect(partial_first_results).to be true }
-
-        @homepage.type_non_note_string_and_enter admit.last_name
-        complete_last_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with the complete last name") { expect(complete_last_results).to be true }
-
-        @homepage.type_non_note_string_and_enter admit.last_name[0..2]
-        partial_last_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with a partial last name") { expect(partial_last_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{admit.first_name} #{admit.last_name}"
-        complete_first_last_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with the complete first and last name") { expect(complete_first_last_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{admit.last_name}, #{admit.first_name}"
-        complete_last_first_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with the complete last and first name") { expect(complete_last_first_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{admit.first_name[0..2]} #{admit.last_name[0..2]}"
-        partial_first_last_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with a partial first and last name") { expect(partial_first_last_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{admit.last_name[0..2]}, #{admit.first_name[0..2]}"
-        partial_last_first_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with a partial last and first name") { expect(partial_last_first_results).to be true }
-
-        @homepage.type_non_note_string_and_enter admit.sis_id.to_s[0..4]
-        partial_sid_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with a partial SID") { expect(partial_sid_results).to be true }
-
-        @homepage.type_non_note_string_and_enter admit.sis_id.to_s
-        complete_sid_results = @search_results_page.admit_in_search_result? admit
-        it("finds CS ID #{admit.sis_id} with the complete SID") { expect(complete_sid_results).to be true }
-
-        # VISIBLE ADMIT DATA
-
-        admit_data = test.searchable_data.find { |d| d[:sid] == admit.sis_id }
-        visible_row_data = @search_results_page.visible_admit_row_data admit.sis_id
-
-        it("shows the name for CS ID #{admit.sis_id}") { expect(visible_row_data[:name]).to include(admit.last_name) }
-        it("shows the CS ID for CS ID #{admit.sis_id}") { expect(visible_row_data[:cs_id]).to eql(admit.sis_id) }
-        it("shows the CEP status for CS ID #{admit.sis_id}") { expect(visible_row_data[:cep]).to eql("#{admit_data[:special_program_cep]}") }
-        it("shows the Re-entry status for CS ID #{admit.sis_id}") { expect(visible_row_data[:re_entry]).to eql("#{admit_data[:re_entry_status]}") }
-        it("shows the 1st Gen College status for CS ID #{admit.sis_id}") { expect(visible_row_data[:first_gen]).to eql("#{admit_data[:first_gen_college]}") }
-        it("shows the UREM status for CS ID #{admit.sis_id}") { expect(visible_row_data[:urem]).to eql("#{admit_data[:urem]}") }
-        it("shows the Fee Waiver status for CS ID #{admit.sis_id}") { expect(visible_row_data[:waiver]).to eql("#{admit_data[:fee_waiver]}") }
-        it("shows the Freshman/Transfer status for CS ID #{admit.sis_id}") { expect(visible_row_data[:fresh_trans]).to eql("#{admit_data[:freshman_or_transfer]}") }
-        it("shows the International status for CS ID #{admit.sis_id}") { expect(visible_row_data[:intl]).to eql("#{admit_data[:intl]}") }
-
-        update_date_present = @search_results_page.data_update_date_heading(latest_update_date).exists?
-        if Date.parse(latest_update_date) == Date.today
-          it("shows no data update date for CS ID #{admit.sis_id}") { expect(update_date_present).to be false }
-        else
-          it("shows the latest data update date for CS ID #{admit.sis_id}") { expect(update_date_present).to be true }
-        end
-
-        @search_results_page.click_admit_link admit.sis_id
-        link_works = @admit_page.verify_block { @admit_page.sid_element.when_visible Utils.short_wait }
-        it("offers links to admit pages for CS ID #{admit.sis_id}") { expect(link_works).to be true }
-
-        @admit_page.go_back
-        back_button_works = @search_results_page.verify_block { @search_results_page.admit_in_search_result? admit }
-        it("can be reloaded using the Back button on an admit page for CS ID #{admit.sis_id}") { expect(back_button_works).to be true }
-
-        it "results can be sorted by last name"
-        # TODO Search by first name to generate many results
-        # TODO it "results can be sorted by last name, first name, then ID"
-        # TODO it "results can be exported"
-
-        # TODO admit_link_works = @search_results_page.click_admit_result admit
-        # TODO it("includes a link to the admit page for CS ID #{admit.sis_id}") { expect(admit_link_works).to be true }
-
-      rescue => e
-        Utils.log_error e
-        it("test hit an error with admit CS ID #{admit.sis_id}") { fail }
+      @homepage.exclude_admits
+      @homepage.type_non_note_string_and_enter test.test_students.first.sis_id
+      @homepage.wait_for_spinner
+      ce3_excluded = @search_results_page.verify_block do
+        !@search_results_page.admit_results_count?
+        @search_results_page.search_result_all_row_cs_ids.empty?
       end
+      it('can be excluded from results') { expect(ce3_excluded).to be true }
+
+      @homepage.include_admits
+      test.test_students.each do |admit|
+
+        begin
+
+          # SEARCHES
+
+          @homepage.type_non_note_string_and_enter admit.first_name
+          complete_first_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with the complete first name") { expect(complete_first_results).to be true }
+
+          @homepage.type_non_note_string_and_enter admit.first_name[0..2]
+          partial_first_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with a partial first name") { expect(partial_first_results).to be true }
+
+          @homepage.type_non_note_string_and_enter admit.last_name
+          complete_last_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with the complete last name") { expect(complete_last_results).to be true }
+
+          @homepage.type_non_note_string_and_enter admit.last_name[0..2]
+          partial_last_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with a partial last name") { expect(partial_last_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{admit.first_name} #{admit.last_name}"
+          complete_first_last_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with the complete first and last name") { expect(complete_first_last_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{admit.last_name}, #{admit.first_name}"
+          complete_last_first_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with the complete last and first name") { expect(complete_last_first_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{admit.first_name[0..2]} #{admit.last_name[0..2]}"
+          partial_first_last_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with a partial first and last name") { expect(partial_first_last_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{admit.last_name[0..2]}, #{admit.first_name[0..2]}"
+          partial_last_first_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with a partial last and first name") { expect(partial_last_first_results).to be true }
+
+          @homepage.type_non_note_string_and_enter admit.sis_id.to_s[0..4]
+          partial_sid_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with a partial SID") { expect(partial_sid_results).to be true }
+
+          @homepage.type_non_note_string_and_enter admit.sis_id.to_s
+          complete_sid_results = @search_results_page.admit_in_search_result? admit
+          it("finds CS ID #{admit.sis_id} with the complete SID") { expect(complete_sid_results).to be true }
+
+          # VISIBLE ADMIT DATA
+
+          admit_data = test.searchable_data.find { |d| d[:sid] == admit.sis_id }
+          visible_row_data = @search_results_page.visible_admit_row_data admit.sis_id
+
+          it("shows the name for CS ID #{admit.sis_id}") { expect(visible_row_data[:name]).to include(admit.last_name) }
+          it("shows the CS ID for CS ID #{admit.sis_id}") { expect(visible_row_data[:cs_id]).to eql(admit.sis_id) }
+          it("shows the CEP status for CS ID #{admit.sis_id}") { expect(visible_row_data[:cep]).to eql("#{admit_data[:special_program_cep]}") }
+          it("shows the Re-entry status for CS ID #{admit.sis_id}") { expect(visible_row_data[:re_entry]).to eql("#{admit_data[:re_entry_status]}") }
+          it("shows the 1st Gen College status for CS ID #{admit.sis_id}") { expect(visible_row_data[:first_gen]).to eql("#{admit_data[:first_gen_college]}") }
+          it("shows the UREM status for CS ID #{admit.sis_id}") { expect(visible_row_data[:urem]).to eql("#{admit_data[:urem]}") }
+          it("shows the Fee Waiver status for CS ID #{admit.sis_id}") { expect(visible_row_data[:waiver]).to eql("#{admit_data[:fee_waiver]}") }
+          it("shows the Freshman/Transfer status for CS ID #{admit.sis_id}") { expect(visible_row_data[:fresh_trans]).to eql("#{admit_data[:freshman_or_transfer]}") }
+          it("shows the International status for CS ID #{admit.sis_id}") { expect(visible_row_data[:intl]).to eql("#{admit_data[:intl]}") }
+
+          update_date_present = @search_results_page.data_update_date_heading(latest_update_date).exists?
+          if Date.parse(latest_update_date) == Date.today
+            it("shows no data update date for CS ID #{admit.sis_id}") { expect(update_date_present).to be false }
+          else
+            it("shows the latest data update date for CS ID #{admit.sis_id}") { expect(update_date_present).to be true }
+          end
+
+          @search_results_page.click_admit_link admit.sis_id
+          link_works = @admit_page.verify_block { @admit_page.sid_element.when_visible Utils.short_wait }
+          it("offers links to admit pages for CS ID #{admit.sis_id}") { expect(link_works).to be true }
+
+          @admit_page.go_back
+          back_button_works = @search_results_page.verify_block { @search_results_page.admit_in_search_result? admit }
+          it("can be reloaded using the Back button on an admit page for CS ID #{admit.sis_id}") { expect(back_button_works).to be true }
+
+          it "results can be sorted by last name"
+          # TODO Search by first name to generate many results
+          # TODO it "results can be sorted by last name, first name, then ID"
+          # TODO it "results can be exported"
+
+          # TODO admit_link_works = @search_results_page.click_admit_result admit
+          # TODO it("includes a link to the admit page for CS ID #{admit.sis_id}") { expect(admit_link_works).to be true }
+
+        rescue => e
+          Utils.log_error e
+          it("test hit an error with admit CS ID #{admit.sis_id}") { fail }
+        end
+      end
+    rescue => e
+      Utils.log_error e
+      it('test hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
     end
-  rescue => e
-    Utils.log_error e
-    it('test hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
   end
 end

--- a/spec/boac/boac_search_appt_spec.rb
+++ b/spec/boac/boac_search_appt_spec.rb
@@ -1,336 +1,339 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    test_config = BOACTestConfig.new
-    test_config.search_appointments
-    search_word_count = BOACUtils.search_word_count
-    student_searches = []
-    all_advising_note_authors = NessieUtils.get_all_advising_note_authors
+    begin
 
-    test_config.test_students.each do |student|
+      test_config = BOACTestConfig.new
+      test_config.search_appointments
+      search_word_count = BOACUtils.search_word_count
+      student_searches = []
+      all_advising_note_authors = NessieUtils.get_all_advising_note_authors
 
-      begin
-        appt_searches = []
-        expected_boa_appts = BOACUtils.get_student_appts(student, test_config.students)
-        expected_boa_appts.delete_if &:deleted_date
-        expected_sis_appts = NessieUtils.get_sis_appts student
-        expected_appts = expected_boa_appts + expected_sis_appts
-        if expected_appts.any?
-          expected_appts.each { |appt| appt_searches << BOACUtils.generate_appt_search_query(student, appt) }
-        else
-          logger.warn "Bummer, UID #{student.uid} has no appointments to search for"
-        end
-        student_searches << {student: student, appt_searches: appt_searches[0..(BOACUtils.search_max_searches - 1)]}
-
-      rescue => e
-        Utils.log_error e
-        it("hit an error collecting test searches for UID #{student.uid}") { fail }
-      end
-    end
-
-    # EXECUTE SEARCHES
-
-    @driver = Utils.launch_browser test_config.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @homepage.dev_auth test_config.advisor
-    @homepage.load_page
-
-    student_searches.each do |search|
-
-      logger.info "Beginning appointment search tests for UID #{search[:student].uid}"
-
-      search[:appt_searches].each do |appt_search|
+      test_config.test_students.each do |student|
 
         begin
-
-          # Search string
-
-          if appt_search[:string]
-
-            @homepage.set_notes_date_range(nil, nil)
-            @homepage.type_note_appt_string_and_enter appt_search[:string]
-
-            string_results_count = @search_results_page.appt_results_count
-
-            it("returns results when searching with the first #{search_word_count} words in #{appt_search[:test_case]}") { expect(string_results_count).to be > 0 }
-            it("shows no more than 20 results when searching with the first #{search_word_count} words in #{appt_search[:test_case]}") { expect(string_results_count).to be <= 20 }
-
-            if string_results_count < 20
-              student_result_returned = @search_results_page.appt_in_search_result?(appt_search[:appt])
-              it("returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]}") { expect(student_result_returned).to be true }
-
-              if student_result_returned
-                result = @search_results_page.appt_result(search[:student], appt_search[:appt])
-                it("appointment search shows the student name for #{appt_search[:test_case]}") { expect(result[:student_name]).to eql(search[:student].full_name) }
-                it("appointment search shows the student SID for #{appt_search[:test_case]}") { expect(result[:student_sid]).to eql(search[:student].sis_id) }
-                it("appointment search shows a snippet of #{appt_search[:test_case]}") { expect(result[:snippet].gsub(/\W/, '')).to include(appt_search[:string].gsub(/\W/, '')) }
-                it("appointment search shows the appointment date on #{appt_search[:test_case]}") { expect(result[:date]).to eql(appt_search[:appt].created_date.strftime('%b %-d, %Y')) }
-                if appt_search[:appt].advisor
-                  it("appointment search shows the advisor name on #{appt_search[:test_case]}") { expect(result[:advisor_name]).to eql(appt_search[:appt].advisor.full_name) }
-                else
-                  it("appointment search shows no advisor name on #{appt_search[:test_case]}") { expect(result[:advisor_name]).to be_nil }
-                end
-              end
-            else
-              logger.warn "Skipping a search string test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-            end
-
+          appt_searches = []
+          expected_boa_appts = BOACUtils.get_student_appts(student, test_config.students)
+          expected_boa_appts.delete_if &:deleted_date
+          expected_sis_appts = NessieUtils.get_sis_appts student
+          expected_appts = expected_boa_appts + expected_sis_appts
+          if expected_appts.any?
+            expected_appts.each { |appt| appt_searches << BOACUtils.generate_appt_search_query(student, appt) }
           else
-            logger.warn "Skipping a search string test with appointment ID #{appt_search[:appt].id} because the description is too short"
+            logger.warn "Bummer, UID #{student.uid} has no appointments to search for"
           end
-
-          # Topics
-
-          @homepage.reset_search_options_notes_subpanel
-
-          all_topics = Topic::TOPICS.select(&:for_appts).map &:name
-          appt_topics = all_topics.select { |topic_name| appt_search[:appt].topics.include? topic_name.upcase }
-          non_appt_topics = all_topics - appt_topics
-
-          appt_topics.each do |appt_topic|
-            topic = Topic::TOPICS.find { |t| t.name == appt_topic }
-            @homepage.select_note_topic topic
-            @homepage.type_note_appt_string_and_enter appt_search[:string]
-            topic_results_count = @search_results_page.appt_results_count
-
-            if topic_results_count < 20
-              topic_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-              it("returns a result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and matching topic #{topic.name}") do
-                expect(topic_match).to be true
-              end
-
-              non_topic = Topic::TOPICS.find { |t| t.name == non_appt_topics.first }
-              @homepage.select_note_topic non_topic
-              @homepage.enter_search_string appt_search[:string]
-              @homepage.click_search_button
-              topic_no_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-              it "returns no result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and non-matching topic #{topic.name}" do
-                expect(topic_no_match).to be false
-              end
-            else
-              logger.warn "Skipping a search string + topic test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-            end
-          end
-
-          # Posted by (the user who met with the student rather than the appointment creator)
-
-          if appt_search[:appt].advisor
-
-            @homepage.reset_search_options_notes_subpanel
-            logger.info "Checking filters for #{appt_search[:test_case]} posted by UID #{appt_search[:appt].advisor.uid}"
-
-            if appt_search[:appt].advisor.uid == test_config.advisor.uid
-              logger.info 'Searching for an appointment belonging to the logged in advisor'
-
-              # Posted by you
-              @homepage.select_notes_posted_by_you
-              @homepage.type_note_appt_string_and_enter appt_search[:string]
-              you_posted_results_count = @search_results_page.appt_results_count
-
-              if you_posted_results_count < 20
-                you_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-                it "returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by #{test_config.advisor.uid}" do
-                  expect(you_posted_match).to be true
-                end
-              else
-                logger.warn "Skipping a search string + posted-by-you test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-              end
-
-              # Posted by anyone
-              @homepage.select_notes_posted_by_anyone
-              @homepage.click_search_button
-              if appt_search[:string].empty?
-                validation_error_present = @homepage.verify_block { @homepage.fill_in_field_msg_element.when_visible 1 }
-                it "requires a non-empty search string when searching for #{appt_search[:test_case]} and posted by anyone" do
-                  expect(validation_error_present).to be true
-                end
-              else
-                anyone_posted_results_count = @search_results_page.appt_results_count
-
-                if anyone_posted_results_count < 20
-                  anyone_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-                  it "returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by anyone" do
-                    expect(anyone_posted_match).to be true
-                  end
-                else
-                  logger.warn "Skipping a search string + posted-by-anyone test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-                end
-              end
-
-            else
-              logger.info 'Searching for an appointment posted by someone other than the logged in advisor'
-
-              # Posted by you
-              @homepage.enter_search_string appt_search[:string]
-              @homepage.select_notes_posted_by_you
-              @homepage.click_search_button
-              you_posted_results_count = @search_results_page.appt_results_count
-
-              if you_posted_results_count < 20
-                you_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-                it "returns no result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by #{test_config.advisor.uid}" do
-                  expect(you_posted_match).to be_falsey
-                end
-              else
-                logger.warn "Skipping a search string + posted-by-you test with appointment ID #{appt_search[:note].id} because there are more than 20 results"
-              end
-
-              # Posted by anyone
-              @homepage.select_notes_posted_by_anyone
-              @homepage.type_note_appt_string_and_enter appt_search[:string]
-              if appt_search[:string]&.empty?
-                validation_error_present = @homepage.verify_block { @homepage.fill_in_field_msg_element.when_visible 1 }
-                it "requires a non-empty search string when searching for #{appt_search[:test_case]} and posted by anyone" do
-                  expect(validation_error_present).to be true
-                end
-              else
-                anyone_posted_results_count = @search_results_page.appt_results_count
-
-                if anyone_posted_results_count < 20
-                  anyone_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-                  it "returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by anyone" do
-                    expect(anyone_posted_match).to be true
-                  end
-                else
-                  logger.warn "Skipping a search string + posted-by-anyone test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-                end
-              end
-            end
-
-            # Advisor (the user who met with the student rather than the user who created the appointment)
-
-            if (author = NessieUtils.get_advising_note_author(appt_search[:appt].advisor.uid))
-
-              @homepage.reset_search_options_notes_subpanel
-              @homepage.set_notes_author(author_name = "#{author[:first_name]} #{author[:last_name]}")
-              @homepage.type_note_appt_string_and_enter appt_search[:string]
-              author_results_count = @search_results_page.appt_results_count
-
-              if author_results_count < 20
-                author_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-                it("returns a result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and author name #{author_name}") do
-                  expect(author_match).to be true
-                end
-              else
-                logger.warn "Skipping a search string + name test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-              end
-
-              other_author = loop do
-                a = all_advising_note_authors.sample
-                break a unless a[:uid] == appt_search[:appt].advisor.uid
-              end
-
-              @homepage.set_notes_author(other_author_name = "#{other_author[:first_name]} #{other_author[:last_name]}")
-              @homepage.click_search_button
-              other_author_results_count = @search_results_page.appt_results_count
-
-              if other_author_results_count < 20
-                other_author_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-                it("returns no result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and non-matching author name #{other_author_name}") do
-                  expect(other_author_match).to be false
-                end
-              else
-                logger.warn "Skipping a search string + name test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-              end
-
-            else
-              logger.warn "Bummer, appointment ID #{appt_search[:appt].id} has no identifiable author name"
-            end
-          else
-            logger.warn "Appointment ID #{appt_search[:appt].id} has no associated advisor"
-          end
-
-          # Student
-
-          @homepage.reset_search_options_notes_subpanel
-          @homepage.set_notes_student search[:student]
-          @homepage.type_note_appt_string_and_enter appt_search[:string]
-          student_results_count = @search_results_page.appt_results_count
-
-          if student_results_count < 20
-            student_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-            it("returns a result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and student #{search[:student].sis_id}") do
-              expect(student_match).to be true
-            end
-          else
-            logger.warn "Skipping a search string + student name test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-          end
-
-          # Appointment date
-
-          appt_date = Date.parse(appt_search[:appt].created_date.to_s)
-          logger.info "Checking date filters for an appointment on #{appt_date}"
-
-          @homepage.reset_search_options_notes_subpanel
-          @homepage.set_notes_date_range(appt_date, appt_date + 1)
-          @homepage.type_note_appt_string_and_enter appt_search[:string]
-          range_start_results_count = @search_results_page.appt_results_count
-
-          if range_start_results_count < 20
-            range_start_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-            it "returns a result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range starting with appointment date" do
-              expect(range_start_match).to be true
-            end
-          else
-            logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-          end
-
-          @homepage.set_notes_date_range(appt_date - 1, appt_date)
-          @homepage.click_search_button
-          range_end_results_count = @search_results_page.appt_results_count
-
-          if range_end_results_count < 20
-            range_end_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-            it "returns a result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range ending with last updated date" do
-              expect(range_end_match).to be true
-            end
-          else
-            logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-          end
-
-          @homepage.set_notes_date_range(appt_date - 30, appt_date - 1)
-          @homepage.click_search_button
-          range_before_results_count = @search_results_page.appt_results_count
-
-          if range_before_results_count < 20
-            range_before_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-            it "returns no result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range before last updated date" do
-              expect(range_before_match).to be false
-            end
-          else
-            logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-          end
-
-          @homepage.set_notes_date_range(appt_date + 1, appt_date + 30)
-          @homepage.click_search_button
-          range_after_results_count = @search_results_page.appt_results_count
-
-          if range_after_results_count < 20
-            range_after_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
-            it "returns no result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range after last updated date" do
-              expect(range_after_match).to be false
-            end
-          else
-            logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
-          end
+          student_searches << {student: student, appt_searches: appt_searches[0..(BOACUtils.search_max_searches - 1)]}
 
         rescue => e
           Utils.log_error e
-          it("hit an error executing an appointment search test for #{appt_search[:test_case]}") { fail }
+          it("hit an error collecting test searches for UID #{student.uid}") { fail }
         end
       end
-    end
 
-  rescue => e
-    Utils.log_error e
-    it('test hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
+      # EXECUTE SEARCHES
+
+      @driver = Utils.launch_browser test_config.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @homepage.dev_auth test_config.advisor
+      @homepage.load_page
+
+      student_searches.each do |search|
+
+        logger.info "Beginning appointment search tests for UID #{search[:student].uid}"
+
+        search[:appt_searches].each do |appt_search|
+
+          begin
+
+            # Search string
+
+            if appt_search[:string]
+
+              @homepage.set_notes_date_range(nil, nil)
+              @homepage.type_note_appt_string_and_enter appt_search[:string]
+
+              string_results_count = @search_results_page.appt_results_count
+
+              it("returns results when searching with the first #{search_word_count} words in #{appt_search[:test_case]}") { expect(string_results_count).to be > 0 }
+              it("shows no more than 20 results when searching with the first #{search_word_count} words in #{appt_search[:test_case]}") { expect(string_results_count).to be <= 20 }
+
+              if string_results_count < 20
+                student_result_returned = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                it("returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]}") { expect(student_result_returned).to be true }
+
+                if student_result_returned
+                  result = @search_results_page.appt_result(search[:student], appt_search[:appt])
+                  it("appointment search shows the student name for #{appt_search[:test_case]}") { expect(result[:student_name]).to eql(search[:student].full_name) }
+                  it("appointment search shows the student SID for #{appt_search[:test_case]}") { expect(result[:student_sid]).to eql(search[:student].sis_id) }
+                  it("appointment search shows a snippet of #{appt_search[:test_case]}") { expect(result[:snippet].gsub(/\W/, '')).to include(appt_search[:string].gsub(/\W/, '')) }
+                  it("appointment search shows the appointment date on #{appt_search[:test_case]}") { expect(result[:date]).to eql(appt_search[:appt].created_date.strftime('%b %-d, %Y')) }
+                  if appt_search[:appt].advisor
+                    it("appointment search shows the advisor name on #{appt_search[:test_case]}") { expect(result[:advisor_name]).to eql(appt_search[:appt].advisor.full_name) }
+                  else
+                    it("appointment search shows no advisor name on #{appt_search[:test_case]}") { expect(result[:advisor_name]).to be_nil }
+                  end
+                end
+              else
+                logger.warn "Skipping a search string test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+              end
+
+            else
+              logger.warn "Skipping a search string test with appointment ID #{appt_search[:appt].id} because the description is too short"
+            end
+
+            # Topics
+
+            @homepage.reset_search_options_notes_subpanel
+
+            all_topics = Topic::TOPICS.select(&:for_appts).map &:name
+            appt_topics = all_topics.select { |topic_name| appt_search[:appt].topics.include? topic_name.upcase }
+            non_appt_topics = all_topics - appt_topics
+
+            appt_topics.each do |appt_topic|
+              topic = Topic::TOPICS.find { |t| t.name == appt_topic }
+              @homepage.select_note_topic topic
+              @homepage.type_note_appt_string_and_enter appt_search[:string]
+              topic_results_count = @search_results_page.appt_results_count
+
+              if topic_results_count < 20
+                topic_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                it("returns a result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and matching topic #{topic.name}") do
+                  expect(topic_match).to be true
+                end
+
+                non_topic = Topic::TOPICS.find { |t| t.name == non_appt_topics.first }
+                @homepage.select_note_topic non_topic
+                @homepage.enter_search_string appt_search[:string]
+                @homepage.click_search_button
+                topic_no_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                it "returns no result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and non-matching topic #{topic.name}" do
+                  expect(topic_no_match).to be false
+                end
+              else
+                logger.warn "Skipping a search string + topic test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+              end
+            end
+
+            # Posted by (the user who met with the student rather than the appointment creator)
+
+            if appt_search[:appt].advisor
+
+              @homepage.reset_search_options_notes_subpanel
+              logger.info "Checking filters for #{appt_search[:test_case]} posted by UID #{appt_search[:appt].advisor.uid}"
+
+              if appt_search[:appt].advisor.uid == test_config.advisor.uid
+                logger.info 'Searching for an appointment belonging to the logged in advisor'
+
+                # Posted by you
+                @homepage.select_notes_posted_by_you
+                @homepage.type_note_appt_string_and_enter appt_search[:string]
+                you_posted_results_count = @search_results_page.appt_results_count
+
+                if you_posted_results_count < 20
+                  you_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                  it "returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by #{test_config.advisor.uid}" do
+                    expect(you_posted_match).to be true
+                  end
+                else
+                  logger.warn "Skipping a search string + posted-by-you test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+                end
+
+                # Posted by anyone
+                @homepage.select_notes_posted_by_anyone
+                @homepage.click_search_button
+                if appt_search[:string].empty?
+                  validation_error_present = @homepage.verify_block { @homepage.fill_in_field_msg_element.when_visible 1 }
+                  it "requires a non-empty search string when searching for #{appt_search[:test_case]} and posted by anyone" do
+                    expect(validation_error_present).to be true
+                  end
+                else
+                  anyone_posted_results_count = @search_results_page.appt_results_count
+
+                  if anyone_posted_results_count < 20
+                    anyone_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                    it "returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by anyone" do
+                      expect(anyone_posted_match).to be true
+                    end
+                  else
+                    logger.warn "Skipping a search string + posted-by-anyone test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+                  end
+                end
+
+              else
+                logger.info 'Searching for an appointment posted by someone other than the logged in advisor'
+
+                # Posted by you
+                @homepage.enter_search_string appt_search[:string]
+                @homepage.select_notes_posted_by_you
+                @homepage.click_search_button
+                you_posted_results_count = @search_results_page.appt_results_count
+
+                if you_posted_results_count < 20
+                  you_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                  it "returns no result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by #{test_config.advisor.uid}" do
+                    expect(you_posted_match).to be_falsey
+                  end
+                else
+                  logger.warn "Skipping a search string + posted-by-you test with appointment ID #{appt_search[:note].id} because there are more than 20 results"
+                end
+
+                # Posted by anyone
+                @homepage.select_notes_posted_by_anyone
+                @homepage.type_note_appt_string_and_enter appt_search[:string]
+                if appt_search[:string]&.empty?
+                  validation_error_present = @homepage.verify_block { @homepage.fill_in_field_msg_element.when_visible 1 }
+                  it "requires a non-empty search string when searching for #{appt_search[:test_case]} and posted by anyone" do
+                    expect(validation_error_present).to be true
+                  end
+                else
+                  anyone_posted_results_count = @search_results_page.appt_results_count
+
+                  if anyone_posted_results_count < 20
+                    anyone_posted_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                    it "returns a result when searching with the first #{search_word_count} words in #{appt_search[:test_case]} and posted by anyone" do
+                      expect(anyone_posted_match).to be true
+                    end
+                  else
+                    logger.warn "Skipping a search string + posted-by-anyone test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+                  end
+                end
+              end
+
+              # Advisor (the user who met with the student rather than the user who created the appointment)
+
+              if (author = NessieUtils.get_advising_note_author(appt_search[:appt].advisor.uid))
+
+                @homepage.reset_search_options_notes_subpanel
+                @homepage.set_notes_author(author_name = "#{author[:first_name]} #{author[:last_name]}")
+                @homepage.type_note_appt_string_and_enter appt_search[:string]
+                author_results_count = @search_results_page.appt_results_count
+
+                if author_results_count < 20
+                  author_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                  it("returns a result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and author name #{author_name}") do
+                    expect(author_match).to be true
+                  end
+                else
+                  logger.warn "Skipping a search string + name test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+                end
+
+                other_author = loop do
+                  a = all_advising_note_authors.sample
+                  break a unless a[:uid] == appt_search[:appt].advisor.uid
+                end
+
+                @homepage.set_notes_author(other_author_name = "#{other_author[:first_name]} #{other_author[:last_name]}")
+                @homepage.click_search_button
+                other_author_results_count = @search_results_page.appt_results_count
+
+                if other_author_results_count < 20
+                  other_author_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+                  it("returns no result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and non-matching author name #{other_author_name}") do
+                    expect(other_author_match).to be false
+                  end
+                else
+                  logger.warn "Skipping a search string + name test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+                end
+
+              else
+                logger.warn "Bummer, appointment ID #{appt_search[:appt].id} has no identifiable author name"
+              end
+            else
+              logger.warn "Appointment ID #{appt_search[:appt].id} has no associated advisor"
+            end
+
+            # Student
+
+            @homepage.reset_search_options_notes_subpanel
+            @homepage.set_notes_student search[:student]
+            @homepage.type_note_appt_string_and_enter appt_search[:string]
+            student_results_count = @search_results_page.appt_results_count
+
+            if student_results_count < 20
+              student_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+              it("returns a result when searching with the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} and student #{search[:student].sis_id}") do
+                expect(student_match).to be true
+              end
+            else
+              logger.warn "Skipping a search string + student name test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+            end
+
+            # Appointment date
+
+            appt_date = Date.parse(appt_search[:appt].created_date.to_s)
+            logger.info "Checking date filters for an appointment on #{appt_date}"
+
+            @homepage.reset_search_options_notes_subpanel
+            @homepage.set_notes_date_range(appt_date, appt_date + 1)
+            @homepage.type_note_appt_string_and_enter appt_search[:string]
+            range_start_results_count = @search_results_page.appt_results_count
+
+            if range_start_results_count < 20
+              range_start_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+              it "returns a result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range starting with appointment date" do
+                expect(range_start_match).to be true
+              end
+            else
+              logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+            end
+
+            @homepage.set_notes_date_range(appt_date - 1, appt_date)
+            @homepage.click_search_button
+            range_end_results_count = @search_results_page.appt_results_count
+
+            if range_end_results_count < 20
+              range_end_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+              it "returns a result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range ending with last updated date" do
+                expect(range_end_match).to be true
+              end
+            else
+              logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+            end
+
+            @homepage.set_notes_date_range(appt_date - 30, appt_date - 1)
+            @homepage.click_search_button
+            range_before_results_count = @search_results_page.appt_results_count
+
+            if range_before_results_count < 20
+              range_before_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+              it "returns no result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range before last updated date" do
+                expect(range_before_match).to be false
+              end
+            else
+              logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+            end
+
+            @homepage.set_notes_date_range(appt_date + 1, appt_date + 30)
+            @homepage.click_search_button
+            range_after_results_count = @search_results_page.appt_results_count
+
+            if range_after_results_count < 20
+              range_after_match = @search_results_page.appt_in_search_result?(appt_search[:appt])
+              it "returns no result when searching the first #{search_word_count} words in appointment ID #{appt_search[:appt].id} in a range after last updated date" do
+                expect(range_after_match).to be false
+              end
+            else
+              logger.warn "Skipping a search string + date range test with appointment ID #{appt_search[:appt].id} because there are more than 20 results"
+            end
+
+          rescue => e
+            Utils.log_error e
+            it("hit an error executing an appointment search test for #{appt_search[:test_case]}") { fail }
+          end
+        end
+      end
+
+    rescue => e
+      Utils.log_error e
+      it('test hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end

--- a/spec/boac/boac_search_class_spec.rb
+++ b/spec/boac/boac_search_class_spec.rb
@@ -1,91 +1,94 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    test_config = BOACTestConfig.new
-    test_config.search_classes
+    begin
 
-    @driver = Utils.launch_browser test_config.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @class_page = BOACClassListViewPage.new @driver
-    @homepage.dev_auth test_config.advisor
+      test_config = BOACTestConfig.new
+      test_config.search_classes
 
-    test_config.test_students.each do |student|
+      @driver = Utils.launch_browser test_config.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @class_page = BOACClassListViewPage.new @driver
+      @homepage.dev_auth test_config.advisor
 
-      begin
-        api_student_page = BOACApiStudentPage.new @driver
-        api_student_page.get_data(@driver, student)
-        term = api_student_page.terms.find { |t| api_student_page.term_name(t) == BOACUtils.term }
+      test_config.test_students.each do |student|
 
-        if term
-          term_id = api_student_page.term_id term
-          courses = api_student_page.courses term
-          courses.each do |course|
+        begin
+          api_student_page = BOACApiStudentPage.new @driver
+          api_student_page.get_data(@driver, student)
+          term = api_student_page.terms.find { |t| api_student_page.term_name(t) == BOACUtils.term }
 
-            begin
-              course_sis_data = api_student_page.sis_course_data course
-              unless course_sis_data[:code].include? 'PHYS ED' # PHYS ED has too many identical-looking sections
+          if term
+            term_id = api_student_page.term_id term
+            courses = api_student_page.courses term
+            courses.each do |course|
 
-                api_student_page.sections(course).each do |section|
-                  section_data = api_student_page.sis_section_data section
-                  if section_data[:primary]
+              begin
+                course_sis_data = api_student_page.sis_course_data course
+                unless course_sis_data[:code].include? 'PHYS ED' # PHYS ED has too many identical-looking sections
 
-                    begin
-                      api_section_page = BOACApiSectionPage.new @driver
-                      api_section_page.get_data(@driver, term_id, section_data[:ccn])
+                  api_student_page.sections(course).each do |section|
+                    section_data = api_student_page.sis_section_data section
+                    if section_data[:primary]
 
-                      section_test_case = "course #{course_sis_data[:code]} section #{section_data[:component]} #{section_data[:number]} #{section_data[:ccn]}"
-                      course_code = api_section_page.course_code
-                      subject_area, separator, catalog_id = course_code.rpartition(' ')
-                      abbreviated_subject_area = subject_area[0..-3]
-                      strings = [course_code, "#{abbreviated_subject_area} #{catalog_id}", catalog_id]
+                      begin
+                        api_section_page = BOACApiSectionPage.new @driver
+                        api_section_page.get_data(@driver, term_id, section_data[:ccn])
 
-                      @homepage.load_page
-                      strings.each do |string|
-                        begin
+                        section_test_case = "course #{course_sis_data[:code]} section #{section_data[:component]} #{section_data[:number]} #{section_data[:ccn]}"
+                        course_code = api_section_page.course_code
+                        subject_area, separator, catalog_id = course_code.rpartition(' ')
+                        abbreviated_subject_area = subject_area[0..-3]
+                        strings = [course_code, "#{abbreviated_subject_area} #{catalog_id}", catalog_id]
 
-                          @homepage.type_non_note_string_and_enter string
-                          class_result = @search_results_page.class_in_search_result?(course_code, section_data[:number])
-                          it("allows the user to search for #{section_test_case} by string '#{string}'") { expect(class_result).to be true }
+                        @homepage.load_page
+                        strings.each do |string|
+                          begin
 
-                          if @search_results_page.class_link(course_code, section_data[:number]).exists? && string == strings.first
-                            @search_results_page.click_class_result(course_code, section_data[:number])
-                            class_link_works = @class_page.verify_block { @class_page.wait_for_title course_code }
-                            it("allows the user to visit the class page for #{section_test_case} from search results") { expect(class_link_works).to be true }
+                            @homepage.type_non_note_string_and_enter string
+                            class_result = @search_results_page.class_in_search_result?(course_code, section_data[:number])
+                            it("allows the user to search for #{section_test_case} by string '#{string}'") { expect(class_result).to be true }
+
+                            if @search_results_page.class_link(course_code, section_data[:number]).exists? && string == strings.first
+                              @search_results_page.click_class_result(course_code, section_data[:number])
+                              class_link_works = @class_page.verify_block { @class_page.wait_for_title course_code }
+                              it("allows the user to visit the class page for #{section_test_case} from search results") { expect(class_link_works).to be true }
+                            end
+
+                          rescue => e
+                            Utils.log_error e
+                            it("hit an error with a search for #{section_test_case} by string '#{string}'") { fail }
                           end
-
-                        rescue => e
-                          Utils.log_error e
-                          it("hit an error with a search for #{section_test_case} by string '#{string}'") { fail }
                         end
-                      end
 
-                    rescue => e
-                      Utils.log_error e
-                      it("hit an error performing a class search for #{section_test_case}") { fail }
+                      rescue => e
+                        Utils.log_error e
+                        it("hit an error performing a class search for #{section_test_case}") { fail }
+                      end
                     end
                   end
                 end
+
+              rescue => e
+                Utils.log_error e
+                it("hit an error with class search tests for UID #{student.uid} course #{course['displayName']}") { fail }
               end
-
-            rescue => e
-              Utils.log_error e
-              it("hit an error with class search tests for UID #{student.uid} course #{course['displayName']}") { fail }
             end
+          else
+            logger.warn "Bummer, UID #{student.uid} has no classes in the current term to search for"
           end
-        else
-          logger.warn "Bummer, UID #{student.uid} has no classes in the current term to search for"
-        end
 
-      rescue => e
-        Utils.log_error e
-        it("hit an error with UID #{student.uid}") { fail }
+        rescue => e
+          Utils.log_error e
+          it("hit an error with UID #{student.uid}") { fail }
+        end
       end
     end
   end

--- a/spec/boac/boac_search_note_spec.rb
+++ b/spec/boac/boac_search_note_spec.rb
@@ -1,208 +1,175 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    test_config = BOACTestConfig.new
-    test_config.search_notes
-    max_note_count_per_src = BOACUtils.notes_max_notes - 1
-    search_word_count = BOACUtils.search_word_count
+    begin
 
-    @driver = Utils.launch_browser test_config.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @homepage.dev_auth test_config.advisor
+      test_config = BOACTestConfig.new
+      test_config.search_notes
+      max_note_count_per_src = BOACUtils.notes_max_notes - 1
+      search_word_count = BOACUtils.search_word_count
 
-    # COLLECT DATA TO DRIVE SEARCH TESTS
+      @driver = Utils.launch_browser test_config.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @homepage.dev_auth test_config.advisor
 
-    student_searches = []
-    all_advising_note_authors = NessieUtils.get_all_advising_note_authors
+      # COLLECT DATA TO DRIVE SEARCH TESTS
 
-    test_config.test_students.each do |student|
+      student_searches = []
+      all_advising_note_authors = NessieUtils.get_all_advising_note_authors
 
-      begin
-        note_searches = []
-        expected_asc_notes = NessieUtils.get_asc_notes student
-        expected_boa_notes = BOACUtils.get_student_notes(student).delete_if &:deleted_date
-        expected_data_notes = NessieUtils.get_data_sci_notes student
-        expected_ei_notes = NessieUtils.get_e_and_i_notes student
-        expected_sis_notes = NessieUtils.get_sis_notes student
-        logger.warn "UID #{student.uid} has #{expected_sis_notes.length} SIS notes, #{expected_asc_notes.length} ASC notes,
+      test_config.test_students.each do |student|
+
+        begin
+          note_searches = []
+          expected_asc_notes = NessieUtils.get_asc_notes student
+          expected_boa_notes = BOACUtils.get_student_notes(student).delete_if &:deleted_date
+          expected_data_notes = NessieUtils.get_data_sci_notes student
+          expected_ei_notes = NessieUtils.get_e_and_i_notes student
+          expected_sis_notes = NessieUtils.get_sis_notes student
+          logger.warn "UID #{student.uid} has #{expected_sis_notes.length} SIS notes, #{expected_asc_notes.length} ASC notes,
                               #{expected_ei_notes.length} E&I notes, #{expected_data_notes.length} Data Science notes,
                               and #{expected_boa_notes.length} BOA notes"
 
-        expected_boa_notes.delete_if { |note| !note.subject.nil? && (note.subject.include? 'QA Test') }
+          expected_boa_notes.delete_if { |note| !note.subject.nil? && (note.subject.include? 'QA Test') }
 
-        # Test a representative subset of the total notes
-        range = 0..max_note_count_per_src
-        test_notes = expected_sis_notes.shuffle[range] + expected_ei_notes.shuffle[range] + expected_boa_notes.shuffle[range] +
-            expected_asc_notes.shuffle[range] + expected_data_notes.shuffle[range]
+          # Test a representative subset of the total notes
+          range = 0..max_note_count_per_src
+          test_notes = expected_sis_notes.shuffle[range] + expected_ei_notes.shuffle[range] + expected_boa_notes.shuffle[range] +
+              expected_asc_notes.shuffle[range] + expected_data_notes.shuffle[range]
 
-        if test_notes.any?
-          test_notes.each do |note|
-            begin
-              if (query = BOACUtils.generate_note_search_query(student, note, skip_empty_body: true))
-                note_searches << query
+          if test_notes.any?
+            test_notes.each do |note|
+              begin
+                if (query = BOACUtils.generate_note_search_query(student, note, skip_empty_body: true))
+                  note_searches << query
+                end
+              rescue => e
+                Utils.log_error e
+                it("hit an error collecting note search tests for UID #{student.uid} note ID #{note.id}") { fail }
               end
-            rescue => e
-              Utils.log_error e
-              it("hit an error collecting note search tests for UID #{student.uid} note ID #{note.id}") { fail }
             end
-          end
-        else
-          logger.warn "Bummer, UID #{student.uid} has no notes to search for"
-        end
-
-        student_searches << {student: student, note_searches: note_searches}
-
-      rescue => e
-        Utils.log_error e
-        it("hit an error collecting test searches for UID #{student.uid}") { fail }
-      end
-    end
-
-    # EXECUTE SEARCHES
-
-    @homepage.load_page
-
-    student_searches.each do |search|
-
-      logger.info "Beginning note search tests for UID #{search[:student].uid}"
-
-      search[:note_searches][0..(BOACUtils.search_max_searches - 1)].each do |note_search|
-
-        logger.info "Beginning note search tests for note ID #{note_search[:note].id}"
-
-        begin
-          if note_search[:note].source_body_empty || !note_search[:note].body || note_search[:note].body.empty?
-            logger.warn "Skipping search test for #{note_search[:test_case]} because the source note body was empty and too many results will be returned."
-
           else
+            logger.warn "Bummer, UID #{student.uid} has no notes to search for"
+          end
 
-            # Search string
+          student_searches << {student: student, note_searches: note_searches}
 
-            @homepage.set_notes_date_range(nil, nil)
-            @homepage.type_note_appt_string_and_enter note_search[:string]
+        rescue => e
+          Utils.log_error e
+          it("hit an error collecting test searches for UID #{student.uid}") { fail }
+        end
+      end
 
-            string_results_count = @search_results_page.note_results_count
-            it("returns results when searching with the first #{search_word_count} words in #{note_search[:test_case]}") { expect(string_results_count).to be > 0 }
+      # EXECUTE SEARCHES
 
-            it("shows no more than 20 results when searching with the first #{search_word_count} words in #{note_search[:test_case]}") { expect(string_results_count).to be <= 20 }
+      @homepage.load_page
 
-            if string_results_count > 0 && string_results_count < 20
-              @search_results_page.wait_for_note_search_result_rows
-              student_result_returned = @search_results_page.note_in_search_result?(note_search[:note])
-              it("returns a result when searching with the first #{search_word_count} words in #{note_search[:test_case]}") { expect(student_result_returned).to be true }
+      student_searches.each do |search|
 
-              if student_result_returned
-                result = @search_results_page.note_result(search[:student], note_search[:note])
-                updated_date_expected = note_search[:note].updated_date && note_search[:note].updated_date != note_search[:note].created_date && note_search[:note].advisor.uid != 'UCBCONVERSION'
-                expected_date = updated_date_expected ? note_search[:note].updated_date : note_search[:note].created_date
-                expected_date_text = "#{expected_date.strftime('%b %-d, %Y')}"
-                it("note search shows the student name for #{note_search[:test_case]}") { expect(result[:student_name]).to eql(search[:student].full_name) }
-                it("note search shows the student SID for #{note_search[:test_case]}") { expect(result[:student_sid]).to eql(search[:student].sis_id) }
-                it("note search shows a snippet of #{note_search[:test_case]}") { expect(result[:snippet].gsub(/\W/, '')).to include(note_search[:string].gsub(/\W/, '')) }
-                # TODO it("note search shows the advisor name on #{note_search[:test_case]}") { expect(result[:advisor_name]).not_to be_nil } unless note.advisor_uid == 'UCBCONVERSION'
-                it("note search shows the most recent updated date on #{note_search[:test_case]}") { expect(result[:date]).to eql(expected_date_text) }
-              end
+        logger.info "Beginning note search tests for UID #{search[:student].uid}"
+
+        search[:note_searches][0..(BOACUtils.search_max_searches - 1)].each do |note_search|
+
+          logger.info "Beginning note search tests for note ID #{note_search[:note].id}"
+
+          begin
+            if note_search[:note].source_body_empty || !note_search[:note].body || note_search[:note].body.empty?
+              logger.warn "Skipping search test for #{note_search[:test_case]} because the source note body was empty and too many results will be returned."
+
             else
-              logger.warn "Skipping a search string test with note ID #{note_search[:note].id} because there are more than 20 results"
-            end
 
-            # Topics
+              # Search string
 
-            @homepage.expand_search_options_notes_subpanel
+              @homepage.set_notes_date_range(nil, nil)
+              @homepage.type_note_appt_string_and_enter note_search[:string]
 
-            all_topics = Topic::TOPICS.select(&:for_notes).map &:name
-            note_topics = all_topics.select { |topic_name| note_search[:note].topics.include? topic_name.upcase }
-            non_note_topics = all_topics - note_topics
+              string_results_count = @search_results_page.note_results_count
+              it("returns results when searching with the first #{search_word_count} words in #{note_search[:test_case]}") { expect(string_results_count).to be > 0 }
 
-            if note_search[:note].note_source == NoteSource::DATA
-              logger.warn 'Skipping search by topic since note source is Data Science'
-              # TODO - remove this conditional once Data Science notes are searchable by topic
-            else
-              note_topics.each do |note_topic|
-                topic = Topic::TOPICS.find { |t| t.name == note_topic }
-                @homepage.select_note_topic topic
-                @homepage.type_note_appt_string_and_enter note_search[:string]
-                topic_results_count = @search_results_page.note_results_count
+              it("shows no more than 20 results when searching with the first #{search_word_count} words in #{note_search[:test_case]}") { expect(string_results_count).to be <= 20 }
 
-                if topic_results_count < 20
-                  topic_match = @search_results_page.note_in_search_result?(note_search[:note])
-                  it("returns a result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and matching topic #{topic.name}") do
-                    expect(topic_match).to be true
-                  end
+              if string_results_count > 0 && string_results_count < 20
+                @search_results_page.wait_for_note_search_result_rows
+                student_result_returned = @search_results_page.note_in_search_result?(note_search[:note])
+                it("returns a result when searching with the first #{search_word_count} words in #{note_search[:test_case]}") { expect(student_result_returned).to be true }
 
-                  non_topic = Topic::TOPICS.find { |t| t.name == non_note_topics.first }
-                  @homepage.select_note_topic non_topic
-                  @homepage.type_note_appt_string_and_enter note_search[:string]
-                  topic_no_match = @search_results_page.note_in_search_result?(note_search[:note])
-                  it "returns no result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and non-matching topic #{topic.name}" do
-                    expect(topic_no_match).to be false
-                  end
-                else
-                  logger.warn "Skipping a search string + topic test with note ID #{note_search[:note].id} because there are more than 20 results"
+                if student_result_returned
+                  result = @search_results_page.note_result(search[:student], note_search[:note])
+                  updated_date_expected = note_search[:note].updated_date && note_search[:note].updated_date != note_search[:note].created_date && note_search[:note].advisor.uid != 'UCBCONVERSION'
+                  expected_date = updated_date_expected ? note_search[:note].updated_date : note_search[:note].created_date
+                  expected_date_text = "#{expected_date.strftime('%b %-d, %Y')}"
+                  it("note search shows the student name for #{note_search[:test_case]}") { expect(result[:student_name]).to eql(search[:student].full_name) }
+                  it("note search shows the student SID for #{note_search[:test_case]}") { expect(result[:student_sid]).to eql(search[:student].sis_id) }
+                  it("note search shows a snippet of #{note_search[:test_case]}") { expect(result[:snippet].gsub(/\W/, '')).to include(note_search[:string].gsub(/\W/, '')) }
+                  # TODO it("note search shows the advisor name on #{note_search[:test_case]}") { expect(result[:advisor_name]).not_to be_nil } unless note.advisor_uid == 'UCBCONVERSION'
+                  it("note search shows the most recent updated date on #{note_search[:test_case]}") { expect(result[:date]).to eql(expected_date_text) }
                 end
-              end
-            end
-
-            # Posted by
-
-            if note_search[:note].advisor
-              logger.info "Checking filters for #{note_search[:test_case]} posted by UID #{note_search[:note].advisor.uid}"
-              @homepage.reset_search_options_notes_subpanel
-
-              if note_search[:note].advisor.uid == test_config.advisor.uid
-                logger.info 'Searching for a note posted by the logged in advisor'
-
-                # Posted by you
-                @homepage.reset_search_options_notes_subpanel
-                @homepage.select_notes_posted_by_you
-                @homepage.type_note_appt_string_and_enter note_search[:string]
-                you_posted_results_count = @search_results_page.note_results_count
-
-                if you_posted_results_count < 20
-                  you_posted_match = @search_results_page.note_in_search_result?(note_search[:note])
-                  it "returns a result when searching with the first #{search_word_count} words in #{note_search[:test_case]} and posted by #{test_config.advisor.uid}" do
-                    expect(you_posted_match).to be true
-                  end
-                else
-                  logger.warn "Skipping a search string + posted-by-you test with note ID #{note_search[:note].id} because there are more than 20 results"
-                end
-
-                # Posted by anyone
-                @homepage.select_notes_posted_by_anyone
-                @homepage.click_search_button
-                anyone_posted_results_count = @search_results_page.note_results_count
-
-                if anyone_posted_results_count < 20
-                  anyone_posted_match = @search_results_page.note_in_search_result?(note_search[:note])
-                  it "returns a result when searching with the first #{search_word_count} words in #{note_search[:test_case]} and posted by anyone" do
-                    expect(anyone_posted_match).to be true
-                  end
-                else
-                  logger.warn "Skipping a search string + posted-by-anyone test with note ID #{note_search[:note].id} because there are more than 20 results"
-                end
-
               else
-                if note_search[:note].advisor.uid == 'UCBCONVERSION'
-                  logger.warn 'Skipping test for note-posted-by because the available UID is UCBCONVERSION, which might or might not match the logged in user'
+                logger.warn "Skipping a search string test with note ID #{note_search[:note].id} because there are more than 20 results"
+              end
 
-                else
-                  logger.info 'Searching for a note posted by someone other than the logged in advisor'
+              # Topics
+
+              @homepage.expand_search_options_notes_subpanel
+
+              all_topics = Topic::TOPICS.select(&:for_notes).map &:name
+              note_topics = all_topics.select { |topic_name| note_search[:note].topics.include? topic_name.upcase }
+              non_note_topics = all_topics - note_topics
+
+              if note_search[:note].note_source == NoteSource::DATA
+                logger.warn 'Skipping search by topic since note source is Data Science'
+                # TODO - remove this conditional once Data Science notes are searchable by topic
+              else
+                note_topics.each do |note_topic|
+                  topic = Topic::TOPICS.find { |t| t.name == note_topic }
+                  @homepage.select_note_topic topic
+                  @homepage.type_note_appt_string_and_enter note_search[:string]
+                  topic_results_count = @search_results_page.note_results_count
+
+                  if topic_results_count < 20
+                    topic_match = @search_results_page.note_in_search_result?(note_search[:note])
+                    it("returns a result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and matching topic #{topic.name}") do
+                      expect(topic_match).to be true
+                    end
+
+                    non_topic = Topic::TOPICS.find { |t| t.name == non_note_topics.first }
+                    @homepage.select_note_topic non_topic
+                    @homepage.type_note_appt_string_and_enter note_search[:string]
+                    topic_no_match = @search_results_page.note_in_search_result?(note_search[:note])
+                    it "returns no result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and non-matching topic #{topic.name}" do
+                      expect(topic_no_match).to be false
+                    end
+                  else
+                    logger.warn "Skipping a search string + topic test with note ID #{note_search[:note].id} because there are more than 20 results"
+                  end
+                end
+              end
+
+              # Posted by
+
+              if note_search[:note].advisor
+                logger.info "Checking filters for #{note_search[:test_case]} posted by UID #{note_search[:note].advisor.uid}"
+                @homepage.reset_search_options_notes_subpanel
+
+                if note_search[:note].advisor.uid == test_config.advisor.uid
+                  logger.info 'Searching for a note posted by the logged in advisor'
 
                   # Posted by you
+                  @homepage.reset_search_options_notes_subpanel
                   @homepage.select_notes_posted_by_you
                   @homepage.type_note_appt_string_and_enter note_search[:string]
                   you_posted_results_count = @search_results_page.note_results_count
 
                   if you_posted_results_count < 20
                     you_posted_match = @search_results_page.note_in_search_result?(note_search[:note])
-                    it "returns no result when searching with the first #{search_word_count} words in #{note_search[:test_case]} and posted by #{test_config.advisor.uid}" do
-                      expect(you_posted_match).to be_falsey
+                    it "returns a result when searching with the first #{search_word_count} words in #{note_search[:test_case]} and posted by #{test_config.advisor.uid}" do
+                      expect(you_posted_match).to be true
                     end
                   else
                     logger.warn "Skipping a search string + posted-by-you test with note ID #{note_search[:note].id} because there are more than 20 results"
@@ -222,121 +189,157 @@ describe 'BOAC' do
                     logger.warn "Skipping a search string + posted-by-anyone test with note ID #{note_search[:note].id} because there are more than 20 results"
                   end
 
-                  # Posted by advisor name
-
-                  if (author = NessieUtils.get_advising_note_author(note_search[:note].advisor.uid))
-
-                    author_name = "#{author[:first_name]} #{author[:last_name]}"
-                    @homepage.reset_search_options_notes_subpanel
-                    @homepage.set_notes_author author_name
-                    @homepage.type_note_appt_string_and_enter note_search[:string]
-                    author_results_count = @search_results_page.note_results_count
-
-                    if author_results_count < 20
-                      author_match = @search_results_page.note_in_search_result?(note_search[:note])
-                      it("returns a result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and author name #{author_name}") do
-                        expect(author_match).to be true
-                      end
-                    else
-                      logger.warn "Skipping a search string + name test with note ID #{note_search[:note].id} because there are more than 20 results"
-                    end
-
-                    other_author = loop do
-                      a = all_advising_note_authors.sample
-                      break a unless a[:uid] == note_search[:note].advisor.uid
-                    end
-
-                    other_author_name = "#{other_author[:first_name]} #{other_author[:last_name]}"
-                    @homepage.set_notes_author other_author_name
-                    @homepage.click_search_button
-                    other_author_results_count = @search_results_page.note_results_count
-
-                    if other_author_results_count < 20
-                      other_author_match = @search_results_page.note_in_search_result?(note_search[:note])
-                      it("returns no result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and non-matching author name #{other_author_name}") do
-                        expect(other_author_match).to be false
-                      end
-                    else
-                      logger.warn "Skipping a search string + name test with note ID #{note_search[:note].id} because there are more than 20 results"
-                    end
+                else
+                  if note_search[:note].advisor.uid == 'UCBCONVERSION'
+                    logger.warn 'Skipping test for note-posted-by because the available UID is UCBCONVERSION, which might or might not match the logged in user'
 
                   else
-                    logger.warn "Bummer, note ID #{note_search[:note].id} has no identifiable author name"
+                    logger.info 'Searching for a note posted by someone other than the logged in advisor'
+
+                    # Posted by you
+                    @homepage.select_notes_posted_by_you
+                    @homepage.type_note_appt_string_and_enter note_search[:string]
+                    you_posted_results_count = @search_results_page.note_results_count
+
+                    if you_posted_results_count < 20
+                      you_posted_match = @search_results_page.note_in_search_result?(note_search[:note])
+                      it "returns no result when searching with the first #{search_word_count} words in #{note_search[:test_case]} and posted by #{test_config.advisor.uid}" do
+                        expect(you_posted_match).to be_falsey
+                      end
+                    else
+                      logger.warn "Skipping a search string + posted-by-you test with note ID #{note_search[:note].id} because there are more than 20 results"
+                    end
+
+                    # Posted by anyone
+                    @homepage.select_notes_posted_by_anyone
+                    @homepage.click_search_button
+                    anyone_posted_results_count = @search_results_page.note_results_count
+
+                    if anyone_posted_results_count < 20
+                      anyone_posted_match = @search_results_page.note_in_search_result?(note_search[:note])
+                      it "returns a result when searching with the first #{search_word_count} words in #{note_search[:test_case]} and posted by anyone" do
+                        expect(anyone_posted_match).to be true
+                      end
+                    else
+                      logger.warn "Skipping a search string + posted-by-anyone test with note ID #{note_search[:note].id} because there are more than 20 results"
+                    end
+
+                    # Posted by advisor name
+
+                    if (author = NessieUtils.get_advising_note_author(note_search[:note].advisor.uid))
+
+                      author_name = "#{author[:first_name]} #{author[:last_name]}"
+                      @homepage.reset_search_options_notes_subpanel
+                      @homepage.set_notes_author author_name
+                      @homepage.type_note_appt_string_and_enter note_search[:string]
+                      author_results_count = @search_results_page.note_results_count
+
+                      if author_results_count < 20
+                        author_match = @search_results_page.note_in_search_result?(note_search[:note])
+                        it("returns a result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and author name #{author_name}") do
+                          expect(author_match).to be true
+                        end
+                      else
+                        logger.warn "Skipping a search string + name test with note ID #{note_search[:note].id} because there are more than 20 results"
+                      end
+
+                      other_author = loop do
+                        a = all_advising_note_authors.sample
+                        break a unless a[:uid] == note_search[:note].advisor.uid
+                      end
+
+                      other_author_name = "#{other_author[:first_name]} #{other_author[:last_name]}"
+                      @homepage.set_notes_author other_author_name
+                      @homepage.click_search_button
+                      other_author_results_count = @search_results_page.note_results_count
+
+                      if other_author_results_count < 20
+                        other_author_match = @search_results_page.note_in_search_result?(note_search[:note])
+                        it("returns no result when searching with the first #{search_word_count} words in note ID #{note_search[:note].id} and non-matching author name #{other_author_name}") do
+                          expect(other_author_match).to be false
+                        end
+                      else
+                        logger.warn "Skipping a search string + name test with note ID #{note_search[:note].id} because there are more than 20 results"
+                      end
+
+                    else
+                      logger.warn "Bummer, note ID #{note_search[:note].id} has no identifiable author name"
+                    end
                   end
                 end
               end
-            end
 
-            # Date last updated
+              # Date last updated
 
-            note_date = Date.parse(note_search[:note].updated_date.to_s)
-            logger.info "Checking date filters for a note last updated on #{note_date}"
+              note_date = Date.parse(note_search[:note].updated_date.to_s)
+              logger.info "Checking date filters for a note last updated on #{note_date}"
 
-            @homepage.reset_search_options_notes_subpanel
-            @homepage.set_notes_date_range(note_date, note_date + 1)
-            @homepage.type_note_appt_string_and_enter note_search[:string]
-            range_start_results_count = @search_results_page.note_results_count
+              @homepage.reset_search_options_notes_subpanel
+              @homepage.set_notes_date_range(note_date, note_date + 1)
+              @homepage.type_note_appt_string_and_enter note_search[:string]
+              range_start_results_count = @search_results_page.note_results_count
 
-            if range_start_results_count < 20
-              range_start_match = @search_results_page.note_in_search_result?(note_search[:note])
-              it "returns a result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range starting with last updated date" do
-                expect(range_start_match).to be true
+              if range_start_results_count < 20
+                range_start_match = @search_results_page.note_in_search_result?(note_search[:note])
+                it "returns a result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range starting with last updated date" do
+                  expect(range_start_match).to be true
+                end
+              else
+                logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
               end
-            else
-              logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
-            end
 
-            @homepage.set_notes_date_range(note_date - 1, note_date)
-            @homepage.click_search_button
-            range_end_results_count = @search_results_page.note_results_count
+              @homepage.set_notes_date_range(note_date - 1, note_date)
+              @homepage.click_search_button
+              range_end_results_count = @search_results_page.note_results_count
 
-            if range_end_results_count < 20
-              range_end_match = @search_results_page.note_in_search_result?(note_search[:note])
-              it "returns a result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range ending with last updated date" do
-                expect(range_end_match).to be true
+              if range_end_results_count < 20
+                range_end_match = @search_results_page.note_in_search_result?(note_search[:note])
+                it "returns a result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range ending with last updated date" do
+                  expect(range_end_match).to be true
+                end
+              else
+                logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
               end
-            else
-              logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
-            end
 
-            @homepage.set_notes_date_range(note_date - 30, note_date - 1)
-            @homepage.click_search_button
-            range_before_results_count = @search_results_page.note_results_count
+              @homepage.set_notes_date_range(note_date - 30, note_date - 1)
+              @homepage.click_search_button
+              range_before_results_count = @search_results_page.note_results_count
 
-            if range_before_results_count < 20
-              range_before_match = @search_results_page.note_in_search_result?(note_search[:note])
-              it "returns no result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range before last updated date" do
-                expect(range_before_match).to be false
+              if range_before_results_count < 20
+                range_before_match = @search_results_page.note_in_search_result?(note_search[:note])
+                it "returns no result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range before last updated date" do
+                  expect(range_before_match).to be false
+                end
+              else
+                logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
               end
-            else
-              logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
-            end
 
-            @homepage.set_notes_date_range(note_date + 1, note_date + 30)
-            @homepage.click_search_button
-            range_after_results_count = @search_results_page.note_results_count
+              @homepage.set_notes_date_range(note_date + 1, note_date + 30)
+              @homepage.click_search_button
+              range_after_results_count = @search_results_page.note_results_count
 
-            if range_after_results_count < 20
-              range_after_match = @search_results_page.note_in_search_result?(note_search[:note])
-              it "returns no result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range after last updated date" do
-                expect(range_after_match).to be false
+              if range_after_results_count < 20
+                range_after_match = @search_results_page.note_in_search_result?(note_search[:note])
+                it "returns no result when searching the first #{search_word_count} words in note ID #{note_search[:note].id} in a range after last updated date" do
+                  expect(range_after_match).to be false
+                end
+              else
+                logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
               end
-            else
-              logger.warn "Skipping a search string + date range test with note ID #{note_search[:note].id} because there are more than 20 results"
             end
+
+          rescue => e
+            Utils.log_error e
+            it("hit an error executing a note search test for #{note_search[:test_case]}") { fail }
           end
-
-        rescue => e
-          Utils.log_error e
-          it("hit an error executing a note search test for #{note_search[:test_case]}") { fail }
         end
       end
-    end
 
-  rescue => e
-    Utils.log_error e
-    it('test hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
+    rescue => e
+      Utils.log_error e
+      it('test hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end

--- a/spec/boac/boac_search_student_spec.rb
+++ b/spec/boac/boac_search_student_spec.rb
@@ -1,102 +1,104 @@
 require_relative '../../util/spec_helper'
 
-describe 'BOAC' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'BOAC' do
 
-  begin
+    include Logging
 
-    test_config = BOACTestConfig.new
-    test_config.search_students
+    begin
 
-    @driver = Utils.launch_browser test_config.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @homepage.dev_auth test_config.advisor
-    @homepage.load_page
+      test_config = BOACTestConfig.new
+      test_config.search_students
 
-    test_config.test_students.each do |student|
+      @driver = Utils.launch_browser test_config.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @homepage.dev_auth test_config.advisor
+      @homepage.load_page
 
-      logger.info "Beginning student search tests for UID #{student.uid}"
+      test_config.test_students.each do |student|
 
-      begin
-        @homepage.type_non_note_string_and_enter student.first_name
-        complete_first_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with the complete first name") { expect(complete_first_results).to be true }
+        logger.info "Beginning student search tests for UID #{student.uid}"
 
-        unless student.first_name[0..2] == student.first_name
-          @homepage.type_non_note_string_and_enter student.first_name[0..2]
-          partial_first_results = @search_results_page.student_in_search_result?(@driver, student)
-          it("finds UID #{student.uid} with a partial first name") { expect(partial_first_results).to be true }
-        end
+        begin
+          @homepage.type_non_note_string_and_enter student.first_name
+          complete_first_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with the complete first name") { expect(complete_first_results).to be true }
 
-        @homepage.type_non_note_string_and_enter student.last_name
-        complete_last_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with the complete last name") { expect(complete_last_results).to be true }
-
-        unless student.last_name[0..2] == student.last_name
-          @homepage.type_non_note_string_and_enter student.last_name[0..2]
-          partial_last_results = @search_results_page.student_in_search_result?(@driver, student)
-          it("finds UID #{student.uid} with a partial last name") { expect(partial_last_results).to be true }
-        end
-
-        @homepage.type_non_note_string_and_enter "#{student.first_name} #{student.last_name}"
-        complete_first_last_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with the complete first and last name") { expect(complete_first_last_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{student.last_name}, #{student.first_name}"
-        complete_last_first_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with the complete last and first name") { expect(complete_last_first_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{student.first_name[0..2]} #{student.last_name[0..2]}"
-        partial_first_last_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with a partial first and last name") { expect(partial_first_last_results).to be true }
-
-        @homepage.type_non_note_string_and_enter "#{student.last_name[0..2]}, #{student.first_name[0..2]}"
-        partial_last_first_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with a partial last and first name") { expect(partial_last_first_results).to be true }
-
-        @homepage.type_non_note_string_and_enter student.sis_id.to_s
-        complete_sid_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with the complete SID") { expect(complete_sid_results).to be true }
-
-        @homepage.type_non_note_string_and_enter student.sis_id.to_s[0..4]
-        partial_sid_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with a partial SID") { expect(partial_sid_results).to be true }
-
-        @homepage.type_non_note_string_and_enter student.email
-        complete_email_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with the complete email address") { expect(complete_email_results).to be true }
-
-        @homepage.type_non_note_string_and_enter student.email[0..4]
-        partial_email_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("finds UID #{student.uid} with a partial email address") { expect(partial_email_results).to be true }
-
-        @homepage.clear_search_input
-        expected_search_history = [student.email[0..4], student.email, student.sis_id.to_s[0..4], student.sis_id.to_s,
-                                   "#{student.last_name[0..2]}, #{student.first_name[0..2]}"]
-        search_history_right = @homepage.verify_block do
-          @homepage.wait_until(3, "Expected #{expected_search_history}, got #{@homepage.visible_search_history}") do
-            @homepage.visible_search_history == expected_search_history
+          unless student.first_name[0..2] == student.first_name
+            @homepage.type_non_note_string_and_enter student.first_name[0..2]
+            partial_first_results = @search_results_page.student_in_search_result?(@driver, student)
+            it("finds UID #{student.uid} with a partial first name") { expect(partial_first_results).to be true }
           end
+
+          @homepage.type_non_note_string_and_enter student.last_name
+          complete_last_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with the complete last name") { expect(complete_last_results).to be true }
+
+          unless student.last_name[0..2] == student.last_name
+            @homepage.type_non_note_string_and_enter student.last_name[0..2]
+            partial_last_results = @search_results_page.student_in_search_result?(@driver, student)
+            it("finds UID #{student.uid} with a partial last name") { expect(partial_last_results).to be true }
+          end
+
+          @homepage.type_non_note_string_and_enter "#{student.first_name} #{student.last_name}"
+          complete_first_last_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with the complete first and last name") { expect(complete_first_last_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{student.last_name}, #{student.first_name}"
+          complete_last_first_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with the complete last and first name") { expect(complete_last_first_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{student.first_name[0..2]} #{student.last_name[0..2]}"
+          partial_first_last_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with a partial first and last name") { expect(partial_first_last_results).to be true }
+
+          @homepage.type_non_note_string_and_enter "#{student.last_name[0..2]}, #{student.first_name[0..2]}"
+          partial_last_first_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with a partial last and first name") { expect(partial_last_first_results).to be true }
+
+          @homepage.type_non_note_string_and_enter student.sis_id.to_s
+          complete_sid_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with the complete SID") { expect(complete_sid_results).to be true }
+
+          @homepage.type_non_note_string_and_enter student.sis_id.to_s[0..4]
+          partial_sid_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with a partial SID") { expect(partial_sid_results).to be true }
+
+          @homepage.type_non_note_string_and_enter student.email
+          complete_email_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with the complete email address") { expect(complete_email_results).to be true }
+
+          @homepage.type_non_note_string_and_enter student.email[0..4]
+          partial_email_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("finds UID #{student.uid} with a partial email address") { expect(partial_email_results).to be true }
+
+          @homepage.clear_search_input
+          expected_search_history = [student.email[0..4], student.email, student.sis_id.to_s[0..4], student.sis_id.to_s,
+                                     "#{student.last_name[0..2]}, #{student.first_name[0..2]}"]
+          search_history_right = @homepage.verify_block do
+            @homepage.wait_until(3, "Expected #{expected_search_history}, got #{@homepage.visible_search_history}") do
+              @homepage.visible_search_history == expected_search_history
+            end
+          end
+          it("shows the right search history for advisor UID #{test_config.advisor.uid}") { expect(search_history_right).to be true }
+
+          @homepage.select_history_item @homepage.visible_search_history[4]
+          history_results = @search_results_page.student_in_search_result?(@driver, student)
+          it("allows the advisor to select the fifth tem from search history to execute the search #{expected_search_history[4]}") { expect(history_results).to be true }
+
+        rescue => e
+          Utils.log_error e
+          it("hit an error performing user searches for UID #{student.uid}") { fail }
         end
-        it("shows the right search history for advisor UID #{test_config.advisor.uid}") { expect(search_history_right).to be true }
-
-        @homepage.select_history_item @homepage.visible_search_history[4]
-        history_results = @search_results_page.student_in_search_result?(@driver, student)
-        it("allows the advisor to select the fifth tem from search history to execute the search #{expected_search_history[4]}") { expect(history_results).to be true }
-
-      rescue => e
-        Utils.log_error e
-        it("hit an error performing user searches for UID #{student.uid}") { fail }
       end
-    end
 
-  rescue => e
-    Utils.log_error e
-    it('test hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
+    rescue => e
+      Utils.log_error e
+      it('test hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
+    end
   end
 end
-

--- a/spec/boac/boac_sis_admit_data_spec.rb
+++ b/spec/boac/boac_sis_admit_data_spec.rb
@@ -1,266 +1,269 @@
 require_relative '../../util/spec_helper'
 
-test = BOACTestConfig.new
-test.admit_pages
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-all_admit_data = NessieUtils.get_admit_page_data
-test_sids = test.test_students.map &:sis_id
-admit_data = all_admit_data.select { |d| test_sids.include? d[:cs_empl_id] }
-latest_update_date = NessieUtils.get_admit_data_update_date
-all_student_sids = NessieUtils.get_all_students.map &:sis_id
+  test = BOACTestConfig.new
+  test.admit_pages
 
-describe 'The BOA admit page' do
+  all_admit_data = NessieUtils.get_admit_page_data
+  test_sids = test.test_students.map &:sis_id
+  admit_data = all_admit_data.select { |d| test_sids.include? d[:cs_empl_id] }
+  latest_update_date = NessieUtils.get_admit_data_update_date
+  all_student_sids = NessieUtils.get_all_students.map &:sis_id
 
-  include Logging
+  describe 'The BOA admit page' do
 
-  begin
+    include Logging
 
-    # Sanity test the data
-    all_admit_data.first.each_key do |k|
-      values = all_admit_data.collect { |d| d[k] }
-      it("has at least some data for field #{k}") { expect(values).not_to be_empty }
-    end
+    begin
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @admit_page = BOACAdmitPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @homepage.dev_auth test.advisor
-
-    admit_data.each do |admit|
-
-      begin
-        @admit_page.load_page admit[:cs_empl_id]
-
-        update_date_present = @admit_page.data_update_date_heading(latest_update_date).exists?
-        if Date.parse(latest_update_date) == Date.today
-          it("shows no update date for CS ID #{admit[:cs_empl_id]}") { expect(update_date_present).to be false }
-        else
-          it("shows the most recent data update date for CS ID #{admit[:cs_empl_id]}") { expect(update_date_present).to be true }
-        end
-
-        visible_name = @admit_page.name
-        expected_name = @admit_page.concatenated_name admit
-        it("shows the name of CS ID #{admit[:cs_empl_id]}") { expect(visible_name).to eql(expected_name) }
-
-        visible_applicant_id = @admit_page.uc_cpid
-        it("shows the ApplyUC CPID of CS ID #{admit[:cs_empl_id]}") { expect(visible_applicant_id).to eql(admit[:applyuc_cpid]) }
-
-        visible_cs_empl_id = @admit_page.sid
-        it("shows the CS Empl ID of CS ID #{admit[:cs_empl_id]}") { expect(visible_cs_empl_id).to eql(admit[:cs_empl_id]) }
-
-        visible_birth_date = @admit_page.birth_date
-        nessie_date = admit[:birthdate]
-        if nessie_date.include? '/'
-          parts = nessie_date.split '/'
-          year = (parts.last.to_i > Date.today.year.to_s[-2, 2].to_i) ? ((Date.today.year - 100).to_s[0..1] + parts.last) : parts.last
-          nessie_date = "#{year}-#{parts[0]}-#{parts[1]}"
-        end
-        expected_birth_date = Time.parse(nessie_date).strftime('%b %-d, %Y')
-        it("shows the birth date of CS ID #{admit[:cs_empl_id]}") { expect(visible_birth_date).to eql(expected_birth_date) }
-
-        visible_fresh_trans = @admit_page.fresh_trans
-        it("shows the freshman or transfer status of CS ID #{admit[:cs_empl_id]}") { expect(visible_fresh_trans).to eql(admit[:freshman_or_transfer]) }
-
-        visible_status = @admit_page.status
-        it("shows the admit status of CS ID #{admit[:cs_empl_id]}") { expect(visible_status).to eql(admit[:admit_status]) }
-
-        visible_sir = @admit_page.sir
-        it("shows the current SIR status of CS ID #{admit[:cs_empl_id]}") { expect(visible_sir).to eql(admit[:current_sir]) }
-
-        visible_college = @admit_page.college
-        it("shows the college of CS ID #{admit[:cs_empl_id]}") { expect(visible_college).to eql(admit[:college]) }
-
-        visible_term = @admit_page.term
-        it("shows the admit term of CS ID #{admit[:cs_empl_id]}") { expect(visible_term).to eql(admit[:admit_term]) }
-
-        visible_email = @admit_page.email
-        it("shows the email of CS ID #{admit[:cs_empl_id]}") { expect(visible_email).to eql(admit[:email]) }
-
-        visible_campus_email = @admit_page.campus_email
-        it("shows the campus email of CS ID #{admit[:cs_empl_id]}") { expect(visible_campus_email).to eql(admit[:campus_email_1]) }
-
-        visible_phone = @admit_page.daytime_phone
-        it("shows the daytime phone of CS ID #{admit[:cs_empl_id]}") { expect(visible_phone).to eql(admit[:daytime_phone]) }
-
-        visible_mobile = @admit_page.mobile
-        it("shows the mobile phone of CS ID #{admit[:cs_empl_id]}") { expect(visible_mobile).to eql(admit[:mobile]) }
-
-        visible_address_1 = @admit_page.address_street_1
-        it("shows the address street 1 of CS ID #{admit[:cs_empl_id]}") { expect(visible_address_1).to eql(admit[:permanent_street_1]) }
-
-        visible_address_2 = @admit_page.address_street_2
-        it("shows the address street 2 of CS ID #{admit[:cs_empl_id]}") { expect(visible_address_2).to eql(admit[:permanent_street_2]) }
-
-        visible_city_etc = @admit_page.address_city_region_postal
-        it("shows the address city / region / post code of CS ID #{admit[:cs_empl_id]}") do
-          expect(visible_city_etc).to eql("#{admit[:permanent_city]&.strip}, #{+ admit[:permanent_region].strip + ' ' if admit[:permanent_region]}#{admit[:permanent_postal]&.strip}")
-        end
-
-        visible_country = @admit_page.address_country
-        it("shows the address country of CS ID #{admit[:cs_empl_id]}") { expect(visible_country).to eql(admit[:permanent_country]) }
-
-        visible_sex = @admit_page.sex
-        it("shows the sex of CS ID #{admit[:cs_empl_id]}") { expect(visible_sex).to eql(admit[:sex]) }
-
-        visible_gender_id = @admit_page.gender_identity
-        it("shows the gender identity of CS ID #{admit[:cs_empl_id]}") { expect(visible_gender_id).to eql(admit[:gender_identity]) }
-
-        visible_x_ethnic = @admit_page.x_ethnic
-        it("shows the x-ethnic status of CS ID #{admit[:cs_empl_id]}") { expect(visible_x_ethnic).to eql(admit[:xethnic]) }
-
-        visible_hispanic = @admit_page.hispanic
-        it("shows the hispanic status of CS ID #{admit[:cs_empl_id]}") { expect(visible_hispanic).to eql(admit[:hispanic]) }
-
-        visible_urem = @admit_page.urem
-        it("shows the UREM of CS ID #{admit[:cs_empl_id]}") { expect(visible_urem).to eql(admit[:urem]) }
-
-        visible_residency = @admit_page.residency_cat
-        it("shows the residency category of CS ID #{admit[:cs_empl_id]}") { expect(visible_residency).to eql(admit[:residency_category]) }
-
-        visible_citizen_status = @admit_page.citizen_status
-        it("shows the US citizenship status of CS ID #{admit[:cs_empl_id]}") { expect(visible_citizen_status).to eql(admit[:us_citizenship_status]) }
-
-        visible_non_citizen_status = @admit_page.non_citizen_status
-        it("shows the US non-citizenship status of CS ID #{admit[:cs_empl_id]}") { expect(visible_non_citizen_status).to eql(admit[:us_non_citizen_status]) }
-
-        visible_citizenship = @admit_page.citizenship
-        it("shows the citizenship country of CS ID #{admit[:cs_empl_id]}") { expect(visible_citizenship).to eql(admit[:citizenship_country]) }
-
-        visible_residence_country = @admit_page.residence_country
-        it("shows the permanent residency country of CS ID #{admit[:cs_empl_id]}") { expect(visible_residence_country).to eql(admit[:permanent_residence_country]) }
-
-        visible_visa_status = @admit_page.visa_status
-        it("shows the non-immigrant visa current status of CS ID #{admit[:cs_empl_id]}") { expect(visible_visa_status).to eql(admit[:non_immigrant_visa_current]) }
-
-        visible_visa_planned = @admit_page.visa_planned
-        it("shows the non-immigrant visa planned status of CS ID #{admit[:cs_empl_id]}") { expect(visible_visa_planned).to eql(admit[:non_immigrant_visa_planned]) }
-
-        visible_first_gen_college = @admit_page.first_gen_college
-        it("shows the first generation college status of CS ID #{admit[:cs_empl_id]}") { expect(visible_first_gen_college).to eql(admit[:first_generation_college]) }
-
-        visible_parent_1_educ = @admit_page.parent_1_educ
-        it("shows the parent 1 education level of CS ID #{admit[:cs_empl_id]}") { expect(visible_parent_1_educ).to eql(admit[:parent_1_education_level]) }
-
-        visible_parent_2_educ = @admit_page.parent_2_educ
-        it("shows the parent 2 education level of CS ID #{admit[:cs_empl_id]}") { expect(visible_parent_2_educ).to eql(admit[:parent_2_education_level]) }
-
-        visible_parent_highest_educ = @admit_page.parent_highest_educ
-        it("shows the highest parent education level of CS ID #{admit[:cs_empl_id]}") { expect(visible_parent_highest_educ).to eql(admit[:highest_parent_education_level]) }
-
-        visible_gpa_hs_unweighted = @admit_page.gpa_hs_unweighted
-        it("shows the high school unweighted GPA of CS ID #{admit[:cs_empl_id]}") { expect(visible_gpa_hs_unweighted).to eql(admit[:hs_unweighted_gpa]) }
-
-        visible_gpa_hs_weighted = @admit_page.gpa_hs_weighted
-        it("shows the high school weighted GPA of CS ID #{admit[:cs_empl_id]}") { expect(visible_gpa_hs_weighted).to eql(admit[:hs_weighted_gpa]) }
-
-        visible_gpa_transfer = @admit_page.gpa_transfer
-        it("shows the transfer GPA of CS ID #{admit[:cs_empl_id]}") { expect(visible_gpa_transfer).to eql(admit[:transfer_gpa]) }
-
-        visible_act_composite = @admit_page.act_composite
-        it("shows the ACT composite score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_composite).to eql(admit[:act_composite]) }
-
-        visible_act_math = @admit_page.act_math
-        it("shows the ACT math score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_math).to eql(admit[:act_math]) }
-
-        visible_act_english = @admit_page.act_english
-        it("shows the ACT English score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_english).to eql(admit[:act_english]) }
-
-        visible_act_reading = @admit_page.act_reading
-        it("shows the ACT reading score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_reading).to eql(admit[:act_reading]) }
-
-        visible_act_writing = @admit_page.act_writing
-        it("shows the ACT writing score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_writing).to eql(admit[:act_writing]) }
-
-        visible_sat_total = @admit_page.sat_total
-        it("shows the SAT total score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_total).to eql(admit[:sat_total]) }
-
-        visible_sat_evidence = @admit_page.sat_evidence
-        it("shows the SAT evidence-based reading and writing section score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_evidence).to eql(admit[:sat_r_evidence_based_rw_section]) }
-
-        visible_sat_math = @admit_page.sat_math
-        it("shows the SAT math score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_math).to eql(admit[:sat_r_math_section]) }
-
-        visible_sat_reading = @admit_page.sat_reading
-        it("shows the SAT essay-reading score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_reading).to eql(admit[:sat_r_essay_reading]) }
-
-        visible_sat_analysis = @admit_page.sat_analysis
-        it("shows the SAT essay-analysis score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_analysis).to eql(admit[:sat_r_essay_analysis]) }
-
-        visible_sat_writing = @admit_page.sat_writing
-        it("shows the SAT writing score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_writing).to eql(admit[:sat_r_essay_writing]) }
-
-        visible_fee_waiver = @admit_page.fee_waiver
-        it("shows the application fee waiver status of CS ID #{admit[:cs_empl_id]}") { expect(visible_fee_waiver).to eql(admit[:application_fee_waiver_flag]) }
-
-        visible_foster_care = @admit_page.foster_care
-        it("shows the foster care status of CS ID #{admit[:cs_empl_id]}") { expect(visible_foster_care).to eql(admit[:foster_care_flag]) }
-
-        visible_family_single_parent = @admit_page.family_single_parent
-        it("shows the family-is-single-parent status of CS ID #{admit[:cs_empl_id]}") { expect(visible_family_single_parent).to eql(admit[:family_is_single_parent]) }
-
-        visible_student_single_parent = @admit_page.student_single_parent
-        it("shows the student-is-single-parent status of CS ID #{admit[:cs_empl_id]}") { expect(visible_student_single_parent).to eql(admit[:student_is_single_parent]) }
-
-        visible_family_dependents = @admit_page.family_dependents
-        it("shows the family dependent count of CS ID #{admit[:cs_empl_id]}") { expect(visible_family_dependents).to eql(admit[:family_dependents_num]) }
-
-        visible_student_dependents = @admit_page.student_dependents
-        it("shows the student dependent count of CS ID #{admit[:cs_empl_id]}") { expect(visible_student_dependents).to eql(admit[:student_dependents_num]) }
-
-        visible_family_income = @admit_page.family_income
-        expected_family_income = admit[:family_income].empty? ? '' : "$#{Utils.int_to_s_with_commas admit[:family_income].to_i}"
-        it("shows the family income of CS ID #{admit[:cs_empl_id]}") { expect(visible_family_income).to eql(expected_family_income) }
-
-        visible_student_income = @admit_page.student_income
-        expected_student_income = admit[:student_income].empty? ? '' : "$#{Utils.int_to_s_with_commas admit[:student_income].to_i}"
-        it("shows the student income of CS ID #{admit[:cs_empl_id]}") { expect(visible_student_income).to eql(expected_student_income) }
-
-        visible_military_dependent = @admit_page.military_dependent
-        it("shows the military dependent status of CS ID #{admit[:cs_empl_id]}") { expect(visible_military_dependent).to eql(admit[:is_military_dependent]) }
-
-        visible_military_status = @admit_page.military_status
-        it("shows the military status of CS ID #{admit[:cs_empl_id]}") { expect(visible_military_status).to eql(admit[:military_status]) }
-
-        visible_re_entry_status = @admit_page.re_entry_status
-        it("shows the re-entry status of CS ID #{admit[:cs_empl_id]}") { expect(visible_re_entry_status).to eql(admit[:reentry_status]) }
-
-        visible_athlete_status = @admit_page.athlete_status
-        it("shows the athlete status of CS ID #{admit[:cs_empl_id]}") { expect(visible_athlete_status).to eql(admit[:athlete_status]) }
-
-        visible_summer_bridge_status = @admit_page.summer_bridge_status
-        it("shows the Summer Bridge status of CS ID #{admit[:cs_empl_id]}") { expect(visible_summer_bridge_status).to eql(admit[:summer_bridge_status]) }
-
-        visible_last_school_lcff_plus = @admit_page.last_school_lcff_plus
-        it("shows the last school LCFF+ status of CS ID #{admit[:cs_empl_id]}") { expect(visible_last_school_lcff_plus).to eql(admit[:last_school_lcff_plus_flag]) }
-
-        visible_special_pgm_cep = @admit_page.special_pgm_cep
-        it("shows the special program CEP status of CS ID #{admit[:cs_empl_id]}") { expect(visible_special_pgm_cep).to eql(admit[:special_program_cep]) }
-
-        student_page_link_present = @admit_page.student_page_link(admit).exists?
-        if all_student_sids.include? admit[:cs_empl_id]
-          it("shows a link to the student page for CS ID #{admit[:cs_empl_id]}") { expect(student_page_link_present).to be true }
-        else
-          it("shows no link to the student page for CS ID #{admit[:cs_empl_id]}") { expect(student_page_link_present).to be false }
-        end
-
-        if student_page_link_present
-          student_page_link_works = @admit_page.verify_block do
-            @admit_page.click_student_page_link admit
-            @student_page.wait_until(Utils.short_wait) { @student_page.sid == "SID #{admit[:cs_empl_id]}" }
-          end
-          it("links to the student page for CS ID #{admit[:cs_empl_id]}") { expect(student_page_link_works).to be true }
-        end
-
-      rescue => e
-        Utils.log_error e
-        it("tests hit an error with admit CS ID #{admit[:cs_empl_id]}") { fail }
+      # Sanity test the data
+      all_admit_data.first.each_key do |k|
+        values = all_admit_data.collect { |d| d[k] }
+        it("has at least some data for field #{k}") { expect(values).not_to be_empty }
       end
+
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @admit_page = BOACAdmitPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @homepage.dev_auth test.advisor
+
+      admit_data.each do |admit|
+
+        begin
+          @admit_page.load_page admit[:cs_empl_id]
+
+          update_date_present = @admit_page.data_update_date_heading(latest_update_date).exists?
+          if Date.parse(latest_update_date) == Date.today
+            it("shows no update date for CS ID #{admit[:cs_empl_id]}") { expect(update_date_present).to be false }
+          else
+            it("shows the most recent data update date for CS ID #{admit[:cs_empl_id]}") { expect(update_date_present).to be true }
+          end
+
+          visible_name = @admit_page.name
+          expected_name = @admit_page.concatenated_name admit
+          it("shows the name of CS ID #{admit[:cs_empl_id]}") { expect(visible_name).to eql(expected_name) }
+
+          visible_applicant_id = @admit_page.uc_cpid
+          it("shows the ApplyUC CPID of CS ID #{admit[:cs_empl_id]}") { expect(visible_applicant_id).to eql(admit[:applyuc_cpid]) }
+
+          visible_cs_empl_id = @admit_page.sid
+          it("shows the CS Empl ID of CS ID #{admit[:cs_empl_id]}") { expect(visible_cs_empl_id).to eql(admit[:cs_empl_id]) }
+
+          visible_birth_date = @admit_page.birth_date
+          nessie_date = admit[:birthdate]
+          if nessie_date.include? '/'
+            parts = nessie_date.split '/'
+            year = (parts.last.to_i > Date.today.year.to_s[-2, 2].to_i) ? ((Date.today.year - 100).to_s[0..1] + parts.last) : parts.last
+            nessie_date = "#{year}-#{parts[0]}-#{parts[1]}"
+          end
+          expected_birth_date = Time.parse(nessie_date).strftime('%b %-d, %Y')
+          it("shows the birth date of CS ID #{admit[:cs_empl_id]}") { expect(visible_birth_date).to eql(expected_birth_date) }
+
+          visible_fresh_trans = @admit_page.fresh_trans
+          it("shows the freshman or transfer status of CS ID #{admit[:cs_empl_id]}") { expect(visible_fresh_trans).to eql(admit[:freshman_or_transfer]) }
+
+          visible_status = @admit_page.status
+          it("shows the admit status of CS ID #{admit[:cs_empl_id]}") { expect(visible_status).to eql(admit[:admit_status]) }
+
+          visible_sir = @admit_page.sir
+          it("shows the current SIR status of CS ID #{admit[:cs_empl_id]}") { expect(visible_sir).to eql(admit[:current_sir]) }
+
+          visible_college = @admit_page.college
+          it("shows the college of CS ID #{admit[:cs_empl_id]}") { expect(visible_college).to eql(admit[:college]) }
+
+          visible_term = @admit_page.term
+          it("shows the admit term of CS ID #{admit[:cs_empl_id]}") { expect(visible_term).to eql(admit[:admit_term]) }
+
+          visible_email = @admit_page.email
+          it("shows the email of CS ID #{admit[:cs_empl_id]}") { expect(visible_email).to eql(admit[:email]) }
+
+          visible_campus_email = @admit_page.campus_email
+          it("shows the campus email of CS ID #{admit[:cs_empl_id]}") { expect(visible_campus_email).to eql(admit[:campus_email_1]) }
+
+          visible_phone = @admit_page.daytime_phone
+          it("shows the daytime phone of CS ID #{admit[:cs_empl_id]}") { expect(visible_phone).to eql(admit[:daytime_phone]) }
+
+          visible_mobile = @admit_page.mobile
+          it("shows the mobile phone of CS ID #{admit[:cs_empl_id]}") { expect(visible_mobile).to eql(admit[:mobile]) }
+
+          visible_address_1 = @admit_page.address_street_1
+          it("shows the address street 1 of CS ID #{admit[:cs_empl_id]}") { expect(visible_address_1).to eql(admit[:permanent_street_1]) }
+
+          visible_address_2 = @admit_page.address_street_2
+          it("shows the address street 2 of CS ID #{admit[:cs_empl_id]}") { expect(visible_address_2).to eql(admit[:permanent_street_2]) }
+
+          visible_city_etc = @admit_page.address_city_region_postal
+          it("shows the address city / region / post code of CS ID #{admit[:cs_empl_id]}") do
+            expect(visible_city_etc).to eql("#{admit[:permanent_city]&.strip}, #{+admit[:permanent_region].strip + ' ' if admit[:permanent_region]}#{admit[:permanent_postal]&.strip}")
+          end
+
+          visible_country = @admit_page.address_country
+          it("shows the address country of CS ID #{admit[:cs_empl_id]}") { expect(visible_country).to eql(admit[:permanent_country]) }
+
+          visible_sex = @admit_page.sex
+          it("shows the sex of CS ID #{admit[:cs_empl_id]}") { expect(visible_sex).to eql(admit[:sex]) }
+
+          visible_gender_id = @admit_page.gender_identity
+          it("shows the gender identity of CS ID #{admit[:cs_empl_id]}") { expect(visible_gender_id).to eql(admit[:gender_identity]) }
+
+          visible_x_ethnic = @admit_page.x_ethnic
+          it("shows the x-ethnic status of CS ID #{admit[:cs_empl_id]}") { expect(visible_x_ethnic).to eql(admit[:xethnic]) }
+
+          visible_hispanic = @admit_page.hispanic
+          it("shows the hispanic status of CS ID #{admit[:cs_empl_id]}") { expect(visible_hispanic).to eql(admit[:hispanic]) }
+
+          visible_urem = @admit_page.urem
+          it("shows the UREM of CS ID #{admit[:cs_empl_id]}") { expect(visible_urem).to eql(admit[:urem]) }
+
+          visible_residency = @admit_page.residency_cat
+          it("shows the residency category of CS ID #{admit[:cs_empl_id]}") { expect(visible_residency).to eql(admit[:residency_category]) }
+
+          visible_citizen_status = @admit_page.citizen_status
+          it("shows the US citizenship status of CS ID #{admit[:cs_empl_id]}") { expect(visible_citizen_status).to eql(admit[:us_citizenship_status]) }
+
+          visible_non_citizen_status = @admit_page.non_citizen_status
+          it("shows the US non-citizenship status of CS ID #{admit[:cs_empl_id]}") { expect(visible_non_citizen_status).to eql(admit[:us_non_citizen_status]) }
+
+          visible_citizenship = @admit_page.citizenship
+          it("shows the citizenship country of CS ID #{admit[:cs_empl_id]}") { expect(visible_citizenship).to eql(admit[:citizenship_country]) }
+
+          visible_residence_country = @admit_page.residence_country
+          it("shows the permanent residency country of CS ID #{admit[:cs_empl_id]}") { expect(visible_residence_country).to eql(admit[:permanent_residence_country]) }
+
+          visible_visa_status = @admit_page.visa_status
+          it("shows the non-immigrant visa current status of CS ID #{admit[:cs_empl_id]}") { expect(visible_visa_status).to eql(admit[:non_immigrant_visa_current]) }
+
+          visible_visa_planned = @admit_page.visa_planned
+          it("shows the non-immigrant visa planned status of CS ID #{admit[:cs_empl_id]}") { expect(visible_visa_planned).to eql(admit[:non_immigrant_visa_planned]) }
+
+          visible_first_gen_college = @admit_page.first_gen_college
+          it("shows the first generation college status of CS ID #{admit[:cs_empl_id]}") { expect(visible_first_gen_college).to eql(admit[:first_generation_college]) }
+
+          visible_parent_1_educ = @admit_page.parent_1_educ
+          it("shows the parent 1 education level of CS ID #{admit[:cs_empl_id]}") { expect(visible_parent_1_educ).to eql(admit[:parent_1_education_level]) }
+
+          visible_parent_2_educ = @admit_page.parent_2_educ
+          it("shows the parent 2 education level of CS ID #{admit[:cs_empl_id]}") { expect(visible_parent_2_educ).to eql(admit[:parent_2_education_level]) }
+
+          visible_parent_highest_educ = @admit_page.parent_highest_educ
+          it("shows the highest parent education level of CS ID #{admit[:cs_empl_id]}") { expect(visible_parent_highest_educ).to eql(admit[:highest_parent_education_level]) }
+
+          visible_gpa_hs_unweighted = @admit_page.gpa_hs_unweighted
+          it("shows the high school unweighted GPA of CS ID #{admit[:cs_empl_id]}") { expect(visible_gpa_hs_unweighted).to eql(admit[:hs_unweighted_gpa]) }
+
+          visible_gpa_hs_weighted = @admit_page.gpa_hs_weighted
+          it("shows the high school weighted GPA of CS ID #{admit[:cs_empl_id]}") { expect(visible_gpa_hs_weighted).to eql(admit[:hs_weighted_gpa]) }
+
+          visible_gpa_transfer = @admit_page.gpa_transfer
+          it("shows the transfer GPA of CS ID #{admit[:cs_empl_id]}") { expect(visible_gpa_transfer).to eql(admit[:transfer_gpa]) }
+
+          visible_act_composite = @admit_page.act_composite
+          it("shows the ACT composite score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_composite).to eql(admit[:act_composite]) }
+
+          visible_act_math = @admit_page.act_math
+          it("shows the ACT math score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_math).to eql(admit[:act_math]) }
+
+          visible_act_english = @admit_page.act_english
+          it("shows the ACT English score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_english).to eql(admit[:act_english]) }
+
+          visible_act_reading = @admit_page.act_reading
+          it("shows the ACT reading score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_reading).to eql(admit[:act_reading]) }
+
+          visible_act_writing = @admit_page.act_writing
+          it("shows the ACT writing score of CS ID #{admit[:cs_empl_id]}") { expect(visible_act_writing).to eql(admit[:act_writing]) }
+
+          visible_sat_total = @admit_page.sat_total
+          it("shows the SAT total score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_total).to eql(admit[:sat_total]) }
+
+          visible_sat_evidence = @admit_page.sat_evidence
+          it("shows the SAT evidence-based reading and writing section score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_evidence).to eql(admit[:sat_r_evidence_based_rw_section]) }
+
+          visible_sat_math = @admit_page.sat_math
+          it("shows the SAT math score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_math).to eql(admit[:sat_r_math_section]) }
+
+          visible_sat_reading = @admit_page.sat_reading
+          it("shows the SAT essay-reading score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_reading).to eql(admit[:sat_r_essay_reading]) }
+
+          visible_sat_analysis = @admit_page.sat_analysis
+          it("shows the SAT essay-analysis score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_analysis).to eql(admit[:sat_r_essay_analysis]) }
+
+          visible_sat_writing = @admit_page.sat_writing
+          it("shows the SAT writing score of CS ID #{admit[:cs_empl_id]}") { expect(visible_sat_writing).to eql(admit[:sat_r_essay_writing]) }
+
+          visible_fee_waiver = @admit_page.fee_waiver
+          it("shows the application fee waiver status of CS ID #{admit[:cs_empl_id]}") { expect(visible_fee_waiver).to eql(admit[:application_fee_waiver_flag]) }
+
+          visible_foster_care = @admit_page.foster_care
+          it("shows the foster care status of CS ID #{admit[:cs_empl_id]}") { expect(visible_foster_care).to eql(admit[:foster_care_flag]) }
+
+          visible_family_single_parent = @admit_page.family_single_parent
+          it("shows the family-is-single-parent status of CS ID #{admit[:cs_empl_id]}") { expect(visible_family_single_parent).to eql(admit[:family_is_single_parent]) }
+
+          visible_student_single_parent = @admit_page.student_single_parent
+          it("shows the student-is-single-parent status of CS ID #{admit[:cs_empl_id]}") { expect(visible_student_single_parent).to eql(admit[:student_is_single_parent]) }
+
+          visible_family_dependents = @admit_page.family_dependents
+          it("shows the family dependent count of CS ID #{admit[:cs_empl_id]}") { expect(visible_family_dependents).to eql(admit[:family_dependents_num]) }
+
+          visible_student_dependents = @admit_page.student_dependents
+          it("shows the student dependent count of CS ID #{admit[:cs_empl_id]}") { expect(visible_student_dependents).to eql(admit[:student_dependents_num]) }
+
+          visible_family_income = @admit_page.family_income
+          expected_family_income = admit[:family_income].empty? ? '' : "$#{Utils.int_to_s_with_commas admit[:family_income].to_i}"
+          it("shows the family income of CS ID #{admit[:cs_empl_id]}") { expect(visible_family_income).to eql(expected_family_income) }
+
+          visible_student_income = @admit_page.student_income
+          expected_student_income = admit[:student_income].empty? ? '' : "$#{Utils.int_to_s_with_commas admit[:student_income].to_i}"
+          it("shows the student income of CS ID #{admit[:cs_empl_id]}") { expect(visible_student_income).to eql(expected_student_income) }
+
+          visible_military_dependent = @admit_page.military_dependent
+          it("shows the military dependent status of CS ID #{admit[:cs_empl_id]}") { expect(visible_military_dependent).to eql(admit[:is_military_dependent]) }
+
+          visible_military_status = @admit_page.military_status
+          it("shows the military status of CS ID #{admit[:cs_empl_id]}") { expect(visible_military_status).to eql(admit[:military_status]) }
+
+          visible_re_entry_status = @admit_page.re_entry_status
+          it("shows the re-entry status of CS ID #{admit[:cs_empl_id]}") { expect(visible_re_entry_status).to eql(admit[:reentry_status]) }
+
+          visible_athlete_status = @admit_page.athlete_status
+          it("shows the athlete status of CS ID #{admit[:cs_empl_id]}") { expect(visible_athlete_status).to eql(admit[:athlete_status]) }
+
+          visible_summer_bridge_status = @admit_page.summer_bridge_status
+          it("shows the Summer Bridge status of CS ID #{admit[:cs_empl_id]}") { expect(visible_summer_bridge_status).to eql(admit[:summer_bridge_status]) }
+
+          visible_last_school_lcff_plus = @admit_page.last_school_lcff_plus
+          it("shows the last school LCFF+ status of CS ID #{admit[:cs_empl_id]}") { expect(visible_last_school_lcff_plus).to eql(admit[:last_school_lcff_plus_flag]) }
+
+          visible_special_pgm_cep = @admit_page.special_pgm_cep
+          it("shows the special program CEP status of CS ID #{admit[:cs_empl_id]}") { expect(visible_special_pgm_cep).to eql(admit[:special_program_cep]) }
+
+          student_page_link_present = @admit_page.student_page_link(admit).exists?
+          if all_student_sids.include? admit[:cs_empl_id]
+            it("shows a link to the student page for CS ID #{admit[:cs_empl_id]}") { expect(student_page_link_present).to be true }
+          else
+            it("shows no link to the student page for CS ID #{admit[:cs_empl_id]}") { expect(student_page_link_present).to be false }
+          end
+
+          if student_page_link_present
+            student_page_link_works = @admit_page.verify_block do
+              @admit_page.click_student_page_link admit
+              @student_page.wait_until(Utils.short_wait) { @student_page.sid == "SID #{admit[:cs_empl_id]}" }
+            end
+            it("links to the student page for CS ID #{admit[:cs_empl_id]}") { expect(student_page_link_works).to be true }
+          end
+
+        rescue => e
+          Utils.log_error e
+          it("tests hit an error with admit CS ID #{admit[:cs_empl_id]}") { fail }
+        end
+      end
+    rescue => e
+      Utils.log_error e
+      it('tests hit an error initializing') { fail }
+    ensure
+      Utils.quit_browser @driver
     end
-  rescue => e
-    Utils.log_error e
-    it('tests hit an error initializing') { fail }
-  ensure
-    Utils.quit_browser @driver
   end
 end

--- a/spec/boac/boac_sis_student_data_spec.rb
+++ b/spec/boac/boac_sis_student_data_spec.rb
@@ -1,676 +1,683 @@
 require_relative '../../util/spec_helper'
 
-include Logging
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-describe 'BOAC' do
+  include Logging
 
-  begin
-    test = BOACTestConfig.new
-    test.sis_student_data
-    alert_students = []
-    hold_students = []
+  describe 'BOAC' do
 
-    # Create files for test output
-    user_profile_data_heading = %w(UID Name PreferredName Email EmailAlt Phone Units GPA Level Transfer Colleges Majors
+      begin
+      test = BOACTestConfig.new
+      test.sis_student_data
+      alert_students = []
+      hold_students = []
+
+      # Create files for test output
+      user_profile_data_heading = %w(UID Name PreferredName Email EmailAlt Phone Units GPA Level Transfer Colleges Majors
                                    CollegesDisc MajorsDisc Minors MinorsDisc Terms Writing History Institutions Cultures
                                    AdvisorPlans AdvisorNames AdvisorEmails EnteredTerm MajorsIntend Visa GradExpect
                                    GradDegree GradDate GradColleges Inactive Alerts Holds)
-    user_profile_sis_data = Utils.create_test_output_csv('boac-sis-profiles.csv', user_profile_data_heading)
+      user_profile_sis_data = Utils.create_test_output_csv('boac-sis-profiles.csv', user_profile_data_heading)
 
-    user_course_data_heading = %w(UID Term UnitsMin UnitsMax CourseCode CourseName SectionCcn SectionCode Primary? Midpoint Grade GradingBasis Units EnrollmentStatus)
-    user_course_sis_data = Utils.create_test_output_csv('boac-sis-courses.csv', user_course_data_heading)
+      user_course_data_heading = %w(UID Term UnitsMin UnitsMax CourseCode CourseName SectionCcn SectionCode Primary? Midpoint Grade GradingBasis Units EnrollmentStatus)
+      user_course_sis_data = Utils.create_test_output_csv('boac-sis-courses.csv', user_course_data_heading)
 
-    @driver = Utils.launch_browser test.chrome_profile
-    @boac_homepage = BOACHomePage.new @driver
-    @boac_cohort_page = BOACUtils.shuffle_max_users ? BOACGroupPage.new(@driver) : BOACFilteredCohortPage.new(@driver, test.advisor)
-    @boac_student_page = BOACStudentPage.new @driver
-    @boac_admin_page = BOACFlightDeckPage.new @driver
-    @boac_search_page = BOACSearchResultsPage.new @driver
+      @driver = Utils.launch_browser test.chrome_profile
+      @boac_homepage = BOACHomePage.new @driver
+      @boac_cohort_page = BOACUtils.shuffle_max_users ? BOACGroupPage.new(@driver) : BOACFilteredCohortPage.new(@driver, test.advisor)
+      @boac_student_page = BOACStudentPage.new @driver
+      @boac_admin_page = BOACFlightDeckPage.new @driver
+      @boac_search_page = BOACSearchResultsPage.new @driver
 
-    @boac_homepage.dev_auth test.advisor
+      @boac_homepage.dev_auth test.advisor
 
-    if @boac_cohort_page.instance_of? BOACFilteredCohortPage
-      @boac_cohort_page.search_and_create_new_cohort(test.default_cohort, default: true)
-    else
-      test.default_cohort = CuratedGroup.new(:name => "Group #{test.id}")
-      @boac_homepage.click_sidebar_create_curated_group
-      @boac_cohort_page.create_group_with_bulk_sids(test.test_students, test.default_cohort)
-    end
+      if @boac_cohort_page.instance_of? BOACFilteredCohortPage
+        @boac_cohort_page.search_and_create_new_cohort(test.default_cohort, default: true)
+      else
+        test.default_cohort = CuratedGroup.new(:name => "Group #{test.id}")
+        @boac_homepage.click_sidebar_create_curated_group
+        @boac_cohort_page.create_group_with_bulk_sids(test.test_students, test.default_cohort)
+      end
 
-    visible_sids = @boac_cohort_page.list_view_sids
-    test.test_students.keep_if { |m| visible_sids.include? m.sis_id }
-    test.test_students.each do |student|
+      visible_sids = @boac_cohort_page.list_view_sids
+      test.test_students.keep_if { |m| visible_sids.include? m.sis_id }
+      test.test_students.each do |student|
 
-      begin
-        api_student_data = BOACApiStudentPage.new @driver
-        api_student_data.get_data(@driver, student)
-        api_sis_profile_data = api_student_data.sis_profile_data
-        academic_standing = api_student_data.academic_standing
+        begin
+          api_student_data = BOACApiStudentPage.new @driver
+          api_student_data.get_data(@driver, student)
+          api_sis_profile_data = api_student_data.sis_profile_data
+          academic_standing = api_student_data.academic_standing
 
-        # COHORT PAGE SIS DATA
+          # COHORT PAGE SIS DATA
 
-        BOACUtils.shuffle_max_users ? @boac_cohort_page.load_page(test.default_cohort) : @boac_cohort_page.load_cohort(test.default_cohort)
-        cohort_page_sis_data = @boac_cohort_page.visible_sis_data student
+          BOACUtils.shuffle_max_users ? @boac_cohort_page.load_page(test.default_cohort) : @boac_cohort_page.load_cohort(test.default_cohort)
+          cohort_page_sis_data = @boac_cohort_page.visible_sis_data student
 
-        if api_sis_profile_data[:academic_career_status] == 'Completed'
-          it "shows no level for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:level]).to be_nil
+          if api_sis_profile_data[:academic_career_status] == 'Completed'
+            it "shows no level for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:level]).to be_nil
+            end
+          else
+            it "shows the level for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:level]).to eql(api_sis_profile_data[:level].to_s)
+            end
           end
-        else
-          it "shows the level for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:level]).to eql(api_sis_profile_data[:level].to_s)
-          end
-        end
 
-        if api_sis_profile_data[:entered_term]
-          it("shows the matriculation term for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:entered_term]).to eql(api_sis_profile_data[:entered_term]) }
-        end
+          if api_sis_profile_data[:entered_term]
+            it("shows the matriculation term for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:entered_term]).to eql(api_sis_profile_data[:entered_term]) }
+          end
 
-        if api_sis_profile_data[:academic_career_status] == 'Completed'
-          it "shows the right graduation date for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:graduation_date]).to eql('Graduated ' + Date.parse(api_sis_profile_data[:graduation][:date]).strftime('%b %e, %Y'))
+          if api_sis_profile_data[:academic_career_status] == 'Completed'
+            it "shows the right graduation date for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:graduation_date]).to eql('Graduated ' + Date.parse(api_sis_profile_data[:graduation][:date]).strftime('%b %e, %Y'))
+            end
+            it "shows the right graduation colleges for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:graduation_colleges]).to eql(api_sis_profile_data[:graduation][:colleges])
+            end
+          else
+            it "shows no graduation date for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:graduation_date]).to be_nil
+            end
+            it "shows no graduation colleges for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:graduation_colleges]).to be_nil
+            end
           end
-          it "shows the right graduation colleges for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:graduation_colleges]).to eql(api_sis_profile_data[:graduation][:colleges])
-          end
-        else
-          it "shows no graduation date for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:graduation_date]).to be_nil
-          end
-          it "shows no graduation colleges for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:graduation_colleges]).to be_nil
-          end
-        end
 
-        if api_sis_profile_data[:academic_career_status] == 'Inactive'
-          it "shows UID #{student.uid} as inactive on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:inactive]).to be true
+          if api_sis_profile_data[:academic_career_status] == 'Inactive'
+            it "shows UID #{student.uid} as inactive on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:inactive]).to be true
+            end
+          else
+            it "does not show UID #{student.uid} as inactive on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:inactive]).to be false
+            end
           end
-        else
-          it "does not show UID #{student.uid} as inactive on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:inactive]).to be false
-          end
-        end
 
-        # TODO - shows withdrawal indicator if withdrawn
+          # TODO - shows withdrawal indicator if withdrawn
 
-        if academic_standing&.any?
-          latest_standing = academic_standing.first
-          if latest_standing.code == 'GST'
+          if academic_standing&.any?
+            latest_standing = academic_standing.first
+            if latest_standing.code == 'GST'
+              it "shows no academic standing for UID #{student.uid} on the #{test.default_cohort.name} page" do
+                expect(cohort_page_sis_data[:academic_standing]).to be_nil
+              end
+            else
+              it "shows the academic standing '#{latest_standing.descrip}' for UID #{student.uid} on the #{test.default_cohort.name} page" do
+                expect(cohort_page_sis_data[:academic_standing]).to eql("#{latest_standing.descrip} (#{latest_standing.term_name})")
+              end
+            end
+          else
             it "shows no academic standing for UID #{student.uid} on the #{test.default_cohort.name} page" do
               expect(cohort_page_sis_data[:academic_standing]).to be_nil
             end
+          end
+
+          active_major_feed, inactive_major_feed = api_sis_profile_data[:majors].compact.partition { |m| m[:active] }
+          active_majors = active_major_feed.map { |m| m[:major] }
+          active_colleges = active_major_feed.map { |m| m[:college] }.compact
+          inactive_majors = inactive_major_feed.map { |m| m[:major] }
+          inactive_colleges = inactive_major_feed.map { |m| m[:college] }.compact
+
+          active_minor_feed, inactive_minor_feed = api_sis_profile_data[:minors].partition { |m| m[:active] }
+          active_minors = active_minor_feed.map { |m| m[:minor] }
+          inactive_minors = inactive_minor_feed.map { |m| m[:minor] }
+
+          if active_majors.any?
+            it "shows the majors for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:majors]).to eql(active_majors.sort)
+            end
           else
-            it "shows the academic standing '#{latest_standing.descrip}' for UID #{student.uid} on the #{test.default_cohort.name} page" do
-              expect(cohort_page_sis_data[:academic_standing]).to eql("#{latest_standing.descrip} (#{latest_standing.term_name})")
+            it("shows no majors for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:majors]).to be_nil }
+          end
+
+          it "shows the sub-plans for UID #{student.uid} on the #{test.default_cohort.name} page" do
+            expect(cohort_page_sis_data[:sub_plans]).to eql(api_sis_profile_data[:sub_plans])
+          end
+
+          if api_sis_profile_data[:academic_career_status] == 'Completed'
+            it "shows no expected graduation term for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:grad_term]).to be_nil
+            end
+          else
+            it "shows the expected graduation term for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:grad_term]).to eql(api_sis_profile_data[:expected_grad_term_name])
             end
           end
-        else
-          it "shows no academic standing for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:academic_standing]).to be_nil
+
+          it "shows the cumulative GPA for UID #{student.uid} on the #{test.default_cohort.name} page" do
+            expect(cohort_page_sis_data[:gpa]).to eql(api_sis_profile_data[:cumulative_gpa])
+            expect(cohort_page_sis_data[:gpa]).not_to be_empty
           end
-        end
 
-        active_major_feed, inactive_major_feed = api_sis_profile_data[:majors].compact.partition { |m| m[:active] }
-        active_majors = active_major_feed.map { |m| m[:major] }
-        active_colleges = active_major_feed.map { |m| m[:college] }.compact
-        inactive_majors = inactive_major_feed.map { |m| m[:major] }
-        inactive_colleges = inactive_major_feed.map { |m| m[:college] }.compact
-
-        active_minor_feed, inactive_minor_feed = api_sis_profile_data[:minors].partition { |m| m[:active] }
-        active_minors = active_minor_feed.map { |m| m[:minor] }
-        inactive_minors = inactive_minor_feed.map { |m| m[:minor] }
-
-        if active_majors.any?
-          it "shows the majors for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:majors]).to eql(active_majors.sort)
+          if api_sis_profile_data[:term_units]
+            it "shows the units in progress for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:term_units]).to eql(api_sis_profile_data[:term_units])
+              expect(cohort_page_sis_data[:term_units]).not_to be_empty
+            end
+          else
+            it("shows no units in progress for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:term_units]).to eql('0') }
           end
-        else
-          it("shows no majors for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:majors]).to be_nil }
-        end
 
-        it "shows the sub-plans for UID #{student.uid} on the #{test.default_cohort.name} page" do
-          expect(cohort_page_sis_data[:sub_plans]).to eql(api_sis_profile_data[:sub_plans])
-        end
-
-        if api_sis_profile_data[:academic_career_status] == 'Completed'
-          it "shows no expected graduation term for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:grad_term]).to be_nil
+          if api_sis_profile_data[:cumulative_units]
+            it "shows the total units for UID #{student.uid} on the #{test.default_cohort.name} page" do
+              expect(cohort_page_sis_data[:units_cumulative]).to eql(api_sis_profile_data[:cumulative_units])
+              expect(cohort_page_sis_data[:units_cumulative]).not_to be_empty
+            end
+          else
+            it("shows no total units for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:units_cumulative]).to eql('0') }
           end
-        else
-          it "shows the expected graduation term for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:grad_term]).to eql(api_sis_profile_data[:expected_grad_term_name])
+
+          it("shows the current term course codes for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:classes]).to eql(api_student_data.current_non_dropped_course_codes) }
+
+          it("shows waitlisted indicators, if any, for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:waitlisted_classes]).to eql(api_student_data.current_waitlisted_course_codes) }
+
+          # STUDENT PAGE SIS DATA
+
+          @boac_cohort_page.click_student_link student
+          @boac_student_page.wait_for_title student.full_name
+          @boac_student_page.expand_personal_details
+
+          api_advisors = api_student_data.advisors
+          api_demographics = api_student_data.demographics_data
+
+          student_page_sis_data = @boac_student_page.visible_sis_data
+
+          it("shows the name for UID #{student.uid} on the student page") { expect(student_page_sis_data[:name]).to eql(student.full_name.split(',').reverse.join(' ').strip) }
+
+          it "shows the email for UID #{student.uid} on the student page" do
+            expect(student_page_sis_data[:email]).to include(api_sis_profile_data[:email])
+            expect(student_page_sis_data[:email]).not_to be_empty
           end
-        end
 
-        it "shows the cumulative GPA for UID #{student.uid} on the #{test.default_cohort.name} page" do
-          expect(cohort_page_sis_data[:gpa]).to eql(api_sis_profile_data[:cumulative_gpa])
-          expect(cohort_page_sis_data[:gpa]).not_to be_empty
-        end
-
-        if api_sis_profile_data[:term_units]
-          it "shows the units in progress for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:term_units]).to eql(api_sis_profile_data[:term_units])
-            expect(cohort_page_sis_data[:term_units]).not_to be_empty
-          end
-        else
-          it("shows no units in progress for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:term_units]).to eql('0') }
-        end
-
-        if api_sis_profile_data[:cumulative_units]
-          it "shows the total units for UID #{student.uid} on the #{test.default_cohort.name} page" do
-            expect(cohort_page_sis_data[:units_cumulative]).to eql(api_sis_profile_data[:cumulative_units])
-            expect(cohort_page_sis_data[:units_cumulative]).not_to be_empty
-          end
-        else
-          it("shows no total units for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:units_cumulative]).to eql('0') }
-        end
-
-        it("shows the current term course codes for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:classes]).to eql(api_student_data.current_non_dropped_course_codes) }
-
-        it("shows waitlisted indicators, if any, for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(cohort_page_sis_data[:waitlisted_classes]).to eql(api_student_data.current_waitlisted_course_codes) }
-
-        # STUDENT PAGE SIS DATA
-
-        @boac_cohort_page.click_student_link student
-        @boac_student_page.wait_for_title student.full_name
-        @boac_student_page.expand_personal_details
-
-        api_advisors = api_student_data.advisors
-        api_demographics = api_student_data.demographics_data
-
-        student_page_sis_data = @boac_student_page.visible_sis_data
-
-        it("shows the name for UID #{student.uid} on the student page") { expect(student_page_sis_data[:name]).to eql(student.full_name.split(',').reverse.join(' ').strip) }
-
-        it "shows the email for UID #{student.uid} on the student page" do
-          expect(student_page_sis_data[:email]).to include(api_sis_profile_data[:email])
-          expect(student_page_sis_data[:email]).not_to be_empty
-        end
-
-        if api_sis_profile_data[:email_alternate]
-          it "shows the alternate email for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:email_alternate]).to eq(api_sis_profile_data[:email_alternate])
-          end
-        else
-          it "shows no alternate email for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:email_alternate]).to be_nil
-          end
-        end
-
-        if api_sis_profile_data[:cumulative_units]
-          it "shows the total units for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:cumulative_units]).to eql(api_sis_profile_data[:cumulative_units])
-            expect(student_page_sis_data[:cumulative_units]).not_to be_empty
-          end
-        else
-          it("shows no total units for UID #{student.uid} on the student page") { expect(student_page_sis_data[:cumulative_units]).to eql('--') }
-        end
-
-        it "shows the phone for UID #{student.uid} on the student page" do
-          expect(student_page_sis_data[:phone]).to eql(api_sis_profile_data[:phone])
-        end
-
-        it "shows the cumulative GPA for UID #{student.uid} on the student page" do
-          expect(student_page_sis_data[:cumulative_gpa]).to eql(api_sis_profile_data[:cumulative_gpa])
-          expect(student_page_sis_data[:cumulative_gpa]).not_to be_empty
-        end
-
-        if api_sis_profile_data[:academic_career_status] != 'Completed' && active_majors.any?
-          it "shows the active majors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:majors]).to eql(active_majors)
-            expect(student_page_sis_data[:colleges]).to eql(active_colleges)
-          end
-        else
-          it("shows no active majors for UID #{student.uid} on the student page") { expect(student_page_sis_data[:majors]).to be_empty }
-          it("shows no colleges for UID #{student.uid} on the student page") { expect(student_page_sis_data[:colleges].all?(&:empty?)).to be true }
-        end
-
-        if api_sis_profile_data[:academic_career_status] != 'Completed' && inactive_majors.any?
-          it "shows the discontinued majors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:majors_discontinued]).to eql(inactive_majors)
-            expect(student_page_sis_data[:colleges_discontinued]).to eql(inactive_colleges)
-          end
-        else
-          it("shows no discontinued majors for UID #{student.uid} on the student page") { expect(student_page_sis_data[:majors_discontinued]).to be_empty }
-          it("shows no discontinued colleges for UID #{student.uid} on the student page") { expect(student_page_sis_data[:colleges_discontinued].all?(&:empty?)).to be true }
-        end
-
-        if api_sis_profile_data[:academic_career_status] != 'Completed' && active_minors.any?
-          it "shows active minors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:minors]).to eq(active_minors)
-          end
-        else
-          it "shows no active minors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:minors]).to be_empty
-          end
-        end
-
-        if api_sis_profile_data[:academic_career_status] != 'Completed' && inactive_minors.any?
-          it "shows inactive minors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:minors_discontinued]).to eq(inactive_minors)
-          end
-        else
-          it "shows no inactive minors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:minors_discontinued]).to be_empty
-          end
-        end
-
-        it "shows the academic level for UID #{student.uid} on the student page" do
-          expect(student_page_sis_data[:level]).to eql(api_sis_profile_data[:level].to_s)
-        end
-
-        if api_advisors.any?
-          it "shows assigned advisor plans for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:advisor_plans].sort).to eq(api_advisors.map { |a| a[:plan] }.sort)
-          end
-          it "shows assigned advisor names for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:advisor_names].sort).to eq(api_advisors.map { |a| a[:name]&.strip }.sort)
-          end
-          it "shows assigned advisor emails for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:advisor_emails].sort).to eq(api_advisors.map { |a| "#{a[:email]}" }.sort)
-          end
-        else
-          it("shows no assigned advisors for UID #{student.uid} on the student page") do
-            expect(student_page_sis_data[:advisor_plans]).to be_empty
-            expect(student_page_sis_data[:advisor_names]).to be_empty
-            expect(student_page_sis_data[:advisor_emails]).to be_empty
-          end
-        end
-
-        if api_sis_profile_data[:entered_term]
-          it "shows the matriculation date for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:entered_term]).to eql(api_sis_profile_data[:entered_term])
-          end
-        end
-
-        if api_sis_profile_data[:intended_majors].any?
-          it "shows intended majors for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:intended_majors]).to eql(api_sis_profile_data[:intended_majors])
-          end
-        end
-
-        if api_demographics[:visa] && api_demographics[:visa][:status] == 'G'
-          it "shows visa status for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:visa]).to eq case api_demographics[:visa][:type]
-              when 'F1' then 'F-1 International Student'
-              when 'J1' then 'J-1 International Student'
-              when 'PR' then 'PR Verified International Student'
-              else 'Other Verified International Student'
+          if api_sis_profile_data[:email_alternate]
+            it "shows the alternate email for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:email_alternate]).to eq(api_sis_profile_data[:email_alternate])
+            end
+          else
+            it "shows no alternate email for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:email_alternate]).to be_nil
             end
           end
-        else
-          it "shows no visa status for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:visa]).to be_nil
-          end
-        end
 
-        if api_sis_profile_data[:academic_career_status] == 'Completed'
-          it "shows the right degree for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:graduation_degree]).to eql(api_sis_profile_data[:graduation][:degree] + ' in ' + api_sis_profile_data[:graduation][:majors].join(', '))
+          if api_sis_profile_data[:cumulative_units]
+            it "shows the total units for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:cumulative_units]).to eql(api_sis_profile_data[:cumulative_units])
+              expect(student_page_sis_data[:cumulative_units]).not_to be_empty
+            end
+          else
+            it("shows no total units for UID #{student.uid} on the student page") { expect(student_page_sis_data[:cumulative_units]).to eql('--') }
           end
-          it "shows the right graduation date for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:graduation_date]).to eql('Awarded ' + Date.parse(api_sis_profile_data[:graduation][:date]).strftime('%b %e, %Y'))
-          end
-          it "shows the right graduation colleges for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:graduation_colleges]).to eql(api_sis_profile_data[:graduation][:colleges])
-          end
-        else
-          it "shows no graduation degree for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:graduation_date]).to be_nil
-          end
-          it "shows no graduation date for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:graduation_date]).to be_nil
-          end
-          it "shows no graduation colleges for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:graduation_colleges]).to be_nil
-          end
-        end
 
-        if api_sis_profile_data[:academic_career_status] == 'Inactive'
-          it "shows UID #{student.uid} as inactive on the student page" do
-            expect(student_page_sis_data[:inactive]).to be true
+          it "shows the phone for UID #{student.uid} on the student page" do
+            expect(student_page_sis_data[:phone]).to eql(api_sis_profile_data[:phone])
           end
-        else
-          it "does not show UID #{student.uid} as inactive on the student page" do
-            expect(student_page_sis_data[:inactive]).to be false
-          end
-        end
 
-        if latest_standing
-          if latest_standing.code == 'GST'
+          it "shows the cumulative GPA for UID #{student.uid} on the student page" do
+            expect(student_page_sis_data[:cumulative_gpa]).to eql(api_sis_profile_data[:cumulative_gpa])
+            expect(student_page_sis_data[:cumulative_gpa]).not_to be_empty
+          end
+
+          if api_sis_profile_data[:academic_career_status] != 'Completed' && active_majors.any?
+            it "shows the active majors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:majors]).to eql(active_majors)
+              expect(student_page_sis_data[:colleges]).to eql(active_colleges)
+            end
+          else
+            it("shows no active majors for UID #{student.uid} on the student page") { expect(student_page_sis_data[:majors]).to be_empty }
+            it("shows no colleges for UID #{student.uid} on the student page") { expect(student_page_sis_data[:colleges].all?(&:empty?)).to be true }
+          end
+
+          if api_sis_profile_data[:academic_career_status] != 'Completed' && inactive_majors.any?
+            it "shows the discontinued majors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:majors_discontinued]).to eql(inactive_majors)
+              expect(student_page_sis_data[:colleges_discontinued]).to eql(inactive_colleges)
+            end
+          else
+            it("shows no discontinued majors for UID #{student.uid} on the student page") { expect(student_page_sis_data[:majors_discontinued]).to be_empty }
+            it("shows no discontinued colleges for UID #{student.uid} on the student page") { expect(student_page_sis_data[:colleges_discontinued].all?(&:empty?)).to be true }
+          end
+
+          if api_sis_profile_data[:academic_career_status] != 'Completed' && active_minors.any?
+            it "shows active minors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:minors]).to eq(active_minors)
+            end
+          else
+            it "shows no active minors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:minors]).to be_empty
+            end
+          end
+
+          if api_sis_profile_data[:academic_career_status] != 'Completed' && inactive_minors.any?
+            it "shows inactive minors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:minors_discontinued]).to eq(inactive_minors)
+            end
+          else
+            it "shows no inactive minors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:minors_discontinued]).to be_empty
+            end
+          end
+
+          it "shows the academic level for UID #{student.uid} on the student page" do
+            expect(student_page_sis_data[:level]).to eql(api_sis_profile_data[:level].to_s)
+          end
+
+          if api_advisors.any?
+            it "shows assigned advisor plans for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:advisor_plans].sort).to eq(api_advisors.map { |a| a[:plan] }.sort)
+            end
+            it "shows assigned advisor names for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:advisor_names].sort).to eq(api_advisors.map { |a| a[:name]&.strip }.sort)
+            end
+            it "shows assigned advisor emails for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:advisor_emails].sort).to eq(api_advisors.map { |a| "#{a[:email]}" }.sort)
+            end
+          else
+            it("shows no assigned advisors for UID #{student.uid} on the student page") do
+              expect(student_page_sis_data[:advisor_plans]).to be_empty
+              expect(student_page_sis_data[:advisor_names]).to be_empty
+              expect(student_page_sis_data[:advisor_emails]).to be_empty
+            end
+          end
+
+          if api_sis_profile_data[:entered_term]
+            it "shows the matriculation date for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:entered_term]).to eql(api_sis_profile_data[:entered_term])
+            end
+          end
+
+          if api_sis_profile_data[:intended_majors].any?
+            it "shows intended majors for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:intended_majors]).to eql(api_sis_profile_data[:intended_majors])
+            end
+          end
+
+          if api_demographics[:visa] && api_demographics[:visa][:status] == 'G'
+            it "shows visa status for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:visa]).to eq case api_demographics[:visa][:type]
+                                                         when 'F1' then
+                                                           'F-1 International Student'
+                                                         when 'J1' then
+                                                           'J-1 International Student'
+                                                         when 'PR' then
+                                                           'PR Verified International Student'
+                                                         else
+                                                           'Other Verified International Student'
+                                                         end
+            end
+          else
+            it "shows no visa status for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:visa]).to be_nil
+            end
+          end
+
+          if api_sis_profile_data[:academic_career_status] == 'Completed'
+            it "shows the right degree for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:graduation_degree]).to eql(api_sis_profile_data[:graduation][:degree] + ' in ' + api_sis_profile_data[:graduation][:majors].join(', '))
+            end
+            it "shows the right graduation date for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:graduation_date]).to eql('Awarded ' + Date.parse(api_sis_profile_data[:graduation][:date]).strftime('%b %e, %Y'))
+            end
+            it "shows the right graduation colleges for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:graduation_colleges]).to eql(api_sis_profile_data[:graduation][:colleges])
+            end
+          else
+            it "shows no graduation degree for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:graduation_date]).to be_nil
+            end
+            it "shows no graduation date for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:graduation_date]).to be_nil
+            end
+            it "shows no graduation colleges for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:graduation_colleges]).to be_nil
+            end
+          end
+
+          if api_sis_profile_data[:academic_career_status] == 'Inactive'
+            it "shows UID #{student.uid} as inactive on the student page" do
+              expect(student_page_sis_data[:inactive]).to be true
+            end
+          else
+            it "does not show UID #{student.uid} as inactive on the student page" do
+              expect(student_page_sis_data[:inactive]).to be false
+            end
+          end
+
+          if latest_standing
+            if latest_standing.code == 'GST'
+              it "shows no academic standing for UID #{student.uid} on the student page" do
+                expect(student_page_sis_data[:academic_standing]).to be_nil
+              end
+            else
+              it "shows the academic standing '#{latest_standing.descrip}' for UID #{student.uid} on the student page" do
+                expect(student_page_sis_data[:academic_standing]).to eql("#{latest_standing.descrip} (#{latest_standing.term_name})")
+              end
+            end
+          else
             it "shows no academic standing for UID #{student.uid} on the student page" do
               expect(student_page_sis_data[:academic_standing]).to be_nil
             end
+          end
+
+          if api_sis_profile_data[:terms_in_attendance] && !api_sis_profile_data[:terms_in_attendance].empty? && api_sis_profile_data[:level] != 'Graduate'
+            it "shows the terms in attendance for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:terms_in_attendance]).to include(api_sis_profile_data[:terms_in_attendance])
+            end
           else
-            it "shows the academic standing '#{latest_standing.descrip}' for UID #{student.uid} on the student page" do
-              expect(student_page_sis_data[:academic_standing]).to eql("#{latest_standing.descrip} (#{latest_standing.term_name})")
+            it "shows no terms in attendance for UID #{student.uid} on the student page" do
+              expect(student_page_sis_data[:terms_in_attendance]).to be_nil
             end
           end
-        else
-          it "shows no academic standing for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:academic_standing]).to be_nil
+
+          (api_sis_profile_data[:transfer]) ?
+              (it("shows Transfer for UID #{student.uid} on the student page") { expect(student_page_sis_data[:transfer]).to eql('Transfer') }) :
+              (it("shows no Transfer for UID #{student.uid} on the student page") { expect(student_page_sis_data[:transfer]).to be_nil })
+
+          (api_sis_profile_data[:level] == 'Graduate') ?
+              (it("shows no expected graduation date for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_graduation]).to be nil }) :
+              (it("shows the expected graduation date for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_graduation]).to eql(api_sis_profile_data[:expected_grad_term_name]) })
+
+          has_calcentral_link = @boac_student_page.calcentral_link(student).exists?
+          it("shows a link to the student overview page in CalCentral on the student page for UID #{student.uid}") { expect(has_calcentral_link).to be true }
+
+          # TIMELINE
+
+          # Requirements
+
+          student_page_reqts = @boac_student_page.visible_requirements
+          it("shows the Entry Level Writing Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_writing]).to eql(api_sis_profile_data[:reqt_writing]) }
+          it("shows the American History Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_history]).to eql(api_sis_profile_data[:reqt_history]) }
+          it("shows the American Institutions Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_institutions]).to eql(api_sis_profile_data[:reqt_institutions]) }
+          it("shows the American Cultures Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_cultures]).to eql(api_sis_profile_data[:reqt_cultures]) }
+
+          # Alerts
+
+          alerts = BOACUtils.get_students_alerts [student]
+          alert_data = alerts.map { |a| {text: a.message, date: @boac_student_page.expected_item_short_date_format(a.date)} }
+          dismissed = BOACUtils.get_dismissed_alerts(alerts).map &:message
+          logger.info "UID #{student.uid} alert count is #{alert_data.length}, with #{dismissed.length} dismissed"
+          visible_alerts = @boac_student_page.visible_alerts
+
+          if alerts.any?
+            alert_students << student
+            logger.debug "UID #{student.uid} alerts are #{alert_data}, and visible alerts are #{visible_alerts}"
+            it("has the alert messages for UID #{student.uid} on the student page") { expect(visible_alerts & alert_data).to eql(visible_alerts) }
           end
-        end
 
-        if api_sis_profile_data[:terms_in_attendance] && !api_sis_profile_data[:terms_in_attendance].empty? && api_sis_profile_data[:level] != 'Graduate'
-          it "shows the terms in attendance for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:terms_in_attendance]).to include(api_sis_profile_data[:terms_in_attendance])
-          end
-        else
-          it "shows no terms in attendance for UID #{student.uid} on the student page" do
-            expect(student_page_sis_data[:terms_in_attendance]).to be_nil
-          end
-        end
-
-        (api_sis_profile_data[:transfer]) ?
-            (it("shows Transfer for UID #{student.uid} on the student page") { expect(student_page_sis_data[:transfer]).to eql('Transfer') }) :
-            (it("shows no Transfer for UID #{student.uid} on the student page") { expect(student_page_sis_data[:transfer]).to be_nil })
-
-        (api_sis_profile_data[:level] == 'Graduate') ?
-            (it("shows no expected graduation date for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_graduation]).to be nil }) :
-            (it("shows the expected graduation date for UID #{student.uid} on the #{test.default_cohort.name} page") { expect(student_page_sis_data[:expected_graduation]).to eql(api_sis_profile_data[:expected_grad_term_name]) })
-
-        has_calcentral_link = @boac_student_page.calcentral_link(student).exists?
-        it("shows a link to the student overview page in CalCentral on the student page for UID #{student.uid}") { expect(has_calcentral_link).to be true }
-
-        # TIMELINE
-
-        # Requirements
-
-        student_page_reqts = @boac_student_page.visible_requirements
-        it("shows the Entry Level Writing Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_writing]).to eql(api_sis_profile_data[:reqt_writing]) }
-        it("shows the American History Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_history]).to eql(api_sis_profile_data[:reqt_history]) }
-        it("shows the American Institutions Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_institutions]).to eql(api_sis_profile_data[:reqt_institutions]) }
-        it("shows the American Cultures Requirement for UID #{student.uid} on the student page") { expect(student_page_reqts[:reqt_cultures]).to eql(api_sis_profile_data[:reqt_cultures]) }
-
-        # Alerts
-
-        alerts = BOACUtils.get_students_alerts [student]
-        alert_data = alerts.map { |a| {text: a.message, date: @boac_student_page.expected_item_short_date_format(a.date)} }
-        dismissed = BOACUtils.get_dismissed_alerts(alerts).map &:message
-        logger.info "UID #{student.uid} alert count is #{alert_data.length}, with #{dismissed.length} dismissed"
-        visible_alerts = @boac_student_page.visible_alerts
-
-        if alerts.any?
-          alert_students << student
-          logger.debug "UID #{student.uid} alerts are #{alert_data}, and visible alerts are #{visible_alerts}"
-          it("has the alert messages for UID #{student.uid} on the student page") { expect(visible_alerts & alert_data).to eql(visible_alerts) }
-        end
-
-        visible_alert_text = visible_alerts.map { |a| a[:text] }
-        if latest_standing&.term_id == BOACUtils.term_code.to_s
-          if latest_standing.code == 'GST'
+          visible_alert_text = visible_alerts.map { |a| a[:text] }
+          if latest_standing&.term_id == BOACUtils.term_code.to_s
+            if latest_standing.code == 'GST'
+              it "shows no academic standing alert for UID #{student.uid} on the student page" do
+                expect(visible_alert_text).not_to include("Student's academic standing is '#{latest_standing.descrip}'.")
+              end
+            else
+              it "shows an academic standing alert '#{latest_standing.descrip}' for UID #{student.uid} on the student page" do
+                expect(visible_alert_text).to include("Student's academic standing is '#{latest_standing.descrip}'.")
+              end
+            end
+          else
             it "shows no academic standing alert for UID #{student.uid} on the student page" do
-              expect(visible_alert_text).not_to include("Student's academic standing is '#{latest_standing.descrip}'.")
-            end
-          else
-            it "shows an academic standing alert '#{latest_standing.descrip}' for UID #{student.uid} on the student page" do
-              expect(visible_alert_text).to include("Student's academic standing is '#{latest_standing.descrip}'.")
-            end
-          end
-        else
-          it "shows no academic standing alert for UID #{student.uid} on the student page" do
-            visible_alert_text.each do |alert|
-              expect(alert).not_to include("Student's academic standing is")
-            end
-          end
-        end
-
-        # Holds
-
-        holds = NessieUtils.get_student_holds student
-        hold_msgs = (holds.map { |h| h.message.gsub(/\W/, '') }).sort
-        logger.info "UID #{student.uid} hold count is #{hold_msgs.length}"
-
-        if holds.any?
-          hold_students << student
-          visible_holds = @boac_student_page.visible_holds.sort
-          logger.debug "UID #{student.uid} holds are #{hold_msgs}, and visible holds are #{visible_holds}"
-          it("has the hold messages for UID #{student.uid} on the student page") { expect(visible_holds).to eql(hold_msgs) }
-        end
-
-        if (withdrawal = api_sis_profile_data[:withdrawal])
-          withdrawal_msg_present = @boac_student_page.withdrawal_msg?
-          it("shows withdrawal information for UID #{student.uid} on the student page") { expect(withdrawal_msg_present).to be true }
-          if withdrawal_msg_present
-            msg = @boac_student_page.withdrawal_msg
-            it("shows the withdrawal type for UID #{student.uid} on the student page") { expect(msg).to include(withdrawal[:desc]) }
-            it("shows the withdrawal reason for UID #{student.uid} on the student page") { expect(msg).to include(withdrawal[:reason]) }
-            it("shows the withdrawal date for UID #{student.uid} on the student page") { expect(msg).to include(withdrawal[:date]) }
-          end
-        end
-
-        # TERMS
-
-        terms = api_student_data.terms
-        if terms.any?
-          if terms.length > 1 && api_student_data.term_id(terms.last).to_s != BOACUtils.term_code.to_s
-            @boac_student_page.click_view_previous_semesters
-          else
-            has_view_more_button = @boac_student_page.view_more_button_element.visible?
-            it("shows no View Previous Semesters button for UID #{student.uid} on the student page") { expect(has_view_more_button).to be false }
-          end
-
-          terms.each do |term|
-
-            begin
-              term_id = api_student_data.term_id term
-              term_name = api_student_data.term_name term
-              logger.info "Checking #{term_name}"
-              visible_term_data = @boac_student_page.visible_term_data(term_id, term_name)
-
-              # TERM UNITS
-
-              if api_student_data.term_units(term) && api_student_data.term_units(term).to_i.zero?
-                it("shows no term units total for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units]).to be_nil }
-              else
-                it("shows the term units total for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units]).to eql(api_student_data.term_units term) }
+              visible_alert_text.each do |alert|
+                expect(alert).not_to include("Student's academic standing is")
               end
+            end
+          end
 
-              if api_sis_profile_data[:term_units_min]
-                if api_sis_profile_data[:term_units_min].zero? || term != api_student_data.current_term
+          # Holds
+
+          holds = NessieUtils.get_student_holds student
+          hold_msgs = (holds.map { |h| h.message.gsub(/\W/, '') }).sort
+          logger.info "UID #{student.uid} hold count is #{hold_msgs.length}"
+
+          if holds.any?
+            hold_students << student
+            visible_holds = @boac_student_page.visible_holds.sort
+            logger.debug "UID #{student.uid} holds are #{hold_msgs}, and visible holds are #{visible_holds}"
+            it("has the hold messages for UID #{student.uid} on the student page") { expect(visible_holds).to eql(hold_msgs) }
+          end
+
+          if (withdrawal = api_sis_profile_data[:withdrawal])
+            withdrawal_msg_present = @boac_student_page.withdrawal_msg?
+            it("shows withdrawal information for UID #{student.uid} on the student page") { expect(withdrawal_msg_present).to be true }
+            if withdrawal_msg_present
+              msg = @boac_student_page.withdrawal_msg
+              it("shows the withdrawal type for UID #{student.uid} on the student page") { expect(msg).to include(withdrawal[:desc]) }
+              it("shows the withdrawal reason for UID #{student.uid} on the student page") { expect(msg).to include(withdrawal[:reason]) }
+              it("shows the withdrawal date for UID #{student.uid} on the student page") { expect(msg).to include(withdrawal[:date]) }
+            end
+          end
+
+          # TERMS
+
+          terms = api_student_data.terms
+          if terms.any?
+            if terms.length > 1 && api_student_data.term_id(terms.last).to_s != BOACUtils.term_code.to_s
+              @boac_student_page.click_view_previous_semesters
+            else
+              has_view_more_button = @boac_student_page.view_more_button_element.visible?
+              it("shows no View Previous Semesters button for UID #{student.uid} on the student page") { expect(has_view_more_button).to be false }
+            end
+
+            terms.each do |term|
+
+              begin
+                term_id = api_student_data.term_id term
+                term_name = api_student_data.term_name term
+                logger.info "Checking #{term_name}"
+                visible_term_data = @boac_student_page.visible_term_data(term_id, term_name)
+
+                # TERM UNITS
+
+                if api_student_data.term_units(term) && api_student_data.term_units(term).to_i.zero?
+                  it("shows no term units total for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units]).to be_nil }
+                else
+                  it("shows the term units total for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units]).to eql(api_student_data.term_units term) }
+                end
+
+                if api_sis_profile_data[:term_units_min]
+                  if api_sis_profile_data[:term_units_min].zero? || term != api_student_data.current_term
+                    it("shows no term units minimum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_min]).to be_nil }
+                  else
+                    it("shows the term units minimum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_min]).to eql(api_sis_profile_data[:term_units_min].to_s) }
+                  end
+                else
                   it("shows no term units minimum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_min]).to be_nil }
-                else
-                  it("shows the term units minimum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_min]).to eql(api_sis_profile_data[:term_units_min].to_s) }
                 end
-              else
-                it("shows no term units minimum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_min]).to be_nil }
-              end
 
-              if api_sis_profile_data[:term_units_max]
-                if api_sis_profile_data[:term_units_max].zero? || term != api_student_data.current_term
+                if api_sis_profile_data[:term_units_max]
+                  if api_sis_profile_data[:term_units_max].zero? || term != api_student_data.current_term
+                    it("shows no term units maximum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_max]).to be_nil }
+                  else
+                    it("shows the term units maximum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_max]).to eql(api_sis_profile_data[:term_units_max].to_s) }
+                  end
+                else
                   it("shows no term units maximum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_max]).to be_nil }
-                else
-                  it("shows the term units maximum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_max]).to eql(api_sis_profile_data[:term_units_max].to_s) }
                 end
-              else
-                it("shows no term units maximum for UID #{student.uid} term #{term_name}") { expect(visible_term_data[:term_units_max]).to be_nil }
-              end
 
-              # ACADEMIC STANDING
+                # ACADEMIC STANDING
 
-              if academic_standing&.any?
-                term_standing = academic_standing.find { |s| s.term_id.to_s == term_id.to_s }
-                if term_standing
-                  if term_standing.code == 'GST'
+                if academic_standing&.any?
+                  term_standing = academic_standing.find { |s| s.term_id.to_s == term_id.to_s }
+                  if term_standing
+                    if term_standing.code == 'GST'
+                      it "shows no academic standing for UID #{student.uid} term #{term_name} on the student page" do
+                        expect(visible_term_data[:academic_standing]).to be_nil
+                      end
+                    else
+                      it "shows the academic standing '#{term_standing.descrip}' for UID #{student.uid} term #{term_name} on the student page" do
+                        expect(visible_term_data[:academic_standing]).to eql("#{term_standing.descrip} (#{term_standing.term_name})")
+                      end
+                    end
+                  else
                     it "shows no academic standing for UID #{student.uid} term #{term_name} on the student page" do
                       expect(visible_term_data[:academic_standing]).to be_nil
                     end
-                  else
-                    it "shows the academic standing '#{term_standing.descrip}' for UID #{student.uid} term #{term_name} on the student page" do
-                      expect(visible_term_data[:academic_standing]).to eql("#{term_standing.descrip} (#{term_standing.term_name})")
+                  end
+                end
+
+                # COURSES
+
+                term_section_ccns = []
+
+                if api_student_data.courses(term).any?
+                  api_student_data.courses(term).each do |course|
+
+                    begin
+                      course_sis_data = api_student_data.sis_course_data course
+                      course_code = course_sis_data[:code]
+
+                      logger.info "Checking course #{course_code}"
+
+                      @boac_student_page.expand_course_data(term_name, course_code)
+
+                      visible_course_sis_data = @boac_student_page.visible_course_sis_data(term_name, course_code)
+                      visible_course_title = visible_course_sis_data[:title]
+                      visible_units = visible_course_sis_data[:units_completed]
+                      visible_grading_basis = visible_course_sis_data[:grading_basis]
+                      visible_midpoint = visible_course_sis_data[:mid_point_grade]
+                      visible_grade = visible_course_sis_data[:grade]
+
+                      it "shows the course title for UID #{student.uid} term #{term_name} course #{course_code}" do
+                        expect(visible_course_title).not_to be_empty
+                        expect(visible_course_title).to eql(course_sis_data[:title])
+                      end
+
+                      it "shows the units for UID #{student.uid} term #{term_name} course #{course_code}" do
+                        expect(visible_units).not_to be_empty
+                        expect(visible_units).to eql(course_sis_data[:units_completed])
+                      end
+
+                      if course_sis_data[:grade].empty?
+                        if course_sis_data[:grading_basis] == 'NON'
+                          it "shows no grade and no grading basis for UID #{student.uid} term #{term_name} course #{course_code}" do
+                            expect(visible_grade).to be_empty
+                            expect(visible_grading_basis).to be_nil
+                          end
+                        else
+                          it("shows the grading basis for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_grading_basis).to eql(course_sis_data[:grading_basis]) }
+                        end
+                      else
+                        it("shows the grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_grade).to eql(course_sis_data[:grade]) }
+                      end
+
+                      if term_name == BOACUtils.term
+                        if course_sis_data[:midpoint]
+                          it "shows the midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}" do
+                            expect(visible_midpoint).not_to be_empty
+                            expect(visible_midpoint).to eql(course_sis_data[:midpoint])
+                          end
+                        else
+                          it("shows no midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_midpoint).to include('No data') }
+                        end
+                      else
+                        it("shows no midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_midpoint).to be_nil }
+                      end
+
+                      # SECTIONS
+
+                      section_statuses = []
+                      api_student_data.sections(course).each do |section|
+
+                        begin
+                          index = api_student_data.sections(course).index section
+                          section_sis_data = api_student_data.sis_section_data section
+                          term_section_ccns << section_sis_data[:ccn]
+                          component = section_sis_data[:component]
+
+                          visible_section_sis_data = @boac_student_page.visible_section_sis_data(term_name, course_code, index)
+                          visible_section = visible_section_sis_data[:section].split("\n").last
+
+                          it "shows the section number for UID #{student.uid} term #{term_name} course #{course_code} section #{component}" do
+                            expect(visible_section).not_to be_empty
+                            expect(visible_section).to eql("#{section_sis_data[:component]} #{section_sis_data[:number]}")
+                          end
+
+                          section_statuses << section_sis_data[:status]
+
+                        rescue => e
+                          BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_code}-#{section_sis_data[:ccn]}")
+                          it("encountered an error for UID #{student.uid} term #{term_name} course #{course_code} section #{section_sis_data[:ccn]}") { fail }
+                        ensure
+                          row = [student.uid, term_name, api_sis_profile_data[:term_units_min], api_sis_profile_data[:term_units_max], course_code, course_sis_data[:title],
+                                 section_sis_data[:ccn], "#{section_sis_data[:component]} #{section_sis_data[:number]}", section_sis_data[:primary], course_sis_data[:midpoint],
+                                 course_sis_data[:grade], course_sis_data[:grading_basis], course_sis_data[:units_completed], section_sis_data[:status]]
+                          Utils.add_csv_row(user_course_sis_data, row)
+                        end
+                      end
+
+                      visible_wait_list_status = visible_course_sis_data[:wait_list]
+                      (section_statuses.include? 'W') ?
+                          (it("shows the wait list status for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_wait_list_status).to be true }) :
+                          (it("shows no enrollment status for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_wait_list_status).to be false })
+
+                    rescue => e
+                      BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_code}")
+                      it("encountered an error for UID #{student.uid} term #{term_name} course #{course_code}") { fail }
                     end
                   end
+
+                  it("shows no dupe courses for UID #{student.uid} in term #{term_name}") { expect(term_section_ccns).to eql(term_section_ccns.uniq) }
+
                 else
-                  it "shows no academic standing for UID #{student.uid} term #{term_name} on the student page" do
-                    expect(visible_term_data[:academic_standing]).to be_nil
-                  end
+                  logger.warn "No course data in #{term_name}"
                 end
-              end
 
-              # COURSES
+                # DROPPED SECTIONS
 
-              term_section_ccns = []
+                drops = api_student_data.dropped_sections term
+                if drops
+                  drops.each do |drop|
+                    visible_drop = @boac_student_page.visible_dropped_section_data(term_name, drop[:title], drop[:component], drop[:number])
+                    (term_name == BOACUtils.term) ?
+                        (it("shows dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{student.uid} in #{term_name}") { expect(visible_drop).to be_truthy }) :
+                        (it("shows no dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{student.uid} in past term #{term_name}") { expect(visible_drop).to be_falsey })
 
-              if api_student_data.courses(term).any?
-                api_student_data.courses(term).each do |course|
-
-                  begin
-                    course_sis_data = api_student_data.sis_course_data course
-                    course_code = course_sis_data[:code]
-
-                    logger.info "Checking course #{course_code}"
-
-                    @boac_student_page.expand_course_data(term_name, course_code)
-
-                    visible_course_sis_data = @boac_student_page.visible_course_sis_data(term_name, course_code)
-                    visible_course_title = visible_course_sis_data[:title]
-                    visible_units = visible_course_sis_data[:units_completed]
-                    visible_grading_basis = visible_course_sis_data[:grading_basis]
-                    visible_midpoint = visible_course_sis_data[:mid_point_grade]
-                    visible_grade = visible_course_sis_data[:grade]
-
-                    it "shows the course title for UID #{student.uid} term #{term_name} course #{course_code}" do
-                      expect(visible_course_title).not_to be_empty
-                      expect(visible_course_title).to eql(course_sis_data[:title])
-                    end
-
-                    it "shows the units for UID #{student.uid} term #{term_name} course #{course_code}" do
-                      expect(visible_units).not_to be_empty
-                      expect(visible_units).to eql(course_sis_data[:units_completed])
-                    end
-
-                    if course_sis_data[:grade].empty?
-                      if course_sis_data[:grading_basis] == 'NON'
-                        it "shows no grade and no grading basis for UID #{student.uid} term #{term_name} course #{course_code}" do
-                          expect(visible_grade).to be_empty
-                          expect(visible_grading_basis).to be_nil
-                        end
-                      else
-                        it("shows the grading basis for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_grading_basis).to eql(course_sis_data[:grading_basis]) }
-                      end
-                    else
-                      it("shows the grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_grade).to eql(course_sis_data[:grade]) }
-                    end
-
-                    if term_name == BOACUtils.term
-                      if course_sis_data[:midpoint]
-                        it "shows the midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}" do
-                          expect(visible_midpoint).not_to be_empty
-                          expect(visible_midpoint).to eql(course_sis_data[:midpoint])
-                        end
-                      else
-                        it("shows no midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_midpoint).to include('No data') }
-                      end
-                    else
-                      it("shows no midpoint grade for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_midpoint).to be_nil }
-                    end
-
-                    # SECTIONS
-
-                    section_statuses = []
-                    api_student_data.sections(course).each do |section|
-
-                      begin
-                        index = api_student_data.sections(course).index section
-                        section_sis_data = api_student_data.sis_section_data section
-                        term_section_ccns << section_sis_data[:ccn]
-                        component = section_sis_data[:component]
-
-                        visible_section_sis_data = @boac_student_page.visible_section_sis_data(term_name, course_code, index)
-                        visible_section = visible_section_sis_data[:section].split("\n").last
-
-                        it "shows the section number for UID #{student.uid} term #{term_name} course #{course_code} section #{component}" do
-                          expect(visible_section).not_to be_empty
-                          expect(visible_section).to eql("#{section_sis_data[:component]} #{section_sis_data[:number]}")
-                        end
-
-                        section_statuses << section_sis_data[:status]
-
-                      rescue => e
-                        BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_code}-#{section_sis_data[:ccn]}")
-                        it("encountered an error for UID #{student.uid} term #{term_name} course #{course_code} section #{section_sis_data[:ccn]}") { fail }
-                      ensure
-                        row = [student.uid, term_name, api_sis_profile_data[:term_units_min], api_sis_profile_data[:term_units_max], course_code, course_sis_data[:title],
-                               section_sis_data[:ccn], "#{section_sis_data[:component]} #{section_sis_data[:number]}", section_sis_data[:primary], course_sis_data[:midpoint],
-                               course_sis_data[:grade], course_sis_data[:grading_basis], course_sis_data[:units_completed], section_sis_data[:status]]
-                        Utils.add_csv_row(user_course_sis_data, row)
-                      end
-                    end
-
-                    visible_wait_list_status = visible_course_sis_data[:wait_list]
-                    (section_statuses.include? 'W') ?
-                        (it("shows the wait list status for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_wait_list_status).to be true }) :
-                        (it("shows no enrollment status for UID #{student.uid} term #{term_name} course #{course_code}") { expect(visible_wait_list_status).to be false })
-
-                  rescue => e
-                    BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}-#{course_code}")
-                    it("encountered an error for UID #{student.uid} term #{term_name} course #{course_code}") { fail }
+                    row = [student.uid, term_name, nil, nil, drop[:title], nil, nil, drop[:number], nil, nil, nil, 'D']
+                    Utils.add_csv_row(user_course_sis_data, row)
                   end
                 end
 
-                it("shows no dupe courses for UID #{student.uid} in term #{term_name}") { expect(term_section_ccns).to eql(term_section_ccns.uniq) }
-
-              else
-                logger.warn "No course data in #{term_name}"
+              rescue => e
+                BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}")
+                it("encountered an error for UID #{student.uid} term #{term_name}") { fail }
               end
-
-              # DROPPED SECTIONS
-
-              drops = api_student_data.dropped_sections term
-              if drops
-                drops.each do |drop|
-                  visible_drop = @boac_student_page.visible_dropped_section_data(term_name, drop[:title], drop[:component], drop[:number])
-                  (term_name == BOACUtils.term) ?
-                      (it("shows dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{student.uid} in #{term_name}") { expect(visible_drop).to be_truthy }) :
-                      (it("shows no dropped section #{drop[:title]} #{drop[:component]} #{drop[:number]} for UID #{student.uid} in past term #{term_name}") { expect(visible_drop).to be_falsey })
-
-                  row = [student.uid, term_name, nil, nil, drop[:title], nil, nil, drop[:number], nil, nil, nil, 'D']
-                  Utils.add_csv_row(user_course_sis_data, row)
-                end
-              end
-
-            rescue => e
-              BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}-#{term_name}")
-              it("encountered an error for UID #{student.uid} term #{term_name}") { fail }
             end
+
+          else
+            logger.warn "UID #{student.uid} has no term data"
           end
 
-        else
-          logger.warn "UID #{student.uid} has no term data"
-        end
-
-      rescue => e
-        BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}")
-        it("encountered an error for UID #{student.uid}") { fail }
-      ensure
-        if student_page_sis_data
-          row = [student.uid, student_page_sis_data[:name], student_page_sis_data[:preferred_name], student_page_sis_data[:email],
-                 student_page_sis_data[:email_alternate], student_page_sis_data[:phone], student_page_sis_data[:cumulative_units],
-                 student_page_sis_data[:cumulative_gpa], student_page_sis_data[:level], student_page_sis_data[:transfer],
-                 student_page_sis_data[:colleges], student_page_sis_data[:majors],
-                 student_page_sis_data[:colleges_discontinued], student_page_sis_data[:majors_discontinued],
-                 student_page_sis_data[:minors], student_page_sis_data[:minors_discontinued],
-                 student_page_sis_data[:terms_in_attendance],
-                 student_page_reqts[:reqt_writing], student_page_reqts[:reqt_history], student_page_reqts[:reqt_institutions],
-                 student_page_reqts[:reqt_cultures], student_page_sis_data[:advisor_plans], student_page_sis_data[:advisor_names],
-                 student_page_sis_data[:advisor_emails], student_page_sis_data[:entered_term], student_page_sis_data[:intended_majors],
-                 student_page_sis_data[:visa], student_page_sis_data[:expected_graduation], student_page_sis_data[:graduation_degree],
-                 student_page_sis_data[:graduation_date], student_page_sis_data[:graduation_colleges], student_page_sis_data[:inactive],
-                 alert_data, hold_msgs]
-          Utils.add_csv_row(user_profile_sis_data, row)
+        rescue => e
+          BOACUtils.log_error_and_screenshot(@driver, e, "#{student.uid}")
+          it("encountered an error for UID #{student.uid}") { fail }
+        ensure
+          if student_page_sis_data
+            row = [student.uid, student_page_sis_data[:name], student_page_sis_data[:preferred_name], student_page_sis_data[:email],
+                   student_page_sis_data[:email_alternate], student_page_sis_data[:phone], student_page_sis_data[:cumulative_units],
+                   student_page_sis_data[:cumulative_gpa], student_page_sis_data[:level], student_page_sis_data[:transfer],
+                   student_page_sis_data[:colleges], student_page_sis_data[:majors],
+                   student_page_sis_data[:colleges_discontinued], student_page_sis_data[:majors_discontinued],
+                   student_page_sis_data[:minors], student_page_sis_data[:minors_discontinued],
+                   student_page_sis_data[:terms_in_attendance],
+                   student_page_reqts[:reqt_writing], student_page_reqts[:reqt_history], student_page_reqts[:reqt_institutions],
+                   student_page_reqts[:reqt_cultures], student_page_sis_data[:advisor_plans], student_page_sis_data[:advisor_names],
+                   student_page_sis_data[:advisor_emails], student_page_sis_data[:entered_term], student_page_sis_data[:intended_majors],
+                   student_page_sis_data[:visa], student_page_sis_data[:expected_graduation], student_page_sis_data[:graduation_degree],
+                   student_page_sis_data[:graduation_date], student_page_sis_data[:graduation_colleges], student_page_sis_data[:inactive],
+                   alert_data, hold_msgs]
+            Utils.add_csv_row(user_profile_sis_data, row)
+          end
         end
       end
+
+      it('has at least one student with an alert') { expect(alert_students).not_to be_empty }
+      it('has at least one student with a hold') { expect(hold_students).not_to be_empty }
+
+    rescue => e
+      Utils.log_error e
+      it('encountered an error') { fail }
+    ensure
+      Utils.quit_browser @driver
     end
-
-  it('has at least one student with an alert') { expect(alert_students).not_to be_empty }
-  it('has at least one student with a hold') { expect(hold_students).not_to be_empty }
-
-  rescue => e
-    Utils.log_error e
-    it('encountered an error') { fail }
-  ensure
-    Utils.quit_browser @driver
   end
 end

--- a/spec/boac/boac_topic_mgmt_spec.rb
+++ b/spec/boac/boac_topic_mgmt_spec.rb
@@ -1,353 +1,356 @@
 require_relative '../../util/spec_helper'
 
-describe 'A BOAC topic' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  before(:all) do
-    @test = BOACTestConfig.new
-    @test.topic_mgmt
-
-    @driver = Utils.launch_browser
-    @student = @test.students.shuffle.first
-    @topic = Topic.new("Topic test #{@test.id}", true, true)
-    @note = Note.new student: @student, subject: "Topic test #{@test.id}"
-    @appt = Appointment.new advisor: @test.advisor, student: @student, detail: "Topic test #{@test.id}", topics: [@topic]
-    @template = NoteTemplate.new(title: "Template #{@test.id}", subject: 'Template subj', body: 'Template body')
-
-    @homepage = BOACHomePage.new @driver
-    @pax_manifest = BOACPaxManifestPage.new @driver
-    @flight_deck = BOACFlightDeckPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @search_results = BOACSearchResultsPage.new @driver
-
-    @homepage.dev_auth
-    @homepage.click_flight_deck_link
-  end
-
-  after(:all) do
-    Utils.quit_browser @driver
-    BOACUtils.hard_delete_topic @topic if @topic.id
-    @template.hard_delete_template if @template.id
-  end
-
-  context 'creation' do
-
-    it 'requires a label and note and/or appointment selection' do
-      @flight_deck.click_create_topic
-      expect(@flight_deck.topic_save_button_element.enabled?).to be false
-      @flight_deck.enter_topic_label 'foo'
-      expect(@flight_deck.topic_save_button_element.enabled?).to be false
-      @flight_deck.check_topic_in_notes
-      expect(@flight_deck.topic_save_button_element.enabled?).to be true
-      @flight_deck.uncheck_topic_in_notes
-      expect(@flight_deck.topic_save_button_element.enabled?).to be false
-      @flight_deck.check_topic_in_appts
-      expect(@flight_deck.topic_save_button_element.enabled?).to be true
-    end
-
-    it 'requires a unique label' do
-      existing_topic = Topic::ACADEMIC_PROGRESS
-      @flight_deck.enter_topic_label existing_topic.name
-      expect(@flight_deck.label_validation_error).to eql("Sorry, the label '#{existing_topic.name}' is assigned to an existing topic.")
-      expect(@flight_deck.topic_save_button_element.enabled?).to be false
-    end
-
-    it 'can have a label up to 50 characters' do
-      long_label = 'A long label ' * 4
-      @flight_deck.enter_topic_label long_label[0..49]
-      expect(@flight_deck.label_length_validation).to include('(0 left)')
-    end
-
-    it('can be canceled') { @flight_deck.click_cancel_topic }
-    it('can be saved') { @flight_deck.create_topic @topic }
-
-    it 'can be searched on the Flight Deck' do
-      @flight_deck.search_for_topic @topic
-      @flight_deck.topic_row(@topic).when_visible 1
-    end
-
-    it 'shows the right topic data on the Flight Deck' do
-      expect(@flight_deck.topic_deleted? @topic).to be false
-      expect(@flight_deck.topic_in_notes @topic).to eql('Yes')
-      expect(@flight_deck.topic_in_notes_count @topic).to eql('0')
-      expect(@flight_deck.topic_in_appts @topic).to eql('Yes')
-      expect(@flight_deck.topic_in_appts_count @topic).to eql('0')
-    end
-  end
-
-  context 'editing' do
-
-    it 'can be canceled' do
-      @flight_deck.click_edit_topic @topic
-      @flight_deck.click_cancel_topic
-    end
-
-    it 'requires note and/or appointment selection' do
-      @flight_deck.click_edit_topic @topic
-      @flight_deck.uncheck_topic_in_notes
-      @flight_deck.uncheck_topic_in_appts
-      expect(@flight_deck.topic_save_button_element.enabled?).to be false
-      @flight_deck.check_topic_in_notes
-      expect(@flight_deck.topic_save_button_element.enabled?).to be true
-      @flight_deck.uncheck_topic_in_notes
-      @flight_deck.check_topic_in_appts
-      expect(@flight_deck.topic_save_button_element.enabled?).to be true
-    end
-  end
-
-  context 'when it is available to both notes and appointments' do
+  describe 'A BOAC topic' do
 
     before(:all) do
-      @flight_deck.hit_escape
-      @flight_deck.log_out
-      @homepage.dev_auth @test.advisor
-      @homepage.click_settings_link
-      @flight_deck.enable_drop_in_advising_role(@test.advisor.dept_memberships.find { |m| m.dept == @test.dept })
-      @homepage.click_create_note_batch
-      @homepage.enter_new_note_subject @note
-      @homepage.create_template(@template, @note)
-    end
+      @test = BOACTestConfig.new
+      @test.topic_mgmt
 
-    it 'can be selected for an individual note' do
-      @student_page.load_page @student
-      @student_page.click_create_new_note
-      expect(@student_page.topic_options).to include(@topic.name)
-    end
+      @driver = Utils.launch_browser
+      @student = @test.students.shuffle.first
+      @topic = Topic.new("Topic test #{@test.id}", true, true)
+      @note = Note.new student: @student, subject: "Topic test #{@test.id}"
+      @appt = Appointment.new advisor: @test.advisor, student: @student, detail: "Topic test #{@test.id}", topics: [@topic]
+      @template = NoteTemplate.new(title: "Template #{@test.id}", subject: 'Template subj', body: 'Template body')
 
-    it 'can be selected for a batch note' do
-      @student_page.hit_escape
-      @student_page.click_create_note_batch
-      expect(@student_page.topic_options).to include(@topic.name)
-    end
+      @homepage = BOACHomePage.new @driver
+      @pax_manifest = BOACPaxManifestPage.new @driver
+      @flight_deck = BOACFlightDeckPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @search_results = BOACSearchResultsPage.new @driver
 
-    it 'can be selected for a note template' do
-      @student_page.click_templates_button
-      @student_page.click_edit_template @template
-      expect(@student_page.topic_options).to include(@topic.name)
-    end
-
-    it 'can be selected for a drop-in appointment' do
-      @homepage.load_page
-      @homepage.click_new_appt
-      expect(@homepage.available_appt_reasons).to include(@topic.name)
-    end
-
-    it 'is returned in search results for any notes that include the topic' do
-      @student_page.load_page @student
-      @student_page.create_note(@note, [@topic], nil)
-      @student_page.expand_search_options_notes_subpanel
-      @student_page.select_note_topic @topic
-      @student_page.click_search_button
-      expect(@search_results.note_in_search_result? @note).to be true
-    end
-
-    it 'is returned in search results for any appointments that include the topic' do
-      @homepage.load_page
-      @homepage.click_new_appt
-      @homepage.create_appt @appt
-      @student_page.expand_search_options_notes_subpanel
-      @student_page.select_note_topic @topic
-      @student_page.click_search_button
-      expect(@search_results.appt_in_search_result? @appt).to be true
-    end
-
-    it 'shows its usage in both notes and appointments' do
-      @search_results.log_out
       @homepage.dev_auth
       @homepage.click_flight_deck_link
-      @flight_deck.search_for_topic @topic
-      expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
-      expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
     end
+
+    after(:all) do
+      Utils.quit_browser @driver
+      BOACUtils.hard_delete_topic @topic if @topic.id
+      @template.hard_delete_template if @template.id
+    end
+
+    context 'creation' do
+
+      it 'requires a label and note and/or appointment selection' do
+        @flight_deck.click_create_topic
+        expect(@flight_deck.topic_save_button_element.enabled?).to be false
+        @flight_deck.enter_topic_label 'foo'
+        expect(@flight_deck.topic_save_button_element.enabled?).to be false
+        @flight_deck.check_topic_in_notes
+        expect(@flight_deck.topic_save_button_element.enabled?).to be true
+        @flight_deck.uncheck_topic_in_notes
+        expect(@flight_deck.topic_save_button_element.enabled?).to be false
+        @flight_deck.check_topic_in_appts
+        expect(@flight_deck.topic_save_button_element.enabled?).to be true
+      end
+
+      it 'requires a unique label' do
+        existing_topic = Topic::ACADEMIC_PROGRESS
+        @flight_deck.enter_topic_label existing_topic.name
+        expect(@flight_deck.label_validation_error).to eql("Sorry, the label '#{existing_topic.name}' is assigned to an existing topic.")
+        expect(@flight_deck.topic_save_button_element.enabled?).to be false
+      end
+
+      it 'can have a label up to 50 characters' do
+        long_label = 'A long label ' * 4
+        @flight_deck.enter_topic_label long_label[0..49]
+        expect(@flight_deck.label_length_validation).to include('(0 left)')
+      end
+
+      it('can be canceled') { @flight_deck.click_cancel_topic }
+      it('can be saved') { @flight_deck.create_topic @topic }
+
+      it 'can be searched on the Flight Deck' do
+        @flight_deck.search_for_topic @topic
+        @flight_deck.topic_row(@topic).when_visible 1
+      end
+
+      it 'shows the right topic data on the Flight Deck' do
+        expect(@flight_deck.topic_deleted? @topic).to be false
+        expect(@flight_deck.topic_in_notes @topic).to eql('Yes')
+        expect(@flight_deck.topic_in_notes_count @topic).to eql('0')
+        expect(@flight_deck.topic_in_appts @topic).to eql('Yes')
+        expect(@flight_deck.topic_in_appts_count @topic).to eql('0')
+      end
+    end
+
+    context 'editing' do
+
+      it 'can be canceled' do
+        @flight_deck.click_edit_topic @topic
+        @flight_deck.click_cancel_topic
+      end
+
+      it 'requires note and/or appointment selection' do
+        @flight_deck.click_edit_topic @topic
+        @flight_deck.uncheck_topic_in_notes
+        @flight_deck.uncheck_topic_in_appts
+        expect(@flight_deck.topic_save_button_element.enabled?).to be false
+        @flight_deck.check_topic_in_notes
+        expect(@flight_deck.topic_save_button_element.enabled?).to be true
+        @flight_deck.uncheck_topic_in_notes
+        @flight_deck.check_topic_in_appts
+        expect(@flight_deck.topic_save_button_element.enabled?).to be true
+      end
+    end
+
+    context 'when it is available to both notes and appointments' do
+
+      before(:all) do
+        @flight_deck.hit_escape
+        @flight_deck.log_out
+        @homepage.dev_auth @test.advisor
+        @homepage.click_settings_link
+        @flight_deck.enable_drop_in_advising_role(@test.advisor.dept_memberships.find { |m| m.dept == @test.dept })
+        @homepage.click_create_note_batch
+        @homepage.enter_new_note_subject @note
+        @homepage.create_template(@template, @note)
+      end
+
+      it 'can be selected for an individual note' do
+        @student_page.load_page @student
+        @student_page.click_create_new_note
+        expect(@student_page.topic_options).to include(@topic.name)
+      end
+
+      it 'can be selected for a batch note' do
+        @student_page.hit_escape
+        @student_page.click_create_note_batch
+        expect(@student_page.topic_options).to include(@topic.name)
+      end
+
+      it 'can be selected for a note template' do
+        @student_page.click_templates_button
+        @student_page.click_edit_template @template
+        expect(@student_page.topic_options).to include(@topic.name)
+      end
+
+      it 'can be selected for a drop-in appointment' do
+        @homepage.load_page
+        @homepage.click_new_appt
+        expect(@homepage.available_appt_reasons).to include(@topic.name)
+      end
+
+      it 'is returned in search results for any notes that include the topic' do
+        @student_page.load_page @student
+        @student_page.create_note(@note, [@topic], nil)
+        @student_page.expand_search_options_notes_subpanel
+        @student_page.select_note_topic @topic
+        @student_page.click_search_button
+        expect(@search_results.note_in_search_result? @note).to be true
+      end
+
+      it 'is returned in search results for any appointments that include the topic' do
+        @homepage.load_page
+        @homepage.click_new_appt
+        @homepage.create_appt @appt
+        @student_page.expand_search_options_notes_subpanel
+        @student_page.select_note_topic @topic
+        @student_page.click_search_button
+        expect(@search_results.appt_in_search_result? @appt).to be true
+      end
+
+      it 'shows its usage in both notes and appointments' do
+        @search_results.log_out
+        @homepage.dev_auth
+        @homepage.click_flight_deck_link
+        @flight_deck.search_for_topic @topic
+        expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
+        expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
+      end
+    end
+
+    context 'when it is available to notes only' do
+
+      before(:all) do
+        @topic.for_appts = false
+        @flight_deck.edit_topic @topic
+        @flight_deck.log_out
+        @homepage.dev_auth @test.advisor
+      end
+
+      it 'can be selected for an individual note' do
+        @student_page.load_page @student
+        @student_page.click_create_new_note
+        expect(@student_page.topic_options).to include(@topic.name)
+      end
+
+      it 'can be selected for a batch note' do
+        @student_page.hit_escape
+        @student_page.click_create_note_batch
+        expect(@student_page.topic_options).to include(@topic.name)
+      end
+
+      it 'can be selected for a note template' do
+        @student_page.click_templates_button
+        @student_page.click_edit_template @template
+        expect(@student_page.topic_options).to include(@topic.name)
+      end
+
+      it 'cannot be selected for a drop-in appointment' do
+        @homepage.load_page
+        @homepage.click_new_appt
+        expect(@homepage.available_appt_reasons).not_to include(@topic.name)
+      end
+
+      it 'is returned in search results for any notes that include the topic' do
+        @homepage.hit_escape
+        @student_page.expand_search_options_notes_subpanel
+        @student_page.select_note_topic @topic
+        @student_page.click_search_button
+        expect(@search_results.note_in_search_result? @note).to be true
+      end
+
+      it 'is returned in search results for any appointments that include the topic' do
+        expect(@search_results.appt_in_search_result? @appt).to be true
+      end
+
+      it 'shows its usage in both notes and appointments' do
+        @search_results.log_out
+        @homepage.dev_auth
+        @homepage.click_flight_deck_link
+        @flight_deck.search_for_topic @topic
+        expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
+        expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
+      end
+    end
+
+    context 'when it is available to appointments only' do
+
+      before(:all) do
+        @topic.for_appts = true
+        @topic.for_notes = false
+        @flight_deck.edit_topic @topic
+        @flight_deck.log_out
+        @homepage.dev_auth @test.advisor
+      end
+
+      it 'cannot be selected for an individual note' do
+        @student_page.load_page @student
+        @student_page.click_create_new_note
+        expect(@student_page.topic_options).not_to include(@topic.name)
+      end
+
+      it 'cannot be selected for a batch note' do
+        @student_page.hit_escape
+        @student_page.click_create_note_batch
+        expect(@student_page.topic_options).not_to include(@topic.name)
+      end
+
+      it 'cannot be selected for a note template' do
+        @student_page.click_templates_button
+        @student_page.click_edit_template @template
+        expect(@student_page.topic_options).not_to include(@topic.name)
+      end
+
+      it 'can be selected for a drop-in appointment' do
+        @homepage.load_page
+        @homepage.click_new_appt
+        expect(@homepage.available_appt_reasons).to include(@topic.name)
+      end
+
+      it 'is returned in search results for any notes that include the topic' do
+        @homepage.hit_escape
+        @student_page.expand_search_options_notes_subpanel
+        @student_page.select_note_topic @topic
+        @student_page.click_search_button
+        expect(@search_results.note_in_search_result? @note).to be true
+      end
+
+      it 'is returned in search results for any appointments that include the topic' do
+        expect(@search_results.appt_in_search_result? @appt).to be true
+      end
+
+      it 'shows its usage in both notes and appointments' do
+        @search_results.log_out
+        @homepage.dev_auth
+        @homepage.click_flight_deck_link
+        @flight_deck.search_for_topic @topic
+        expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
+        expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
+      end
+    end
+
+    context 'when it is deleted' do
+
+      before(:all) { @flight_deck.delete_topic @topic }
+
+      it('shows as deleted on the Flight Deck') { expect(@flight_deck.topic_deleted? @topic).to be true }
+
+      it 'shows null availability in both notes and appointments' do
+        expect(@flight_deck.topic_in_notes @topic).to eql('—')
+        expect(@flight_deck.topic_in_appts @topic).to eql('—')
+      end
+
+      it 'shows its usage in both notes and appointments' do
+        expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
+        expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
+      end
+
+      it 'cannot be selected for an individual note' do
+        @flight_deck.log_out
+        @homepage.dev_auth @test.advisor
+        @student_page.load_page @student
+        @student_page.click_create_new_note
+        expect(@student_page.topic_options).not_to include(@topic.name)
+      end
+
+      it 'cannot be selected for a batch note' do
+        @student_page.hit_escape
+        @student_page.click_create_note_batch
+        expect(@student_page.topic_options).not_to include(@topic.name)
+      end
+
+      it 'cannot be selected for a note template' do
+        @student_page.click_templates_button
+        @student_page.click_edit_template @template
+        expect(@student_page.topic_options).not_to include(@topic.name)
+      end
+
+      it 'cannot be selected for a drop-in appointment' do
+        @homepage.load_page
+        @homepage.click_new_appt
+        expect(@homepage.available_appt_reasons).not_to include(@topic.name)
+      end
+
+      it 'is returned in search results for any notes that include the topic' do
+        @homepage.hit_escape
+        @student_page.expand_search_options_notes_subpanel
+        @student_page.select_note_topic @topic
+        @student_page.click_search_button
+        expect(@search_results.note_in_search_result? @note).to be true
+      end
+
+      it 'is returned in search results for any appointments that include the topic' do
+        expect(@search_results.appt_in_search_result? @appt).to be true
+      end
+    end
+
+    context 'when it is un-deleted' do
+
+      before(:all) do
+        @search_results.log_out
+        @homepage.dev_auth
+        @homepage.click_flight_deck_link
+        @flight_deck.search_for_topic @topic
+        @flight_deck.undelete_topic @topic
+      end
+
+      it 'is returned in search results for any notes that include the topic' do
+        @student_page.expand_search_options_notes_subpanel
+        @student_page.select_note_topic @topic
+        @student_page.click_search_button
+        expect(@search_results.note_in_search_result? @note).to be true
+      end
+
+      it 'is returned in search results for any appointments that include the topic' do
+        expect(@search_results.appt_in_search_result? @appt).to be true
+      end
+    end
+
+    # TODO - sorting columns
+
   end
-
-  context 'when it is available to notes only' do
-
-    before(:all) do
-      @topic.for_appts = false
-      @flight_deck.edit_topic @topic
-      @flight_deck.log_out
-      @homepage.dev_auth @test.advisor
-    end
-
-    it 'can be selected for an individual note' do
-      @student_page.load_page @student
-      @student_page.click_create_new_note
-      expect(@student_page.topic_options).to include(@topic.name)
-    end
-
-    it 'can be selected for a batch note' do
-      @student_page.hit_escape
-      @student_page.click_create_note_batch
-      expect(@student_page.topic_options).to include(@topic.name)
-    end
-
-    it 'can be selected for a note template' do
-      @student_page.click_templates_button
-      @student_page.click_edit_template @template
-      expect(@student_page.topic_options).to include(@topic.name)
-    end
-
-    it 'cannot be selected for a drop-in appointment' do
-      @homepage.load_page
-      @homepage.click_new_appt
-      expect(@homepage.available_appt_reasons).not_to include(@topic.name)
-    end
-
-    it 'is returned in search results for any notes that include the topic' do
-      @homepage.hit_escape
-      @student_page.expand_search_options_notes_subpanel
-      @student_page.select_note_topic @topic
-      @student_page.click_search_button
-      expect(@search_results.note_in_search_result? @note).to be true
-    end
-
-    it 'is returned in search results for any appointments that include the topic' do
-      expect(@search_results.appt_in_search_result? @appt).to be true
-    end
-
-    it 'shows its usage in both notes and appointments' do
-      @search_results.log_out
-      @homepage.dev_auth
-      @homepage.click_flight_deck_link
-      @flight_deck.search_for_topic @topic
-      expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
-      expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
-    end
-  end
-
-  context 'when it is available to appointments only' do
-
-    before(:all) do
-      @topic.for_appts = true
-      @topic.for_notes = false
-      @flight_deck.edit_topic @topic
-      @flight_deck.log_out
-      @homepage.dev_auth @test.advisor
-    end
-
-    it 'cannot be selected for an individual note' do
-      @student_page.load_page @student
-      @student_page.click_create_new_note
-      expect(@student_page.topic_options).not_to include(@topic.name)
-    end
-
-    it 'cannot be selected for a batch note' do
-      @student_page.hit_escape
-      @student_page.click_create_note_batch
-      expect(@student_page.topic_options).not_to include(@topic.name)
-    end
-
-    it 'cannot be selected for a note template' do
-      @student_page.click_templates_button
-      @student_page.click_edit_template @template
-      expect(@student_page.topic_options).not_to include(@topic.name)
-    end
-
-    it 'can be selected for a drop-in appointment' do
-      @homepage.load_page
-      @homepage.click_new_appt
-      expect(@homepage.available_appt_reasons).to include(@topic.name)
-    end
-
-    it 'is returned in search results for any notes that include the topic' do
-      @homepage.hit_escape
-      @student_page.expand_search_options_notes_subpanel
-      @student_page.select_note_topic @topic
-      @student_page.click_search_button
-      expect(@search_results.note_in_search_result? @note).to be true
-    end
-
-    it 'is returned in search results for any appointments that include the topic' do
-      expect(@search_results.appt_in_search_result? @appt).to be true
-    end
-
-    it 'shows its usage in both notes and appointments' do
-      @search_results.log_out
-      @homepage.dev_auth
-      @homepage.click_flight_deck_link
-      @flight_deck.search_for_topic @topic
-      expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
-      expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
-    end
-  end
-
-  context 'when it is deleted' do
-
-    before(:all) { @flight_deck.delete_topic @topic }
-
-    it('shows as deleted on the Flight Deck') { expect(@flight_deck.topic_deleted? @topic).to be true }
-
-    it 'shows null availability in both notes and appointments' do
-      expect(@flight_deck.topic_in_notes @topic).to eql('—')
-      expect(@flight_deck.topic_in_appts @topic).to eql('—')
-    end
-
-    it 'shows its usage in both notes and appointments' do
-      expect(@flight_deck.topic_in_notes_count @topic).to eql('1')
-      expect(@flight_deck.topic_in_appts_count @topic).to eql('1')
-    end
-
-    it 'cannot be selected for an individual note' do
-      @flight_deck.log_out
-      @homepage.dev_auth @test.advisor
-      @student_page.load_page @student
-      @student_page.click_create_new_note
-      expect(@student_page.topic_options).not_to include(@topic.name)
-    end
-
-    it 'cannot be selected for a batch note' do
-      @student_page.hit_escape
-      @student_page.click_create_note_batch
-      expect(@student_page.topic_options).not_to include(@topic.name)
-    end
-
-    it 'cannot be selected for a note template' do
-      @student_page.click_templates_button
-      @student_page.click_edit_template @template
-      expect(@student_page.topic_options).not_to include(@topic.name)
-    end
-
-    it 'cannot be selected for a drop-in appointment' do
-      @homepage.load_page
-      @homepage.click_new_appt
-      expect(@homepage.available_appt_reasons).not_to include(@topic.name)
-    end
-
-    it 'is returned in search results for any notes that include the topic' do
-      @homepage.hit_escape
-      @student_page.expand_search_options_notes_subpanel
-      @student_page.select_note_topic @topic
-      @student_page.click_search_button
-      expect(@search_results.note_in_search_result? @note).to be true
-    end
-
-    it 'is returned in search results for any appointments that include the topic' do
-      expect(@search_results.appt_in_search_result? @appt).to be true
-    end
-  end
-
-  context 'when it is un-deleted' do
-
-    before(:all) do
-      @search_results.log_out
-      @homepage.dev_auth
-      @homepage.click_flight_deck_link
-      @flight_deck.search_for_topic @topic
-      @flight_deck.undelete_topic @topic
-    end
-
-    it 'is returned in search results for any notes that include the topic' do
-      @student_page.expand_search_options_notes_subpanel
-      @student_page.select_note_topic @topic
-      @student_page.click_search_button
-      expect(@search_results.note_in_search_result? @note).to be true
-    end
-
-    it 'is returned in search results for any appointments that include the topic' do
-      expect(@search_results.appt_in_search_result? @appt).to be true
-    end
-  end
-
-  # TODO - sorting columns
-
 end

--- a/spec/boac/boac_user_mgmt_spec.rb
+++ b/spec/boac/boac_user_mgmt_spec.rb
@@ -1,146 +1,190 @@
 require_relative '../../util/spec_helper'
 
-describe 'The BOAC passenger manifest' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'The BOAC passenger manifest' do
 
-  test = BOACTestConfig.new
-  test.user_mgmt
-  auth_users = BOACUtils.get_authorized_users
-  non_admin_depts = BOACDepartments::DEPARTMENTS - [BOACDepartments::ADMIN, BOACDepartments::NOTES_ONLY]
-  dept_advisors = non_admin_depts.map { |dept| {:dept => dept, :advisors => BOACUtils.get_dept_advisors(dept)} }
-  dept_advisors.keep_if { |a| a[:advisors].any? }
+    include Logging
 
-  before(:all) do
-    # Initialize a user for the add/edit user tests
-    @add_edit_user = BOACUser.new(
-        uid: BOACUtils.config['test_add_edit_uid'],
-        active: true,
-        can_access_canvas_data: true,
-        dept_memberships: [
-            DeptMembership.new(
-                dept: BOACDepartments::L_AND_S,
-                advisor_role: AdvisorRole::ADVISOR,
-                is_automated: true
-            )
-        ]
-    )
+    test = BOACTestConfig.new
+    test.user_mgmt
+    auth_users = BOACUtils.get_authorized_users
+    non_admin_depts = BOACDepartments::DEPARTMENTS - [BOACDepartments::ADMIN, BOACDepartments::NOTES_ONLY]
+    dept_advisors = non_admin_depts.map { |dept| {:dept => dept, :advisors => BOACUtils.get_dept_advisors(dept)} }
+    dept_advisors.keep_if { |a| a[:advisors].any? }
 
-    # Initialize users for the add/remove scheduler tests
-    @add_remove_advisor = auth_users.find { |u| (u.depts == [BOACDepartments::L_AND_S]) && u.can_access_advising_data }
-    @add_remove_scheduler = test.students.find { |s| s.uid == BOACUtils.config['test_add_remove_scheduler'].to_s }
+    before(:all) do
+      # Initialize a user for the add/edit user tests
+      @add_edit_user = BOACUser.new(
+          uid: BOACUtils.config['test_add_edit_uid'],
+          active: true,
+          can_access_canvas_data: true,
+          dept_memberships: [
+              DeptMembership.new(
+                  dept: BOACDepartments::L_AND_S,
+                  advisor_role: AdvisorRole::ADVISOR,
+                  is_automated: true
+              )
+          ]
+      )
 
-    # Hard delete the add/edit user and the add/remove scheduler in case they're still lying around from a previous test run
-    BOACUtils.hard_delete_auth_user @add_edit_user
-    BOACUtils.hard_delete_auth_user @add_remove_scheduler
-    auth_users.delete_if { |u| u.uid == @add_edit_user.uid || u.sis_id == @add_remove_scheduler.sis_id }
+      # Initialize users for the add/remove scheduler tests
+      @add_remove_advisor = auth_users.find { |u| (u.depts == [BOACDepartments::L_AND_S]) && u.can_access_advising_data }
+      @add_remove_scheduler = test.students.find { |s| s.uid == BOACUtils.config['test_add_remove_scheduler'].to_s }
 
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @admin_page = BOACFlightDeckPage.new @driver
-    @pax_manifest_page = BOACPaxManifestPage.new @driver
-    @class_page = BOACClassListViewPage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, @add_edit_user)
-    @intake_desk_page = BOACApptIntakeDeskPage.new @driver
-    @student_page = BOACStudentPage.new @driver
+      # Hard delete the add/edit user and the add/remove scheduler in case they're still lying around from a previous test run
+      BOACUtils.hard_delete_auth_user @add_edit_user
+      BOACUtils.hard_delete_auth_user @add_remove_scheduler
+      auth_users.delete_if { |u| u.uid == @add_edit_user.uid || u.sis_id == @add_remove_scheduler.sis_id }
 
-    @homepage.dev_auth
-    @homepage.click_pax_manifest_link
-    @pax_manifest_page.filter_mode_select_element.when_visible Utils.medium_wait
-  end
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @admin_page = BOACFlightDeckPage.new @driver
+      @pax_manifest_page = BOACPaxManifestPage.new @driver
+      @class_page = BOACClassListViewPage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, @add_edit_user)
+      @intake_desk_page = BOACApptIntakeDeskPage.new @driver
+      @student_page = BOACStudentPage.new @driver
 
-  after(:all) do
-    BOACUtils.hard_delete_auth_user @add_remove_scheduler
-    BOACUtils.hard_delete_auth_user @add_edit_user
-    Utils.quit_browser @driver
-  end
+      @homepage.dev_auth
+      @homepage.click_pax_manifest_link
+      @pax_manifest_page.filter_mode_select_element.when_visible Utils.medium_wait
+    end
 
-  it 'defaults to user search mode' do
-    expect(@pax_manifest_page.filter_mode_select).to eql('Search')
-    expect(@pax_manifest_page.user_search_input_element.visible?).to be true
-  end
+    after(:all) do
+      BOACUtils.hard_delete_auth_user @add_remove_scheduler
+      BOACUtils.hard_delete_auth_user @add_edit_user
+      Utils.quit_browser @driver
+    end
 
-  context 'in user search mode' do
-    auth_users.select { |u| u.uid.length == 7 }.shuffle.last(25).each do |user|
-      context "searching for UID #{user.uid}" do
-        before(:all) do
-          @pax_manifest_page.search_for_advisor user
-          @pax_manifest_page.wait_for_advisor_list
-          @pax_manifest_page.expand_user_row user
-        end
+    it 'defaults to user search mode' do
+      expect(@pax_manifest_page.filter_mode_select).to eql('Search')
+      expect(@pax_manifest_page.user_search_input_element.visible?).to be true
+    end
 
-        it("shows a search result for UID #{user.uid}") { expect(@pax_manifest_page.list_view_uids.first).to eql(user.uid) }
+    context 'in user search mode' do
+      auth_users.select { |u| u.uid.length == 7 }.shuffle.last(25).each do |user|
+        context "searching for UID #{user.uid}" do
+          before(:all) do
+            @pax_manifest_page.search_for_advisor user
+            @pax_manifest_page.wait_for_advisor_list
+            @pax_manifest_page.expand_user_row user
+          end
 
-        it("shows the department(s) for UID #{user.uid}") { expect(@pax_manifest_page.visible_advisor_depts(user).sort).to eql(user.depts.map(&:name).uniq.sort) }
+          it("shows a search result for UID #{user.uid}") { expect(@pax_manifest_page.list_view_uids.first).to eql(user.uid) }
 
-        it "shows the department role(s) for UID #{user.uid}" do
-          user.dept_memberships.each do |membership|
-            if membership.dept
-              expected_roles = []
-              expected_roles << 'Advisor' if membership.advisor_role == AdvisorRole::ADVISOR
-              expected_roles << 'Director' if membership.advisor_role == AdvisorRole::DIRECTOR
-              expected_roles << 'Scheduler' if membership.advisor_role == AdvisorRole::SCHEDULER
-              expected_roles << 'Drop-in Advisor' if membership.is_drop_in_advisor
-              visible_dept_roles = @pax_manifest_page.visible_dept_roles(user, membership.dept.code)
-              visible_roles = visible_dept_roles[/.*\(([^\)]*)/,1]
-              actual_roles = visible_roles.split(', ')
-              actual_roles.concat(actual_roles.pop.split(' and '))
-              expect(actual_roles).to eql(expected_roles)
+          it("shows the department(s) for UID #{user.uid}") { expect(@pax_manifest_page.visible_advisor_depts(user).sort).to eql(user.depts.map(&:name).uniq.sort) }
+
+          it "shows the department role(s) for UID #{user.uid}" do
+            user.dept_memberships.each do |membership|
+              if membership.dept
+                expected_roles = []
+                expected_roles << 'Advisor' if membership.advisor_role == AdvisorRole::ADVISOR
+                expected_roles << 'Director' if membership.advisor_role == AdvisorRole::DIRECTOR
+                expected_roles << 'Scheduler' if membership.advisor_role == AdvisorRole::SCHEDULER
+                expected_roles << 'Drop-in Advisor' if membership.is_drop_in_advisor
+                visible_dept_roles = @pax_manifest_page.visible_dept_roles(user, membership.dept.code)
+                visible_roles = visible_dept_roles[/.*\(([^\)]*)/, 1]
+                actual_roles = visible_roles.split(', ')
+                actual_roles.concat(actual_roles.pop.split(' and '))
+                expect(actual_roles).to eql(expected_roles)
+              end
             end
           end
-        end
 
-        it "shows the right Canvas permission for UID #{user.uid}" do
-          visible_user_details = @pax_manifest_page.get_user_details user
-          expect(visible_user_details['canAccessCanvasData']).to eql(user.can_access_canvas_data)
-        end
+          it "shows the right Canvas permission for UID #{user.uid}" do
+            visible_user_details = @pax_manifest_page.get_user_details user
+            expect(visible_user_details['canAccessCanvasData']).to eql(user.can_access_canvas_data)
+          end
 
-        it "shows the right admin permission for UID #{user.uid}" do
-          visible_user_details = @pax_manifest_page.get_user_details user
-          expect(visible_user_details['isAdmin']).to eql(user.is_admin)
-        end
+          it "shows the right admin permission for UID #{user.uid}" do
+            visible_user_details = @pax_manifest_page.get_user_details user
+            expect(visible_user_details['isAdmin']).to eql(user.is_admin)
+          end
 
-        it "shows the active/deleted status for UID #{user.uid}" do
-          visible_user_details = @pax_manifest_page.get_user_details user
-          expect(visible_user_details['deletedAt'] ? false : true).to eql(user.active)
-        end
+          it "shows the active/deleted status for UID #{user.uid}" do
+            visible_user_details = @pax_manifest_page.get_user_details user
+            expect(visible_user_details['deletedAt'] ? false : true).to eql(user.active)
+          end
 
-        it "shows the right blocked status for UID #{user.uid}" do
-          visible_user_details = @pax_manifest_page.get_user_details user
-          expect(visible_user_details['isBlocked']).to eql(user.is_blocked)
-        end
+          it "shows the right blocked status for UID #{user.uid}" do
+            visible_user_details = @pax_manifest_page.get_user_details user
+            expect(visible_user_details['isBlocked']).to eql(user.is_blocked)
+          end
 
-        it "shows the department membership type(s) for UID #{user.uid}" do
-          visible_user_details = @pax_manifest_page.get_user_details user
-          user.dept_memberships.each do |dept_role|
-            if dept_role.dept
-              visible_dept = visible_user_details['departments'].find { |d| d['code'] == dept_role.dept.code}
-              expect(visible_dept['automateMembership']).to eql(dept_role.is_automated)
+          it "shows the department membership type(s) for UID #{user.uid}" do
+            visible_user_details = @pax_manifest_page.get_user_details user
+            user.dept_memberships.each do |dept_role|
+              if dept_role.dept
+                visible_dept = visible_user_details['departments'].find { |d| d['code'] == dept_role.dept.code }
+                expect(visible_dept['automateMembership']).to eql(dept_role.is_automated)
+              end
             end
           end
-        end
 
-        it "shows a 'become' link if UID #{user.uid} is active" do
-          has_become_link = @pax_manifest_page.become_user_link_element(user).exists?
-          (user.active && user.uid != Utils.super_admin_uid) ? (expect(has_become_link).to be true) : (expect(has_become_link).to be false)
+          it "shows a 'become' link if UID #{user.uid} is active" do
+            has_become_link = @pax_manifest_page.become_user_link_element(user).exists?
+            (user.active && user.uid != Utils.super_admin_uid) ? (expect(has_become_link).to be true) : (expect(has_become_link).to be false)
+          end
         end
       end
     end
-  end
 
-  context 'in user filter mode' do
-    before { @pax_manifest_page.select_filter_mode }
+    context 'in user filter mode' do
+      before { @pax_manifest_page.select_filter_mode }
 
-    it 'shows all departments' do
-      expected_options = ['All'] + (dept_advisors.map { |a| a[:dept].name }).sort
-      expect(@pax_manifest_page.dept_select_options).to eql(expected_options)
+      it 'shows all departments' do
+        expected_options = ['All'] + (dept_advisors.map { |a| a[:dept].name }).sort
+        expect(@pax_manifest_page.dept_select_options).to eql(expected_options)
+      end
+
+      dept_advisors.each do |dept|
+        it "shows all the advisors in #{dept[:dept].name}" do
+          logger.info "Checking advisor list for #{dept[:dept].name}"
+          @pax_manifest_page.select_dept dept[:dept]
+          expected_uids = dept[:advisors].map(&:uid).sort
+          @pax_manifest_page.wait_for_advisor_list
+          visible_uids = @pax_manifest_page.list_view_uids.sort
+          @pax_manifest_page.wait_until(1, "Expected but not present: #{expected_uids - visible_uids}, present but not expected: #{visible_uids - expected_uids}") do
+            visible_uids == expected_uids
+          end
+        end
+      end
+
+      it 'shows some advisor names' do
+        @pax_manifest_page.select_all_depts
+        @pax_manifest_page.wait_for_advisor_list
+        visible_names = @pax_manifest_page.advisor_name_elements.map &:text
+        visible_names.keep_if { |n| !n.empty? }
+        expect(visible_names).not_to be_empty
+      end
+
+      it 'shows some advisor department titles' do
+        visible_dept_titles = @pax_manifest_page.advisor_dept_elements.map &:text
+        visible_dept_titles.keep_if { |t| !t.empty? }
+        expect(visible_dept_titles).not_to be_empty
+      end
+
+      it 'shows some advisor email addresses' do
+        visible_emails = @pax_manifest_page.advisor_email_elements.map { |e| e.attribute('href') }
+        visible_emails.keep_if { |e| !e.empty? }
+        expect(visible_emails).not_to be_empty
+      end
+
+      # TODO it 'allows an admin to sort users by Last Name ascending'
+      # TODO it 'allows an admin to sort users by Last Name descending'
+      # TODO it 'allows an admin to sort users by Last Login ascending'
+      # TODO it 'allows an admin to sort users by Last Login descending'
     end
 
-    dept_advisors.each do |dept|
-      it "shows all the advisors in #{dept[:dept].name}" do
-        logger.info "Checking advisor list for #{dept[:dept].name}"
-        @pax_manifest_page.select_dept dept[:dept]
-        expected_uids = dept[:advisors].map(&:uid).sort
+    context 'in BOA Admin mode' do
+      before { @pax_manifest_page.select_admin_mode }
+
+      it "shows all the admins" do
+        dept = BOACDepartments::ADMIN
+        logger.info "Checking users list for #{dept.name}"
+        admin_users = auth_users.select { |u| u.is_admin }
+        expected_uids = admin_users.map(&:uid).sort
         @pax_manifest_page.wait_for_advisor_list
         visible_uids = @pax_manifest_page.list_view_uids.sort
         @pax_manifest_page.wait_until(1, "Expected but not present: #{expected_uids - visible_uids}, present but not expected: #{visible_uids - expected_uids}") do
@@ -149,349 +193,308 @@ describe 'The BOAC passenger manifest' do
       end
     end
 
-    it 'shows some advisor names' do
-      @pax_manifest_page.select_all_depts
-      @pax_manifest_page.wait_for_advisor_list
-      visible_names = @pax_manifest_page.advisor_name_elements.map &:text
-      visible_names.keep_if { |n| !n.empty? }
-      expect(visible_names).not_to be_empty
-    end
+    context 'exporting all BOA users' do
 
-    it 'shows some advisor department titles' do
-      visible_dept_titles = @pax_manifest_page.advisor_dept_elements.map &:text
-      visible_dept_titles.keep_if { |t| !t.empty? }
-      expect(visible_dept_titles).not_to be_empty
-    end
+      before(:all) { @csv = @pax_manifest_page.download_boa_users }
 
-    it 'shows some advisor email addresses' do
-      visible_emails = @pax_manifest_page.advisor_email_elements.map { |e| e.attribute('href') }
-      visible_emails.keep_if { |e| !e.empty? }
-      expect(visible_emails).not_to be_empty
-    end
-
-    # TODO it 'allows an admin to sort users by Last Name ascending'
-    # TODO it 'allows an admin to sort users by Last Name descending'
-    # TODO it 'allows an admin to sort users by Last Login ascending'
-    # TODO it 'allows an admin to sort users by Last Login descending'
-  end
-
-  context 'in BOA Admin mode' do
-    before { @pax_manifest_page.select_admin_mode }
-
-    it "shows all the admins" do
-      dept = BOACDepartments::ADMIN
-      logger.info "Checking users list for #{dept.name}"
-      admin_users = auth_users.select { |u| u.is_admin }
-      expected_uids = admin_users.map(&:uid).sort
-      @pax_manifest_page.wait_for_advisor_list
-      visible_uids = @pax_manifest_page.list_view_uids.sort
-      @pax_manifest_page.wait_until(1, "Expected but not present: #{expected_uids - visible_uids}, present but not expected: #{visible_uids - expected_uids}") do
-        visible_uids == expected_uids
-      end
-    end
-  end
-
-  context 'exporting all BOA users' do
-
-    before(:all) { @csv = @pax_manifest_page.download_boa_users }
-
-    dept_advisors.each do |dept|
-      it "exports all #{dept[:dept].name} users" do
-        dept_user_uids = dept[:advisors].map &:uid
-        csv_dept_user_uids = @csv.map do |r|
-          if r[:department]&.include? "#{dept[:dept].code}:"
-            r[:uid].to_s
+      dept_advisors.each do |dept|
+        it "exports all #{dept[:dept].name} users" do
+          dept_user_uids = dept[:advisors].map &:uid
+          csv_dept_user_uids = @csv.map do |r|
+            if r[:department]&.include? "#{dept[:dept].code}:"
+              r[:uid].to_s
+            end
+          end
+          unexpected_advisors = csv_dept_user_uids.compact.uniq - dept_user_uids
+          missing_advisors = dept_user_uids - csv_dept_user_uids.compact.uniq
+          logger.debug "Unexpected #{dept[:dept].name} advisors: #{unexpected_advisors}" unless unexpected_advisors.empty?
+          logger.debug "Missing #{dept[:dept].name} advisors: #{missing_advisors}" unless missing_advisors.empty?
+          @pax_manifest_page.wait_until(1, "Unexpected #{dept[:dept].name} advisors: #{unexpected_advisors}. Missing #{dept[:dept].name} advisors: #{missing_advisors}") do
+            csv_dept_user_uids.compact.uniq.sort == dept_user_uids.sort
           end
         end
-        unexpected_advisors = csv_dept_user_uids.compact.uniq - dept_user_uids
-        missing_advisors = dept_user_uids - csv_dept_user_uids.compact.uniq
-        logger.debug "Unexpected #{dept[:dept].name} advisors: #{unexpected_advisors}" unless unexpected_advisors.empty?
-        logger.debug "Missing #{dept[:dept].name} advisors: #{missing_advisors}" unless missing_advisors.empty?
-        @pax_manifest_page.wait_until(1, "Unexpected #{dept[:dept].name} advisors: #{unexpected_advisors}. Missing #{dept[:dept].name} advisors: #{missing_advisors}") do
-          csv_dept_user_uids.compact.uniq.sort == dept_user_uids.sort
+      end
+
+      it 'generates valid data' do
+        first_names = []
+        last_names = []
+        uids = []
+        titles = []
+        emails = []
+        departments = []
+        appt_roles = []
+        can_access_canvas_data_flags = []
+        is_blocked_flags = []
+        last_logins = []
+        @csv.each do |r|
+          first_names << r[:first_name] if r[:first_name]
+          last_names << r[:last_name] if r[:last_name]
+          uids << r[:uid] if r[:uid]
+          titles << r[:title] if r[:title]
+          emails << r[:email] if r[:email]
+          departments << r[:department] if r[:department]
+          appt_roles << r[:appointment_roles] if r[:appointment_roles]
+          can_access_canvas_data_flags << r[:can_access_canvas_data]
+          is_blocked_flags << r[:is_blocked]
+          last_logins << r[:last_login] if r[:last_login]
+        end
+        logger.warn "The export CSV has #{@csv.count} rows, with #{first_names.length} first names, #{last_names.length} last names, and #{emails.length} emails"
+        expect(first_names).not_to be_empty
+        expect(last_names).not_to be_empty
+        expect(uids).not_to be_empty
+        expect(titles).not_to be_empty
+        expect(emails).not_to be_empty
+        expect(departments).not_to be_empty
+        expect(appt_roles).not_to be_empty
+        expect(can_access_canvas_data_flags).not_to be_empty
+        expect(is_blocked_flags).not_to be_empty
+        expect(last_logins).not_to be_empty
+      end
+    end
+
+    context 'in user adding mode' do
+
+      before(:all) { @pax_manifest_page.load_page }
+
+      it 'allows an admin to cancel adding a user' do
+        @pax_manifest_page.click_add_user
+        @pax_manifest_page.click_cancel_button
+      end
+
+      it 'allows an admin to add a user' do
+        @pax_manifest_page.add_user @add_edit_user
+        @pax_manifest_page.search_for_advisor @add_edit_user
+        @pax_manifest_page.wait_until(Utils.short_wait) { @pax_manifest_page.list_view_uids.include? @add_edit_user.uid.to_s }
+      end
+
+      it 'prevents an admin adding an existing user' do
+        @pax_manifest_page.click_add_user
+        @pax_manifest_page.enter_new_user_data @add_edit_user
+        @pax_manifest_page.dupe_user_el(@add_edit_user).when_visible Utils.short_wait
+      end
+    end
+
+    context 'in user edit mode' do
+
+      before(:each) { @pax_manifest_page.hit_escape }
+
+      it 'allows an admin to cancel an edit' do
+        @pax_manifest_page.click_edit_user @add_edit_user
+        @pax_manifest_page.click_cancel_button
+      end
+
+      it 'allows an admin to block a user' do
+        @add_edit_user.is_blocked = true
+        @pax_manifest_page.edit_user @add_edit_user
+        @pax_manifest_page.click_edit_user @add_edit_user
+        @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_blocked_cbx }
+        expect(@pax_manifest_page.is_blocked_cbx.selected?).to be true
+      end
+
+      it 'allows an admin to unblock a user' do
+        @add_edit_user.is_blocked = false
+        @pax_manifest_page.edit_user @add_edit_user
+        @pax_manifest_page.click_edit_user @add_edit_user
+        @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_blocked_cbx }
+        expect(@pax_manifest_page.is_blocked_cbx.selected?).to be false
+      end
+
+      it 'allows an admin to set a user\'s department membership to automated' do
+        @add_edit_user.dept_memberships.first.is_automated = true
+        @pax_manifest_page.edit_user @add_edit_user
+        @pax_manifest_page.click_edit_user @add_edit_user
+        @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_automated_dept_cbx @add_edit_user.dept_memberships.first.dept }
+        expect(@pax_manifest_page.is_automated_dept_cbx(@add_edit_user.dept_memberships.first.dept).selected?).to be true
+      end
+
+      it 'allows an admin to set a user\'s department membership to manual' do
+        @add_edit_user.dept_memberships.first.is_automated = false
+        @pax_manifest_page.edit_user @add_edit_user
+        @pax_manifest_page.click_edit_user @add_edit_user
+        @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_automated_dept_cbx @add_edit_user.dept_memberships.first.dept }
+        expect(@pax_manifest_page.is_automated_dept_cbx(@add_edit_user.dept_memberships.first.dept).selected?).to be false
+      end
+
+      context 'performing edits' do
+
+        before(:all) { @student = test.students.sample }
+
+        before(:each) do
+          @pax_manifest_page.hit_escape
+          @pax_manifest_page.log_out if @pax_manifest_page.header_dropdown?
+          @homepage.dev_auth
+          @pax_manifest_page.load_page
+          @pax_manifest_page.search_for_advisor @add_edit_user
+        end
+
+        it 'allows an admin to add an admin role to a user' do
+          @add_edit_user.is_admin = true
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @pax_manifest_page.load_page
+        end
+
+        it 'allows an admin to remove an admin role from a user' do
+          @add_edit_user.is_admin = false
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @pax_manifest_page.hit_page_url
+          @pax_manifest_page.wait_for_title 'Page not found'
+        end
+
+        it 'allows an admin to prevent a user from viewing Canvas data' do
+          @add_edit_user.can_access_canvas_data = false
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @class_page.hit_class_page_url('2198', '21595')
+          @class_page.wait_for_title 'Page not found'
+        end
+
+        it 'allows an admin to permit a user to view Canvas data' do
+          @add_edit_user.can_access_canvas_data = true
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @class_page.load_page('2198', '21595')
+        end
+
+        it 'allows an admin to prevent a user from viewing notes and appointments' do
+          @add_edit_user.can_access_advising_data = false
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @student_page.load_page @student
+          @student_page.wait_for_timeline
+          expect(@student_page.new_note_button?).to be false
+          expect(@student_page.notes_button?).to be false
+          expect(@student_page.appts_button?).to be false
+        end
+
+        it 'allows an admin to permit a user to view notes and appointments' do
+          @add_edit_user.can_access_advising_data = true
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @student_page.load_page @student
+          @student_page.wait_for_timeline
+          expect(@student_page.new_note_button?).to be true
+          expect(@student_page.notes_button?).to be true
+          expect(@student_page.appts_button?).to be true
+        end
+
+        it 'allows an admin to delete a user' do
+          @add_edit_user.active = false
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.log_out
+          @homepage.enter_dev_auth_creds @add_edit_user
+          @homepage.deleted_msg_element.when_visible Utils.short_wait
+        end
+
+        it 'allows an admin to un-delete a user' do
+          @add_edit_user.active = true
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.log_out
+          @homepage.dev_auth @add_edit_user
+        end
+
+        it 'allows an admin to give a user a department membership' do
+          @add_edit_user.dept_memberships << DeptMembership.new(dept: BOACDepartments::ASC, advisor_role: AdvisorRole::ADVISOR)
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+          expect(@cohort_page.new_filter_option('groupCodes').visible?).to be true
+        end
+
+        it 'allows an admin to remove a user\'s department membership' do
+          asc_role = @add_edit_user.dept_memberships.find { |r| r.dept == BOACDepartments::ASC }
+          @add_edit_user.dept_memberships.delete asc_role
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.wait_for_title 'Home'
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+          expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false
+        end
+
+        it 'allows an admin to give a user a department director role' do
+          @add_edit_user.dept_memberships.first.advisor_role = AdvisorRole::DIRECTOR
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.no_filtered_cohorts_msg_element.when_visible Utils.short_wait
+          expect(@homepage.new_appt_button?).to be false
+        end
+
+        it 'allows an admin to give a user a department scheduler role' do
+          @add_edit_user.dept_memberships.first.advisor_role = AdvisorRole::SCHEDULER
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @intake_desk_page.wait_for_title 'Drop-in Appointments Desk'
+          @intake_desk_page.new_appt_button_element.when_visible Utils.short_wait
+        end
+
+        it 'allows an admin to give a user a department advisor role' do
+          @add_edit_user.dept_memberships.first.advisor_role = AdvisorRole::ADVISOR
+          @pax_manifest_page.edit_user @add_edit_user
+          @pax_manifest_page.click_become_user_link_element @add_edit_user
+          @homepage.no_filtered_cohorts_msg_element.when_visible Utils.short_wait
+          expect(@homepage.new_appt_button?).to be false
         end
       end
     end
 
-    it 'generates valid data' do
-      first_names = []
-      last_names = []
-      uids = []
-      titles = []
-      emails = []
-      departments = []
-      appt_roles = []
-      can_access_canvas_data_flags = []
-      is_blocked_flags = []
-      last_logins = []
-      @csv.each do |r|
-        first_names << r[:first_name] if r[:first_name]
-        last_names << r[:last_name] if r[:last_name]
-        uids << r[:uid] if r[:uid]
-        titles << r[:title] if r[:title]
-        emails << r[:email] if r[:email]
-        departments << r[:department] if r[:department]
-        appt_roles << r[:appointment_roles] if r[:appointment_roles]
-        can_access_canvas_data_flags << r[:can_access_canvas_data]
-        is_blocked_flags << r[:is_blocked]
-        last_logins << r[:last_login] if r[:last_login]
-      end
-      logger.warn "The export CSV has #{@csv.count} rows, with #{first_names.length} first names, #{last_names.length} last names, and #{emails.length} emails"
-      expect(first_names).not_to be_empty
-      expect(last_names).not_to be_empty
-      expect(uids).not_to be_empty
-      expect(titles).not_to be_empty
-      expect(emails).not_to be_empty
-      expect(departments).not_to be_empty
-      expect(appt_roles).not_to be_empty
-      expect(can_access_canvas_data_flags).not_to be_empty
-      expect(is_blocked_flags).not_to be_empty
-      expect(last_logins).not_to be_empty
-    end
-  end
+    context 'in scheduler adding mode' do
 
-  context 'in user adding mode' do
-
-    before(:all) { @pax_manifest_page.load_page }
-
-    it 'allows an admin to cancel adding a user' do
-      @pax_manifest_page.click_add_user
-      @pax_manifest_page.click_cancel_button
-    end
-
-    it 'allows an admin to add a user' do
-      @pax_manifest_page.add_user @add_edit_user
-      @pax_manifest_page.search_for_advisor @add_edit_user
-      @pax_manifest_page.wait_until(Utils.short_wait) { @pax_manifest_page.list_view_uids.include? @add_edit_user.uid.to_s }
-    end
-
-    it 'prevents an admin adding an existing user' do
-      @pax_manifest_page.click_add_user
-      @pax_manifest_page.enter_new_user_data @add_edit_user
-      @pax_manifest_page.dupe_user_el(@add_edit_user).when_visible Utils.short_wait
-    end
-  end
-
-  context 'in user edit mode' do
-
-    before(:each) { @pax_manifest_page.hit_escape }
-
-    it 'allows an admin to cancel an edit' do
-      @pax_manifest_page.click_edit_user @add_edit_user
-      @pax_manifest_page.click_cancel_button
-    end
-
-    it 'allows an admin to block a user' do
-      @add_edit_user.is_blocked = true
-      @pax_manifest_page.edit_user @add_edit_user
-      @pax_manifest_page.click_edit_user @add_edit_user
-      @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_blocked_cbx }
-      expect(@pax_manifest_page.is_blocked_cbx.selected?).to be true
-    end
-
-    it 'allows an admin to unblock a user' do
-      @add_edit_user.is_blocked = false
-      @pax_manifest_page.edit_user @add_edit_user
-      @pax_manifest_page.click_edit_user @add_edit_user
-      @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_blocked_cbx }
-      expect(@pax_manifest_page.is_blocked_cbx.selected?).to be false
-    end
-
-    it 'allows an admin to set a user\'s department membership to automated' do
-      @add_edit_user.dept_memberships.first.is_automated = true
-      @pax_manifest_page.edit_user @add_edit_user
-      @pax_manifest_page.click_edit_user @add_edit_user
-      @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_automated_dept_cbx @add_edit_user.dept_memberships.first.dept }
-      expect(@pax_manifest_page.is_automated_dept_cbx(@add_edit_user.dept_memberships.first.dept).selected?).to be true
-    end
-
-    it 'allows an admin to set a user\'s department membership to manual' do
-      @add_edit_user.dept_memberships.first.is_automated = false
-      @pax_manifest_page.edit_user @add_edit_user
-      @pax_manifest_page.click_edit_user @add_edit_user
-      @pax_manifest_page.wait_until(2) { @pax_manifest_page.is_automated_dept_cbx @add_edit_user.dept_memberships.first.dept }
-      expect(@pax_manifest_page.is_automated_dept_cbx(@add_edit_user.dept_memberships.first.dept).selected?).to be false
-    end
-
-    context 'performing edits' do
-
-      before(:all) { @student = test.students.sample }
-
-      before(:each) do
-        @pax_manifest_page.hit_escape
-        @pax_manifest_page.log_out if @pax_manifest_page.header_dropdown?
-        @homepage.dev_auth
-        @pax_manifest_page.load_page
-        @pax_manifest_page.search_for_advisor @add_edit_user
+      it 'allows an advisor to add a scheduler' do
+        @homepage.log_out
+        @homepage.dev_auth @add_remove_advisor
+        @homepage.click_settings_link
+        @admin_page.add_scheduler @add_remove_scheduler
+        @admin_page.wait_until(Utils.short_wait) { @admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
       end
 
-      it 'allows an admin to add an admin role to a user' do
-        @add_edit_user.is_admin = true
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @pax_manifest_page.load_page
+      it 'allows a newly created scheduler to reach the intake desk' do
+        @homepage.log_out
+        @homepage.dev_auth @add_remove_scheduler
+        @intake_desk_page.new_appt_button_element.when_visible Utils.short_wait
+        expect(@intake_desk_page.title).to include('Drop-in Appointments Desk')
+      end
+    end
+
+    context 'in scheduler removing mode' do
+
+      it 'allows an advisor to cancel removing a scheduler' do
+        @homepage.log_out
+        @homepage.dev_auth @add_remove_advisor
+        @homepage.click_settings_link
+        @admin_page.click_remove_scheduler @add_remove_scheduler
+        @admin_page.click_cancel_remove_scheduler
+        @admin_page.wait_until(Utils.short_wait) { @admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
       end
 
-      it 'allows an admin to remove an admin role from a user' do
-        @add_edit_user.is_admin = false
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @pax_manifest_page.hit_page_url
-        @pax_manifest_page.wait_for_title 'Page not found'
+      it 'allows an advisor to remove a scheduler' do
+        @admin_page.remove_scheduler @add_remove_scheduler
+        @admin_page.wait_until(Utils.short_wait) { !@admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
       end
 
-      it 'allows an admin to prevent a user from viewing Canvas data' do
-        @add_edit_user.can_access_canvas_data = false
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @class_page.hit_class_page_url('2198', '21595')
-        @class_page.wait_for_title 'Page not found'
-      end
-
-      it 'allows an admin to permit a user to view Canvas data' do
-        @add_edit_user.can_access_canvas_data = true
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @class_page.load_page('2198', '21595')
-      end
-
-      it 'allows an admin to prevent a user from viewing notes and appointments' do
-        @add_edit_user.can_access_advising_data = false
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @student_page.load_page @student
-        @student_page.wait_for_timeline
-        expect(@student_page.new_note_button?).to be false
-        expect(@student_page.notes_button?).to be false
-        expect(@student_page.appts_button?).to be false
-      end
-
-      it 'allows an admin to permit a user to view notes and appointments' do
-        @add_edit_user.can_access_advising_data = true
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @student_page.load_page @student
-        @student_page.wait_for_timeline
-        expect(@student_page.new_note_button?).to be true
-        expect(@student_page.notes_button?).to be true
-        expect(@student_page.appts_button?).to be true
-      end
-
-      it 'allows an admin to delete a user' do
-        @add_edit_user.active = false
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.log_out
-        @homepage.enter_dev_auth_creds @add_edit_user
+      it 'prevents a removed scheduler from logging in' do
+        @admin_page.log_out
+        @homepage.enter_dev_auth_creds @add_remove_scheduler
         @homepage.deleted_msg_element.when_visible Utils.short_wait
       end
 
-      it 'allows an admin to un-delete a user' do
-        @add_edit_user.active = true
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.log_out
-        @homepage.dev_auth @add_edit_user
+      it 'allows an advisor to re-add a removed scheduler' do
+        @homepage.dev_auth @add_remove_advisor
+        @homepage.click_settings_link
+        @admin_page.add_scheduler @add_remove_scheduler
+        @admin_page.wait_until(Utils.short_wait) { @admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
       end
-
-      it 'allows an admin to give a user a department membership' do
-        @add_edit_user.dept_memberships << DeptMembership.new(dept: BOACDepartments::ASC, advisor_role: AdvisorRole::ADVISOR)
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
-        expect(@cohort_page.new_filter_option('groupCodes').visible?).to be true
-      end
-
-      it 'allows an admin to remove a user\'s department membership' do
-        asc_role = @add_edit_user.dept_memberships.find { |r| r.dept == BOACDepartments::ASC }
-        @add_edit_user.dept_memberships.delete asc_role
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.wait_for_title 'Home'
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
-        expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false
-      end
-
-      it 'allows an admin to give a user a department director role' do
-        @add_edit_user.dept_memberships.first.advisor_role = AdvisorRole::DIRECTOR
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.no_filtered_cohorts_msg_element.when_visible Utils.short_wait
-        expect(@homepage.new_appt_button?).to be false
-      end
-
-      it 'allows an admin to give a user a department scheduler role' do
-        @add_edit_user.dept_memberships.first.advisor_role = AdvisorRole::SCHEDULER
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @intake_desk_page.wait_for_title 'Drop-in Appointments Desk'
-        @intake_desk_page.new_appt_button_element.when_visible Utils.short_wait
-      end
-
-      it 'allows an admin to give a user a department advisor role' do
-        @add_edit_user.dept_memberships.first.advisor_role = AdvisorRole::ADVISOR
-        @pax_manifest_page.edit_user @add_edit_user
-        @pax_manifest_page.click_become_user_link_element @add_edit_user
-        @homepage.no_filtered_cohorts_msg_element.when_visible Utils.short_wait
-        expect(@homepage.new_appt_button?).to be false
-      end
-    end
-  end
-
-  context 'in scheduler adding mode' do
-
-    it 'allows an advisor to add a scheduler' do
-      @homepage.log_out
-      @homepage.dev_auth @add_remove_advisor
-      @homepage.click_settings_link
-      @admin_page.add_scheduler @add_remove_scheduler
-      @admin_page.wait_until(Utils.short_wait) { @admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
-    end
-
-    it 'allows a newly created scheduler to reach the intake desk' do
-      @homepage.log_out
-      @homepage.dev_auth @add_remove_scheduler
-      @intake_desk_page.new_appt_button_element.when_visible Utils.short_wait
-      expect(@intake_desk_page.title).to include('Drop-in Appointments Desk')
-    end
-  end
-
-  context 'in scheduler removing mode' do
-
-    it 'allows an advisor to cancel removing a scheduler' do
-      @homepage.log_out
-      @homepage.dev_auth @add_remove_advisor
-      @homepage.click_settings_link
-      @admin_page.click_remove_scheduler @add_remove_scheduler
-      @admin_page.click_cancel_remove_scheduler
-      @admin_page.wait_until(Utils.short_wait) { @admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
-    end
-
-    it 'allows an advisor to remove a scheduler' do
-      @admin_page.remove_scheduler @add_remove_scheduler
-      @admin_page.wait_until(Utils.short_wait) { !@admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
-    end
-
-    it 'prevents a removed scheduler from logging in' do
-      @admin_page.log_out
-      @homepage.enter_dev_auth_creds @add_remove_scheduler
-      @homepage.deleted_msg_element.when_visible Utils.short_wait
-    end
-
-    it 'allows an advisor to re-add a removed scheduler' do
-      @homepage.dev_auth @add_remove_advisor
-      @homepage.click_settings_link
-      @admin_page.add_scheduler @add_remove_scheduler
-      @admin_page.wait_until(Utils.short_wait) { @admin_page.visible_scheduler_uids.include? @add_remove_scheduler.uid }
     end
   end
 end

--- a/spec/boac/boac_user_role_admin_spec.rb
+++ b/spec/boac/boac_user_role_admin_spec.rb
@@ -1,183 +1,186 @@
 require_relative '../../util/spec_helper'
 
-describe 'An admin using BOAC' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'An admin using BOAC' do
 
-  test = BOACTestConfig.new
-  test.user_role_admin
+    include Logging
 
-  everyone_cohorts = BOACUtils.get_everyone_filtered_cohorts default: true
-  everyone_groups = BOACUtils.get_everyone_curated_groups
-  ce3_cohorts = BOACUtils.get_everyone_filtered_cohorts({admits: true}, BOACDepartments::ZCEEE)
+    test = BOACTestConfig.new
+    test.user_role_admin
 
-  before(:all) do
-    @service_announcement = "#{BOACUtils.config['service_announcement']} " * 15
-    @driver = Utils.launch_browser test.chrome_profile
-    @admin_page = BOACFlightDeckPage.new @driver
-    @api_admin_page = BOACApiAdminPage.new @driver
-    @api_section_page = BOACApiSectionPage.new @driver
-    @api_student_page = BOACApiStudentPage.new @driver
-    @class_page = BOACClassListViewPage.new @driver
-    @curated_group_page = BOACGroupPage.new @driver
-    @filtered_cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
-    @homepage = BOACHomePage.new @driver
-    @search_page = BOACSearchResultsPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @filtered_admit_page = BOACFilteredAdmitsPage.new @driver
-    @admit_page = BOACAdmitPage.new @driver
-
-    @homepage.dev_auth test.advisor
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  context 'visiting Everyone\'s Cohorts' do
+    everyone_cohorts = BOACUtils.get_everyone_filtered_cohorts default: true
+    everyone_groups = BOACUtils.get_everyone_curated_groups
+    ce3_cohorts = BOACUtils.get_everyone_filtered_cohorts({admits: true}, BOACDepartments::ZCEEE)
 
     before(:all) do
-      @homepage.load_page
-      @homepage.click_view_everyone_cohorts
+      @service_announcement = "#{BOACUtils.config['service_announcement']} " * 15
+      @driver = Utils.launch_browser test.chrome_profile
+      @admin_page = BOACFlightDeckPage.new @driver
+      @api_admin_page = BOACApiAdminPage.new @driver
+      @api_section_page = BOACApiSectionPage.new @driver
+      @api_student_page = BOACApiStudentPage.new @driver
+      @class_page = BOACClassListViewPage.new @driver
+      @curated_group_page = BOACGroupPage.new @driver
+      @filtered_cohort_page = BOACFilteredCohortPage.new(@driver, test.advisor)
+      @homepage = BOACHomePage.new @driver
+      @search_page = BOACSearchResultsPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @filtered_admit_page = BOACFilteredAdmitsPage.new @driver
+      @admit_page = BOACAdmitPage.new @driver
+
+      @homepage.dev_auth test.advisor
     end
 
-    it 'sees all default filtered cohorts' do
-      expected_cohort_names = everyone_cohorts.map(&:name).sort
-      visible_cohort_names = (@filtered_cohort_page.visible_everyone_cohorts.map &:name).sort
-      @filtered_cohort_page.wait_until(1, "Expected #{expected_cohort_names}, but got #{visible_cohort_names}") do
-        visible_cohort_names == expected_cohort_names
+    after(:all) { Utils.quit_browser @driver }
+
+    context 'visiting Everyone\'s Cohorts' do
+
+      before(:all) do
+        @homepage.load_page
+        @homepage.click_view_everyone_cohorts
+      end
+
+      it 'sees all default filtered cohorts' do
+        expected_cohort_names = everyone_cohorts.map(&:name).sort
+        visible_cohort_names = (@filtered_cohort_page.visible_everyone_cohorts.map &:name).sort
+        @filtered_cohort_page.wait_until(1, "Expected #{expected_cohort_names}, but got #{visible_cohort_names}") do
+          visible_cohort_names == expected_cohort_names
+        end
       end
     end
+
+    context 'visiting Everyone\'s Groups' do
+
+      before(:all) do
+        @homepage.load_page
+        @homepage.click_view_everyone_groups
+      end
+
+      it 'sees all curated groups' do
+        expected_group_names = everyone_groups.map(&:name).sort
+        visible_group_names = (@curated_group_page.visible_everyone_groups.map &:name).sort
+        @curated_group_page.wait_until(1, "Expected #{expected_group_names}, but got #{visible_group_names}") { visible_group_names == expected_group_names }
+      end
+    end
+
+    context 'performing a filtered cohort search' do
+
+      before(:all) do
+        @homepage.click_sidebar_create_filtered
+        @filtered_cohort_page.wait_for_update_and_click @filtered_cohort_page.new_filter_button_element
+        @filtered_cohort_page.wait_until(1) { @filtered_cohort_page.new_filter_option_elements.any? &:visible? }
+      end
+
+      it('sees a College filter') { expect(@filtered_cohort_page.new_filter_option('colleges').visible?).to be true }
+      it('sees an Entering Term filter') { expect(@filtered_cohort_page.new_filter_option('enteringTerms').visible?).to be true }
+      it('sees an Expected Graduation Term filter') { expect(@filtered_cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
+      it('sees a GPA (Cumulative) filter') { expect(@filtered_cohort_page.new_filter_option('gpaRanges').visible?).to be true }
+      it('sees a GPA (Last Term) filter') { expect(@filtered_cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
+      it('sees a Level filter') { expect(@filtered_cohort_page.new_filter_option('levels').visible?).to be true }
+      it('sees a Major filter') { expect(@filtered_cohort_page.new_filter_option('majors').visible?).to be true }
+      it('sees a Midpoint Deficient Grade filter') { expect(@filtered_cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
+      it('sees a Transfer Student filter') { expect(@filtered_cohort_page.new_filter_option('transfer').visible?).to be true }
+      it('sees a Units Completed filter') { expect(@filtered_cohort_page.new_filter_option('unitRanges').visible?).to be true }
+
+      it('sees an Ethnicity filter') { expect(@filtered_cohort_page.new_filter_option('ethnicities').visible?).to be true }
+      it('sees a Gender filter') { expect(@filtered_cohort_page.new_filter_option('genders').visible?).to be true }
+      it('sees an Underrepresented Minority filter') { expect(@filtered_cohort_page.new_filter_option('underrepresented').visible?).to be true }
+      it('sees a Visa Type filter') { expect(@filtered_cohort_page.new_filter_option('visaTypes').visible?).to be true }
+
+      it('sees an Inactive ASC filter') { expect(@filtered_cohort_page.new_filter_option('isInactiveAsc').visible?).to be true }
+      it('sees an Intensive filter') { expect(@filtered_cohort_page.new_filter_option('inIntensiveCohort').visible?).to be true }
+      it('sees a Team filter') { expect(@filtered_cohort_page.new_filter_option('groupCodes').visible?).to be true }
+
+      it('sees an Advisor (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be true }
+      it('sees a Ethnicity (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeEthnicities').visible?).to be true }
+      it('sees a Gender (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeGenders').visible?).to be true }
+      it('sees an Inactive COE filter') { expect(@filtered_cohort_page.new_filter_option('isInactiveCoe').visible?).to be true }
+      it('sees a Last Name filter') { expect(@filtered_cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
+      it('sees a My Curated Groups filter') { expect(@filtered_cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
+      it('sees a My Students filter') { expect(@filtered_cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+      it('sees a PREP filter') { expect(@filtered_cohort_page.new_filter_option('coePrepStatuses').visible?).to be true }
+      it('sees a Probation filter') { expect(@filtered_cohort_page.new_filter_option('coeProbation').visible?).to be true }
+      it('sees an Underrepresented Minority (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeUnderrepresented').visible?).to be true }
+    end
+
+    context 'performing a filtered admit search' do
+
+      before(:all) do
+        @homepage.hit_escape
+        @homepage.click_sidebar_create_ce3_filtered
+        @filtered_admit_page.wait_for_update_and_click @filtered_admit_page.new_filter_button_element
+        @filtered_admit_page.wait_until(1) { @filtered_admit_page.new_filter_option_elements.any? }
+      end
+
+      it('sees a Freshman or Transfer filter') { expect(@filtered_admit_page.new_filter_option('freshmanOrTransfer').visible?).to be true }
+      it('sees a Current SIR filter') { expect(@filtered_admit_page.new_filter_option('sir').visible?).to be true }
+      it('sees a College filter') { expect(@filtered_admit_page.new_filter_option('admitColleges').visible?).to be true }
+      it('sees an XEthnic filter') { expect(@filtered_admit_page.new_filter_option('xEthnicities').visible?).to be true }
+      it('sees a Hispanic filter') { expect(@filtered_admit_page.new_filter_option('isHispanic').visible?).to be true }
+      it('sees a UREM filter') { expect(@filtered_admit_page.new_filter_option('isUrem').visible?).to be true }
+      it('sees a First Generation College filter') { expect(@filtered_admit_page.new_filter_option('isFirstGenerationCollege').visible?).to be true }
+      it('sees an Application Fee Waiver filter') { expect(@filtered_admit_page.new_filter_option('hasFeeWaiver').visible?).to be true }
+      it('sees a Foster Care filter') { expect(@filtered_admit_page.new_filter_option('inFosterCare').visible?).to be true }
+      it('sees a Family Is Single Parent filter') { expect(@filtered_admit_page.new_filter_option('isFamilySingleParent').visible?).to be true }
+      it('sees a Student Is Single Parent filter') { expect(@filtered_admit_page.new_filter_option('isStudentSingleParent').visible?).to be true }
+      it('sees a Family Dependents filter') { expect(@filtered_admit_page.new_filter_option('familyDependentRanges').visible?).to be true }
+      it('sees a Student Dependents filter') { expect(@filtered_admit_page.new_filter_option('studentDependentRanges').visible?).to be true }
+      it('sees a Re-entry Status filter') { expect(@filtered_admit_page.new_filter_option('isReentry').visible?).to be true }
+      it('sees a Last School LCFF+ filter') { expect(@filtered_admit_page.new_filter_option('isLastSchoolLCFF').visible?).to be true }
+      it('sees a Special Program CEP filter') { expect(@filtered_admit_page.new_filter_option('specialProgramCep').visible?).to be true }
+    end
+
+    context 'visiting student API pages' do
+
+      it 'can see the ASC profile data for an ASC student on the student API page' do
+        filter = CohortFilter.new
+        filter.set_custom_filters asc_team: [Squad::WSF]
+        asc_sids = NessieFilterUtils.get_cohort_result(test, filter)
+        asc_student = test.students.find { |s| s.sis_id == asc_sids.first }
+        @api_student_page.get_data(@driver, asc_student)
+        expect(@api_student_page.asc_profile).not_to be_nil
+      end
+
+      it 'can see the CoE profile data for a CoE student on the student API page' do
+        filter = CohortFilter.new
+        filter.set_custom_filters coe_gender: ['F']
+        coe_sids = NessieFilterUtils.get_cohort_result(test, filter)
+        coe_student = test.students.find { |s| s.sis_id == coe_sids.first }
+        @api_student_page.get_data(@driver, coe_student)
+        expect(@api_student_page.coe_profile).not_to be_nil
+      end
+    end
+
+    context 'navigating directly to a CE3 cohort' do
+
+      it("can reach cohort ID #{ce3_cohorts.first.id}") { @filtered_admit_page.load_cohort ce3_cohorts.first }
+    end
+
+    context 'visiting the admin page' do
+
+      it 'sees a link to the admin page' do
+        @homepage.load_page
+        @homepage.click_flight_deck_link
+      end
+
+      it 'can un-post a service alert' do
+        @admin_page.unpost_service_announcement
+        expect(@admin_page.service_announcement_banner?).to be false
+      end
+
+      it 'can post a service alert' do
+        @admin_page.update_service_announcement @service_announcement
+        @admin_page.post_service_announcement
+        expect(@admin_page.service_announcement_banner).to eql @service_announcement
+      end
+
+      it 'can update a posted service alert' do
+        @service_announcement = "UPDATE - #{@service_announcement}"
+        @admin_page.update_service_announcement @service_announcement
+        @admin_page.wait_until(Utils.short_wait) { @admin_page.service_announcement_banner == @service_announcement }
+      end
+    end
+
   end
-
-  context 'visiting Everyone\'s Groups' do
-
-    before(:all) do
-      @homepage.load_page
-      @homepage.click_view_everyone_groups
-    end
-
-    it 'sees all curated groups' do
-      expected_group_names = everyone_groups.map(&:name).sort
-      visible_group_names = (@curated_group_page.visible_everyone_groups.map &:name).sort
-      @curated_group_page.wait_until(1, "Expected #{expected_group_names}, but got #{visible_group_names}") { visible_group_names == expected_group_names }
-    end
-  end
-
-  context 'performing a filtered cohort search' do
-
-    before(:all) do
-      @homepage.click_sidebar_create_filtered
-      @filtered_cohort_page.wait_for_update_and_click @filtered_cohort_page.new_filter_button_element
-      @filtered_cohort_page.wait_until(1) { @filtered_cohort_page.new_filter_option_elements.any? &:visible? }
-    end
-
-    it('sees a College filter') { expect(@filtered_cohort_page.new_filter_option('colleges').visible?).to be true }
-    it('sees an Entering Term filter') { expect(@filtered_cohort_page.new_filter_option('enteringTerms').visible?).to be true }
-    it('sees an Expected Graduation Term filter') { expect(@filtered_cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
-    it('sees a GPA (Cumulative) filter') { expect(@filtered_cohort_page.new_filter_option('gpaRanges').visible?).to be true }
-    it('sees a GPA (Last Term) filter') { expect(@filtered_cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
-    it('sees a Level filter') { expect(@filtered_cohort_page.new_filter_option('levels').visible?).to be true }
-    it('sees a Major filter') { expect(@filtered_cohort_page.new_filter_option('majors').visible?).to be true }
-    it('sees a Midpoint Deficient Grade filter') { expect(@filtered_cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
-    it('sees a Transfer Student filter') { expect(@filtered_cohort_page.new_filter_option('transfer').visible?).to be true }
-    it('sees a Units Completed filter') { expect(@filtered_cohort_page.new_filter_option('unitRanges').visible?).to be true }
-
-    it('sees an Ethnicity filter') { expect(@filtered_cohort_page.new_filter_option('ethnicities').visible?).to be true }
-    it('sees a Gender filter') { expect(@filtered_cohort_page.new_filter_option('genders').visible?).to be true }
-    it('sees an Underrepresented Minority filter') { expect(@filtered_cohort_page.new_filter_option('underrepresented').visible?).to be true }
-    it('sees a Visa Type filter') { expect(@filtered_cohort_page.new_filter_option('visaTypes').visible?).to be true }
-
-    it('sees an Inactive ASC filter') { expect(@filtered_cohort_page.new_filter_option('isInactiveAsc').visible?).to be true }
-    it('sees an Intensive filter') { expect(@filtered_cohort_page.new_filter_option('inIntensiveCohort').visible?).to be true }
-    it('sees a Team filter') { expect(@filtered_cohort_page.new_filter_option('groupCodes').visible?).to be true }
-
-    it('sees an Advisor (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be true }
-    it('sees a Ethnicity (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeEthnicities').visible?).to be true }
-    it('sees a Gender (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeGenders').visible?).to be true }
-    it('sees an Inactive COE filter') { expect(@filtered_cohort_page.new_filter_option('isInactiveCoe').visible?).to be true }
-    it('sees a Last Name filter') { expect(@filtered_cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
-    it('sees a My Curated Groups filter') { expect(@filtered_cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
-    it('sees a My Students filter') { expect(@filtered_cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
-    it('sees a PREP filter') { expect(@filtered_cohort_page.new_filter_option('coePrepStatuses').visible?).to be true }
-    it('sees a Probation filter') { expect(@filtered_cohort_page.new_filter_option('coeProbation').visible?).to be true }
-    it('sees an Underrepresented Minority (COE) filter') { expect(@filtered_cohort_page.new_filter_option('coeUnderrepresented').visible?).to be true }
-  end
-
-  context 'performing a filtered admit search' do
-
-    before(:all) do
-      @homepage.hit_escape
-      @homepage.click_sidebar_create_ce3_filtered
-      @filtered_admit_page.wait_for_update_and_click @filtered_admit_page.new_filter_button_element
-      @filtered_admit_page.wait_until(1) { @filtered_admit_page.new_filter_option_elements.any? }
-    end
-
-    it('sees a Freshman or Transfer filter') { expect(@filtered_admit_page.new_filter_option('freshmanOrTransfer').visible?).to be true }
-    it('sees a Current SIR filter') { expect(@filtered_admit_page.new_filter_option('sir').visible?).to be true }
-    it('sees a College filter') { expect(@filtered_admit_page.new_filter_option('admitColleges').visible?).to be true }
-    it('sees an XEthnic filter') { expect(@filtered_admit_page.new_filter_option('xEthnicities').visible?).to be true }
-    it('sees a Hispanic filter') { expect(@filtered_admit_page.new_filter_option('isHispanic').visible?).to be true }
-    it('sees a UREM filter') { expect(@filtered_admit_page.new_filter_option('isUrem').visible?).to be true }
-    it('sees a First Generation College filter') { expect(@filtered_admit_page.new_filter_option('isFirstGenerationCollege').visible?).to be true }
-    it('sees an Application Fee Waiver filter') { expect(@filtered_admit_page.new_filter_option('hasFeeWaiver').visible?).to be true }
-    it('sees a Foster Care filter') { expect(@filtered_admit_page.new_filter_option('inFosterCare').visible?).to be true }
-    it('sees a Family Is Single Parent filter') { expect(@filtered_admit_page.new_filter_option('isFamilySingleParent').visible?).to be true }
-    it('sees a Student Is Single Parent filter') { expect(@filtered_admit_page.new_filter_option('isStudentSingleParent').visible?).to be true }
-    it('sees a Family Dependents filter') { expect(@filtered_admit_page.new_filter_option('familyDependentRanges').visible?).to be true }
-    it('sees a Student Dependents filter') { expect(@filtered_admit_page.new_filter_option('studentDependentRanges').visible?).to be true }
-    it('sees a Re-entry Status filter') { expect(@filtered_admit_page.new_filter_option('isReentry').visible?).to be true }
-    it('sees a Last School LCFF+ filter') { expect(@filtered_admit_page.new_filter_option('isLastSchoolLCFF').visible?).to be true }
-    it('sees a Special Program CEP filter') { expect(@filtered_admit_page.new_filter_option('specialProgramCep').visible?).to be true }
-  end
-
-  context 'visiting student API pages' do
-
-    it 'can see the ASC profile data for an ASC student on the student API page' do
-      filter = CohortFilter.new
-      filter.set_custom_filters asc_team: [Squad::WSF]
-      asc_sids = NessieFilterUtils.get_cohort_result(test, filter)
-      asc_student = test.students.find { |s| s.sis_id == asc_sids.first }
-      @api_student_page.get_data(@driver, asc_student)
-      expect(@api_student_page.asc_profile).not_to be_nil
-    end
-
-    it 'can see the CoE profile data for a CoE student on the student API page' do
-      filter = CohortFilter.new
-      filter.set_custom_filters coe_gender: ['F']
-      coe_sids = NessieFilterUtils.get_cohort_result(test, filter)
-      coe_student = test.students.find { |s| s.sis_id == coe_sids.first }
-      @api_student_page.get_data(@driver, coe_student)
-      expect(@api_student_page.coe_profile).not_to be_nil
-    end
-  end
-
-  context 'navigating directly to a CE3 cohort' do
-
-    it("can reach cohort ID #{ce3_cohorts.first.id}") { @filtered_admit_page.load_cohort ce3_cohorts.first }
-  end
-
-  context 'visiting the admin page' do
-
-    it 'sees a link to the admin page' do
-      @homepage.load_page
-      @homepage.click_flight_deck_link
-    end
-
-    it 'can un-post a service alert' do
-      @admin_page.unpost_service_announcement
-      expect(@admin_page.service_announcement_banner?).to be false
-    end
-
-    it 'can post a service alert' do
-      @admin_page.update_service_announcement @service_announcement
-      @admin_page.post_service_announcement
-      expect(@admin_page.service_announcement_banner).to eql @service_announcement
-    end
-
-    it 'can update a posted service alert' do
-      @service_announcement = "UPDATE - #{@service_announcement}"
-      @admin_page.update_service_announcement @service_announcement
-      @admin_page.wait_until(Utils.short_wait) { @admin_page.service_announcement_banner == @service_announcement }
-    end
-  end
-
 end

--- a/spec/boac/boac_user_role_advisor_spec.rb
+++ b/spec/boac/boac_user_role_advisor_spec.rb
@@ -1,710 +1,713 @@
 require_relative '../../util/spec_helper'
 
-describe 'A BOA advisor' do
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-  include Logging
+  describe 'A BOA advisor' do
 
-  before(:all) do
-    @test = BOACTestConfig.new
-    @test.user_role_advisor
+    include Logging
 
-    @test_asc = BOACTestConfig.new
-    @test_asc.user_role_asc @test
+    before(:all) do
+      @test = BOACTestConfig.new
+      @test.user_role_advisor
 
-    @test_coe = BOACTestConfig.new
-    @test_coe.user_role_coe @test
+      @test_asc = BOACTestConfig.new
+      @test_asc.user_role_asc @test
 
-    @admin_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::ADMIN)
-    @admin_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::ADMIN
+      @test_coe = BOACTestConfig.new
+      @test_coe.user_role_coe @test
 
-    @driver = Utils.launch_browser @test.chrome_profile
-    @homepage = BOACHomePage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @api_student_page = BOACApiStudentPage.new @driver
-    @admit_page = BOACAdmitPage.new @driver
-    @cohort_page = BOACFilteredCohortPage.new(@driver, @test_asc.advisor)
-    @group_page = BOACGroupPage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @settings_page = BOACFlightDeckPage.new @driver
-    @api_admin_page = BOACApiAdminPage.new @driver
+      @admin_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::ADMIN)
+      @admin_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::ADMIN
 
-    # Get ASC test data
-    filter = CohortFilter.new
-    filter.set_custom_filters asc_inactive: true
-    asc_sids = NessieFilterUtils.get_cohort_result(@test_asc, filter)
-    @asc_test_student = @test.students.find { |s| s.sis_id == asc_sids.first }
-    @homepage.dev_auth @test_asc.advisor
-    api_page = BOACApiStudentPage.new @driver
-    api_page.get_data(@driver, @asc_test_student)
-    @asc_test_student_sports = api_page.asc_teams
-    @homepage.load_page
-    @homepage.log_out
+      @driver = Utils.launch_browser @test.chrome_profile
+      @homepage = BOACHomePage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @api_student_page = BOACApiStudentPage.new @driver
+      @admit_page = BOACAdmitPage.new @driver
+      @cohort_page = BOACFilteredCohortPage.new(@driver, @test_asc.advisor)
+      @group_page = BOACGroupPage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @settings_page = BOACFlightDeckPage.new @driver
+      @api_admin_page = BOACApiAdminPage.new @driver
 
-    # Get CoE test data
-    filter = CohortFilter.new
-    filter.set_custom_filters coe_inactive: true
-    coe_sids = NessieFilterUtils.get_cohort_result(@test_coe, filter)
-    @coe_test_student = @test.students.find { |s| s.sis_id == coe_sids.first }
-
-    # Get L&S test data
-    @test_l_and_s = BOACTestConfig.new
-    @test_l_and_s.user_role_l_and_s @test
-    @l_and_s_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::L_AND_S)
-    @l_and_s_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::L_AND_S
-
-    # Get admit data
-    admits = NessieUtils.get_admits
-    no_sir = admits.select { |a| !a.is_sir }
-    @admit = if no_sir.any?
-               no_sir.last
-             else
-               admits.last
-             end
-    logger.debug "The test admit's SID is #{@admit.sis_id}"
-    ce3_advisor = BOACUtils.get_dept_advisors(BOACDepartments::ZCEEE, DeptMembership.new(advisor_role: AdvisorRole::ADVISOR)).first
-    ce3_cohort_search = CohortAdmitFilter.new
-    ce3_cohort_search.set_custom_filters urem: true
-    @ce3_cohort = FilteredCohort.new search_criteria: ce3_cohort_search, name: "CE3 #{@test.id}"
-    @homepage.dev_auth ce3_advisor
-    @cohort_page.search_and_create_new_cohort(@ce3_cohort, admits: true)
-    @cohort_page.log_out
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  context 'with ASC' do
-
-    before(:all) { @homepage.dev_auth @test_asc.advisor }
-
-    after(:all) do
+      # Get ASC test data
+      filter = CohortFilter.new
+      filter.set_custom_filters asc_inactive: true
+      asc_sids = NessieFilterUtils.get_cohort_result(@test_asc, filter)
+      @asc_test_student = @test.students.find { |s| s.sis_id == asc_sids.first }
+      @homepage.dev_auth @test_asc.advisor
+      api_page = BOACApiStudentPage.new @driver
+      api_page.get_data(@driver, @asc_test_student)
+      @asc_test_student_sports = api_page.asc_teams
       @homepage.load_page
       @homepage.log_out
+
+      # Get CoE test data
+      filter = CohortFilter.new
+      filter.set_custom_filters coe_inactive: true
+      coe_sids = NessieFilterUtils.get_cohort_result(@test_coe, filter)
+      @coe_test_student = @test.students.find { |s| s.sis_id == coe_sids.first }
+
+      # Get L&S test data
+      @test_l_and_s = BOACTestConfig.new
+      @test_l_and_s.user_role_l_and_s @test
+      @l_and_s_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::L_AND_S)
+      @l_and_s_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::L_AND_S
+
+      # Get admit data
+      admits = NessieUtils.get_admits
+      no_sir = admits.select { |a| !a.is_sir }
+      @admit = if no_sir.any?
+                 no_sir.last
+               else
+                 admits.last
+               end
+      logger.debug "The test admit's SID is #{@admit.sis_id}"
+      ce3_advisor = BOACUtils.get_dept_advisors(BOACDepartments::ZCEEE, DeptMembership.new(advisor_role: AdvisorRole::ADVISOR)).first
+      ce3_cohort_search = CohortAdmitFilter.new
+      ce3_cohort_search.set_custom_filters urem: true
+      @ce3_cohort = FilteredCohort.new search_criteria: ce3_cohort_search, name: "CE3 #{@test.id}"
+      @homepage.dev_auth ce3_advisor
+      @cohort_page.search_and_create_new_cohort(@ce3_cohort, admits: true)
+      @cohort_page.log_out
     end
 
-    context 'visiting Everyone\'s Cohorts' do
+    after(:all) { Utils.quit_browser @driver }
 
-      it 'sees only filtered cohorts created by ASC advisors' do
-        expected = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::ASC).map(&:id).sort
-        visible = (@cohort_page.visible_everyone_cohorts.map &:id).sort
-        @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+    context 'with ASC' do
+
+      before(:all) { @homepage.dev_auth @test_asc.advisor }
+
+      after(:all) do
+        @homepage.load_page
+        @homepage.log_out
       end
 
-      it 'cannot hit an admin filtered cohort URL' do
-        @admin_cohorts.any? ?
-            @cohort_page.hit_non_auth_cohort(@admin_cohorts.first) :
-            logger.warn('Skipping test for ASC access to admin cohorts because admins have no cohorts.')
+      context 'visiting Everyone\'s Cohorts' do
+
+        it 'sees only filtered cohorts created by ASC advisors' do
+          expected = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::ASC).map(&:id).sort
+          visible = (@cohort_page.visible_everyone_cohorts.map &:id).sort
+          @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        end
+
+        it 'cannot hit an admin filtered cohort URL' do
+          @admin_cohorts.any? ?
+              @cohort_page.hit_non_auth_cohort(@admin_cohorts.first) :
+              logger.warn('Skipping test for ASC access to admin cohorts because admins have no cohorts.')
+        end
+
+        it 'cannot hit a non-ASC filtered cohort URL' do
+          coe_everyone_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::COE)
+          coe_everyone_cohorts.any? ?
+              @cohort_page.hit_non_auth_cohort(coe_everyone_cohorts.first) :
+              logger.warn('Skipping test for ASC access to CoE cohorts because CoE has no cohorts.')
+        end
+
+        it('cannot hit a filtered admit cohort URL') { @cohort_page.hit_non_auth_cohort @ce3_cohort }
       end
 
-      it 'cannot hit a non-ASC filtered cohort URL' do
-        coe_everyone_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::COE)
-        coe_everyone_cohorts.any? ?
-            @cohort_page.hit_non_auth_cohort(coe_everyone_cohorts.first) :
-            logger.warn('Skipping test for ASC access to CoE cohorts because CoE has no cohorts.')
+      context 'visiting Everyone\'s Groups' do
+
+        it 'sees only curated groups created by ASC advisors' do
+          expected = BOACUtils.get_everyone_curated_groups(BOACDepartments::ASC).map(&:id).sort
+          visible = (@group_page.visible_everyone_groups.map &:id).sort
+          @group_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        end
+
+        it 'cannot hit an admin curated group URL' do
+          @admin_groups.any? ?
+              @group_page.hit_non_auth_group(@admin_groups.first) :
+              logger.warn('Skipping test for ASC access to admin curated groups because admins have no groups.')
+        end
+
+        it 'cannot hit a non-ASC curated group URL' do
+          coe_everyone_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::COE
+          coe_everyone_groups.any? ?
+              @group_page.hit_non_auth_group(coe_everyone_groups.first) :
+              logger.warn('Skipping test for ASC access to CoE curated groups because CoE has no groups.')
+        end
       end
 
-      it('cannot hit a filtered admit cohort URL') { @cohort_page.hit_non_auth_cohort @ce3_cohort }
-    end
+      context 'visiting a student page' do
 
-    context 'visiting Everyone\'s Groups' do
+        it 'sees team information' do
+          @student_page.load_page @asc_test_student
+          expect(@student_page.sports.sort).to eql(@asc_test_student_sports.sort)
+        end
 
-      it 'sees only curated groups created by ASC advisors' do
-        expected = BOACUtils.get_everyone_curated_groups(BOACDepartments::ASC).map(&:id).sort
-        visible = (@group_page.visible_everyone_groups.map &:id).sort
-        @group_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        it('sees ASC Inactive information') { expect(@student_page.inactive_asc_flag?).to be true }
+
+        it 'sees no COE Inactive information' do
+          @student_page.load_page @coe_test_student
+          expect(@student_page.inactive_coe_flag?).to be false
+        end
       end
 
-      it 'cannot hit an admin curated group URL' do
-        @admin_groups.any? ?
-            @group_page.hit_non_auth_group(@admin_groups.first) :
-            logger.warn('Skipping test for ASC access to admin curated groups because admins have no groups.')
+      context 'visiting a student API page' do
+
+        it 'cannot see COE profile data' do
+          api_page = BOACApiStudentPage.new @driver
+          api_page.get_data(@driver, @coe_test_student)
+          api_page.coe_profile.each_value { |v| expect(v).to be_nil }
+        end
       end
 
-      it 'cannot hit a non-ASC curated group URL' do
-        coe_everyone_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::COE
-        coe_everyone_groups.any? ?
-            @group_page.hit_non_auth_group(coe_everyone_groups.first) :
-            logger.warn('Skipping test for ASC access to CoE curated groups because CoE has no groups.')
-      end
-    end
+      context 'hitting an admit page' do
 
-    context 'visiting a student page' do
-
-      it 'sees team information' do
-        @student_page.load_page @asc_test_student
-        expect(@student_page.sports.sort).to eql(@asc_test_student_sports.sort)
+        it 'sees a 404' do
+          @admit_page.hit_page_url @admit.sis_id
+          @admit_page.wait_for_title 'Page not found'
+        end
       end
 
-      it('sees ASC Inactive information') { expect(@student_page.inactive_asc_flag?).to be true }
+      context 'hitting an admit endpoint' do
 
-      it 'sees no COE Inactive information' do
-        @student_page.load_page @coe_test_student
-        expect(@student_page.inactive_coe_flag?).to be false
+        it 'sees no data' do
+          if @admit
+            api_page = BOACApiAdmitPage.new @driver
+            api_page.hit_endpoint @admit
+            expect(api_page.message).to eql('Unauthorized')
+          else
+            skip
+          end
+        end
       end
-    end
 
-    context 'visiting a student API page' do
+      context 'visiting a cohort page' do
 
-      it 'cannot see COE profile data' do
-        api_page = BOACApiStudentPage.new @driver
-        api_page.get_data(@driver, @coe_test_student)
-        api_page.coe_profile.each_value { |v| expect(v).to be_nil }
+        before(:all) do
+          @inactive_search = CohortFilter.new
+          @inactive_search.set_custom_filters({:asc_inactive => true})
+          @inactive_cohort = FilteredCohort.new({:search_criteria => @inactive_search})
+
+          @homepage.load_page
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        end
+
+        it('sees a College filter') { expect(@cohort_page.new_filter_option('colleges').visible?).to be true }
+        it('sees an Entering Term filter') { expect(@cohort_page.new_filter_option('enteringTerms').visible?).to be true }
+        it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
+        it('sees a GPA (Cumulative) filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
+        it('sees a GPA (Last Term) filter') { expect(@cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
+        it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
+        it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
+        it('sees a Midpoint Deficient Grade filter') { expect(@cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
+        it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
+        it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+
+        it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
+        it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
+        it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented').visible?).to be true }
+        it('sees a Visa Type filter') { expect(@cohort_page.new_filter_option('visaTypes').visible?).to be true }
+
+        it('sees an Inactive ASC filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be true }
+        it('sees an Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be true }
+        it('sees a Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be true }
+
+        it('sees an Advisor (COE) filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be false }
+        it('sees a Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').visible?).to be false }
+        it('sees a Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').visible?).to be false }
+        it('sees an Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').visible?).to be false }
+        it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
+        it('sees a My Curated Groups filter') { expect(@cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
+        it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+        it('sees a PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').visible?).to be false }
+        it('sees a Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').visible?).to be false }
+        it('sees an Underrepresented Minority (COE) filter') { expect(@cohort_page.new_filter_option('coeUnderrepresented').visible?).to be false }
+
+        context 'with results' do
+
+          before(:all) do
+            @homepage.load_page
+            @homepage.click_sidebar_create_filtered
+            @cohort_page.perform_student_search @inactive_cohort
+          end
+
+          it('sees team information') do
+            visible_sports = @cohort_page.student_sports(@asc_test_student).sort
+            expect(visible_sports).to eql(@asc_test_student_sports.sort)
+          end
+          it('sees ASC Inactive information') { expect(@cohort_page.student_inactive_asc_flag? @asc_test_student).to be true }
+        end
       end
-    end
 
-    context 'hitting an admit page' do
+      context 'performing a search' do
 
-      it 'sees a 404' do
-        @admit_page.hit_page_url @admit.sis_id
-        @admit_page.wait_for_title 'Page not found'
+        it 'sees no Admits option' do
+          @homepage.expand_search_options
+          expect(@homepage.include_admits_cbx?).to be false
+        end
+
+        it 'sees no admit results' do
+          if @admit.is_sir
+            logger.warn 'Skipping admit search test since all admits have SIR'
+          else
+            @homepage.enter_string_and_hit_enter @admit.sis_id
+            @search_results_page.no_results_msg.when_visible Utils.short_wait
+          end
+        end
       end
-    end
 
-    context 'hitting an admit endpoint' do
+      context 'looking for admin functions' do
 
-      it 'sees no data' do
-        if @admit
-          api_page = BOACApiAdmitPage.new @driver
-          api_page.hit_endpoint @admit
-          expect(api_page.message).to eql('Unauthorized')
-        else
-          skip
+        before(:all) do
+          @homepage.load_page
+          @homepage.click_header_dropdown
+        end
+
+        it('can access the settings page') { expect(@homepage.settings_link?).to be true }
+        it('cannot access the flight deck page') { expect(@homepage.flight_deck_link?).to be false }
+        it('cannot access the passenger manifest page') { expect(@homepage.pax_manifest_link?).to be false }
+
+        it 'cannot toggle demo mode' do
+          @settings_page.load_advisor_page
+          @settings_page.my_profile_heading_element.when_visible Utils.short_wait
+          expect(@settings_page.demo_mode_toggle?).to be false
+        end
+
+        it('cannot post status alerts') { expect(@settings_page.status_heading?).to be false }
+
+        it 'cannot hit the cachejob page' do
+          @api_admin_page.load_cachejob
+          @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
         end
       end
     end
 
-    context 'visiting a cohort page' do
+    context 'with CoE' do
 
-      before(:all) do
-        @inactive_search = CohortFilter.new
-        @inactive_search.set_custom_filters({:asc_inactive => true})
-        @inactive_cohort = FilteredCohort.new({:search_criteria => @inactive_search})
+      before(:all) { @homepage.dev_auth @test_coe.advisor }
 
+      after(:all) do
         @homepage.load_page
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        @homepage.log_out
       end
 
-      it('sees a College filter') { expect(@cohort_page.new_filter_option('colleges').visible?).to be true }
-      it('sees an Entering Term filter') { expect(@cohort_page.new_filter_option('enteringTerms').visible?).to be true }
-      it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
-      it('sees a GPA (Cumulative) filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
-      it('sees a GPA (Last Term) filter') { expect(@cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
-      it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
-      it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
-      it('sees a Midpoint Deficient Grade filter') { expect(@cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
-      it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
-      it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+      context 'visiting Everyone\'s Cohorts' do
 
-      it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
-      it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
-      it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented').visible?).to be true }
-      it('sees a Visa Type filter') { expect(@cohort_page.new_filter_option('visaTypes').visible?).to be true }
+        it 'sees only filtered cohorts created by CoE advisors' do
+          expected = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::COE).map(&:id).sort
+          visible = (@cohort_page.visible_everyone_cohorts.map &:id).sort
+          @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        end
 
-      it('sees an Inactive ASC filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be true }
-      it('sees an Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be true }
-      it('sees a Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be true }
+        it 'cannot hit an admin filtered cohort URL' do
+          @admin_cohorts.any? ?
+              @cohort_page.hit_non_auth_cohort(@admin_cohorts.first) :
+              logger.warn('Skipping test for ASC access to admin cohorts because admins have no cohorts.')
+        end
 
-      it('sees an Advisor (COE) filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be false }
-      it('sees a Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').visible?).to be false }
-      it('sees a Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').visible?).to be false }
-      it('sees an Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').visible?).to be false }
-      it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
-      it('sees a My Curated Groups filter') { expect(@cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
-      it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
-      it('sees a PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').visible?).to be false }
-      it('sees a Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').visible?).to be false }
-      it('sees an Underrepresented Minority (COE) filter') { expect(@cohort_page.new_filter_option('coeUnderrepresented').visible?).to be false }
+        it 'cannot hit a non-COE filtered cohort URL' do
+          asc_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::ASC)
+          asc_cohorts.any? ?
+              @cohort_page.hit_non_auth_cohort(asc_cohorts.first) :
+              logger.warn('Skipping test for COE access to ASC cohorts because ASC has no cohorts.')
+        end
 
-      context 'with results' do
+        it('cannot hit a filtered admit cohort URL') { @cohort_page.hit_non_auth_cohort @ce3_cohort }
+
+      end
+
+      context 'visiting Everyone\'s Groups' do
+
+        it 'sees only curated groups created by CoE advisors' do
+          expected = BOACUtils.get_everyone_curated_groups(BOACDepartments::COE).map(&:id).sort
+          visible = (@group_page.visible_everyone_groups.map &:id).sort
+          @group_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        end
+
+        it 'cannot hit an admin curated group URL' do
+          @admin_groups.any? ?
+              @group_page.hit_non_auth_group(@admin_groups.first) :
+              logger.warn('Skipping test for ASC access to admin curated groups because admins have no groups.')
+        end
+
+        it 'cannot hit a non-COE curated group URL' do
+          asc_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::ASC
+          asc_groups.any? ?
+              @group_page.hit_non_auth_group(asc_groups.first) :
+              logger.warn('Skipping test for COE access to ASC curated groups because ASC has no groups.')
+        end
+      end
+
+      context 'visiting a COE student page' do
+
+        before(:all) { @student_page.load_page @coe_test_student }
+
+        it('sees COE Inactive information') { expect(@student_page.inactive_coe_flag?).to be true }
+      end
+
+      context 'visiting an ASC student page' do
+
+        before(:all) { @student_page.load_page @asc_test_student }
+
+        it('sees team information') { expect(@student_page.sports.sort).to eql(@asc_test_student_sports.sort) }
+        it('sees no ASC Inactive information') { expect(@student_page.inactive_asc_flag?).to be false }
+      end
+
+      context 'hitting an admit page' do
+
+        it 'sees a 404' do
+          @admit_page.hit_page_url @admit.sis_id
+          @admit_page.wait_for_title 'Page not found'
+        end
+      end
+
+      context 'hitting an admit endpoint' do
+
+        it 'sees no data' do
+          if @admit
+            api_page = BOACApiAdmitPage.new @driver
+            api_page.hit_endpoint @admit
+            expect(api_page.message).to eql('Unauthorized')
+          else
+            skip
+          end
+        end
+      end
+
+      context 'visiting a cohort page' do
+
+        before(:all) do
+          @inactive_search = CohortFilter.new
+          @inactive_search.set_custom_filters({:asc_inactive => true})
+          @inactive_cohort = FilteredCohort.new({:search_criteria => @inactive_search})
+
+          @homepage.load_page
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        end
+
+        it('sees a College filter') { expect(@cohort_page.new_filter_option('colleges').visible?).to be true }
+        it('sees an Entering Term filter') { expect(@cohort_page.new_filter_option('enteringTerms').visible?).to be true }
+        it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
+        it('sees a GPA (Cumulative) filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
+        it('sees a GPA (Last Term) filter') { expect(@cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
+        it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
+        it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
+        it('sees a Midpoint Deficient Grade filter') { expect(@cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
+        it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
+        it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+
+        it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
+        it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
+        it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented').visible?).to be true }
+        it('sees a Visa Type filter') { expect(@cohort_page.new_filter_option('visaTypes').visible?).to be true }
+
+        it('sees an Inactive ASC filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
+        it('sees an Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
+        it('sees a Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
+
+        it('sees an Advisor (COE) filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be true }
+        it('sees a Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').visible?).to be true }
+        it('sees a Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').visible?).to be true }
+        it('sees an Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').visible?).to be true }
+        it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
+        it('sees a My Curated Groups filter') { expect(@cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
+        it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+        it('sees a PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').visible?).to be true }
+        it('sees a Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').visible?).to be true }
+        it('sees an Underrepresented Minority (COE) filter') { expect(@cohort_page.new_filter_option('coeUnderrepresented').visible?).to be true }
+
+      end
+
+      context 'performing a search' do
+
+        it 'sees no Admits option' do
+          @homepage.expand_search_options
+          expect(@homepage.include_admits_cbx?).to be false
+        end
+
+        it 'sees no admit results' do
+          if @admit.is_sir
+            logger.warn 'Skipping admit search test since all admits have SIR'
+          else
+            @homepage.enter_string_and_hit_enter @admit.sis_id
+            @search_results_page.no_results_msg.when_visible Utils.short_wait
+          end
+        end
+      end
+
+      context 'looking for admin functions' do
+
+        before(:all) do
+          @homepage.load_page
+          @homepage.click_header_dropdown
+        end
+
+        it('can access the settings page') { expect(@homepage.settings_link?).to be true }
+        it('cannot access the flight deck page') { expect(@homepage.flight_deck_link?).to be false }
+        it('cannot access the passenger manifest page') { expect(@homepage.pax_manifest_link?).to be false }
+
+        it 'cannot toggle demo mode' do
+          @settings_page.load_advisor_page
+          @settings_page.my_profile_heading_element.when_visible Utils.short_wait
+          expect(@settings_page.demo_mode_toggle?).to be false
+        end
+
+        it('cannot post status alerts') { expect(@settings_page.status_heading?).to be false }
+
+        it 'cannot hit the cachejob page' do
+          @api_admin_page.load_cachejob
+          @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
+        end
+      end
+    end
+
+    context 'with a department other than ASC or COE' do
+
+      before(:all) { @homepage.dev_auth @test_l_and_s.advisor }
+
+      after(:all) do
+        @homepage.load_page
+        @homepage.log_out
+      end
+
+      context 'visiting Everyone\'s Cohorts' do
+
+        it 'sees only filtered cohorts created by advisors in its own department' do
+          expected = @l_and_s_cohorts.map(&:id).sort
+          visible = (@cohort_page.visible_everyone_cohorts.map &:id).sort
+          @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        end
+
+        it 'cannot hit an admin filtered cohort URL' do
+          @admin_cohorts.any? ?
+              @cohort_page.hit_non_auth_cohort(@admin_cohorts.first) :
+              logger.warn('Skipping test for ASC access to admin cohorts because admins have no cohorts.')
+        end
+
+        it('cannot hit a filtered admit cohort URL') { @cohort_page.hit_non_auth_cohort @ce3_cohort }
+      end
+
+      context 'visiting another user\'s cohort' do
+
+        before(:all) { @cohort_page.load_cohort @l_and_s_cohorts.find { |c| ![@test_l_and_s.advisor.uid, '70143'].include? c.owner_uid } }
+
+        it('can view the filters') { @cohort_page.show_filters }
+        it('cannot edit the filters') { expect(@cohort_page.cohort_edit_button_elements).to be_empty }
+        it('can export the student list') { expect(@cohort_page.export_list_button?).to be true }
+        it('cannot rename the cohort') { expect(@cohort_page.rename_cohort_button?).to be false }
+        it('cannot delete the cohort') { expect(@cohort_page.delete_cohort_button?).to be false }
+      end
+
+      context 'visiting Everyone\'s Groups' do
+
+        it 'sees only curated groups created by advisors in its own department' do
+          expected = @l_and_s_groups.map(&:id).sort
+          visible = (@group_page.visible_everyone_groups.map &:id).sort
+          @group_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
+        end
+
+        it 'cannot hit an admin curated group URL' do
+          @admin_groups.any? ?
+              @group_page.hit_non_auth_group(@admin_groups.first) :
+              logger.warn('Skipping test for ASC access to admin curated groups because admins have no groups.')
+        end
+      end
+
+      context 'visiting another user\'s curated group' do
+
+        before(:all) { @group_page.load_page @l_and_s_groups.find { |g| g.owner_uid != @test_l_and_s.advisor.uid } }
+
+        it('can export the student list') { expect(@group_page.export_list_button?).to be true }
+        it('cannot add students') { expect(@group_page.add_students_button?).to be false }
+        it('cannot rename the cohort') { expect(@group_page.rename_cohort_button?).to be false }
+        it('cannot delete the cohort') { expect(@group_page.delete_cohort_button?).to be false }
+      end
+
+      context 'visiting an ASC student page' do
+
+        before(:all) { @student_page.load_page @asc_test_student }
+
+        it('sees team information') { expect(@student_page.sports.sort).to eql(@asc_test_student_sports.sort) }
+        it('sees no ASC Inactive information') { expect(@student_page.inactive_asc_flag?).to be false }
+      end
+
+      context 'visiting a COE student page' do
+
+        before(:all) { @student_page.load_page @coe_test_student }
+
+        it('sees no COE Inactive information') { expect(@student_page.inactive_coe_flag?).to be false }
+      end
+
+      context 'visiting a student API page' do
+
+        it 'cannot see COE profile data on the student API page' do
+          api_page = BOACApiStudentPage.new @driver
+          api_page.get_data(@driver, @coe_test_student)
+          api_page.coe_profile.each_value { |v| expect(v).to be_nil }
+        end
+      end
+
+      context 'hitting an admit page' do
+
+        it 'sees a 404' do
+          @admit_page.hit_page_url @admit.sis_id
+          @admit_page.wait_for_title 'Page not found'
+        end
+      end
+
+      context 'hitting an admit endpoint' do
+
+        it 'sees no data' do
+          if @admit
+            api_page = BOACApiAdmitPage.new @driver
+            api_page.hit_endpoint @admit
+            expect(api_page.message).to eql('Unauthorized')
+          else
+            skip
+          end
+        end
+      end
+
+      context 'performing a filtered cohort search' do
 
         before(:all) do
           @homepage.load_page
           @homepage.click_sidebar_create_filtered
-          @cohort_page.perform_student_search @inactive_cohort
+          @cohort_page.wait_for_update_and_click @cohort_page.new_filter_button_element
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
         end
 
-        it('sees team information') do
-          visible_sports = @cohort_page.student_sports(@asc_test_student).sort
-          expect(visible_sports).to eql(@asc_test_student_sports.sort)
+        it('sees a College filter') { expect(@cohort_page.new_filter_option('colleges').visible?).to be true }
+        it('sees an Entering Term filter') { expect(@cohort_page.new_filter_option('enteringTerms').visible?).to be true }
+        it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
+        it('sees a GPA (Cumulative) filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
+        it('sees a GPA (Last Term) filter') { expect(@cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
+        it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
+        it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
+        it('sees a Midpoint Deficient Grade filter') { expect(@cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
+        it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
+        it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+
+        it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
+        it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
+        it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented').visible?).to be true }
+        it('sees a Visa Type filter') { expect(@cohort_page.new_filter_option('visaTypes').visible?).to be true }
+
+        it('sees an Inactive ASC filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
+        it('sees an Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
+        it('sees a Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
+
+        it('sees an Advisor (COE) filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be false }
+        it('sees a Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').visible?).to be false }
+        it('sees a Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').visible?).to be false }
+        it('sees an Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').visible?).to be false }
+        it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
+        it('sees a My Curated Groups filter') { expect(@cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
+        it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+        it('sees a PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').visible?).to be false }
+        it('sees a Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').visible?).to be false }
+        it('sees an Underrepresented Minority (COE) filter') { expect(@cohort_page.new_filter_option('coeUnderrepresented').visible?).to be false }
+
+      end
+
+      context 'performing a search' do
+
+        it 'sees no Admits option' do
+          @homepage.expand_search_options
+          expect(@homepage.include_admits_cbx?).to be false
         end
-        it('sees ASC Inactive information') { expect(@cohort_page.student_inactive_asc_flag? @asc_test_student).to be true }
+
+        it 'sees no admit results' do
+          if @admit.is_sir
+            logger.warn 'Skipping admit search test since all admits have SIR'
+          else
+            @homepage.enter_string_and_hit_enter @admit.sis_id
+            @search_results_page.no_results_msg.when_visible Utils.short_wait
+          end
+        end
+      end
+
+      context 'looking for admin functions' do
+
+        before(:all) do
+          @homepage.load_page
+          @homepage.click_header_dropdown
+        end
+
+        it('can access the settings page') { expect(@homepage.settings_link?).to be true }
+        it('cannot access the flight deck page') { expect(@homepage.flight_deck_link?).to be false }
+        it('cannot access the passenger manifest page') { expect(@homepage.pax_manifest_link?).to be false }
+
+        it 'cannot toggle demo mode' do
+          @settings_page.load_advisor_page
+          @settings_page.my_profile_heading_element.when_visible Utils.short_wait
+          expect(@settings_page.demo_mode_toggle?).to be false
+        end
+
+        it('cannot post status alerts') do
+          @settings_page.load_advisor_page
+          @settings_page.my_profile_heading_element.when_visible Utils.short_wait
+          expect(@settings_page.status_heading?).to be false
+        end
+
+        it 'cannot hit the cachejob page' do
+          @api_admin_page.load_cachejob
+          @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
+        end
       end
     end
 
-    context 'performing a search' do
-
-      it 'sees no Admits option' do
-        @homepage.expand_search_options
-        expect(@homepage.include_admits_cbx?).to be false
-      end
-
-      it 'sees no admit results' do
-        if @admit.is_sir
-          logger.warn 'Skipping admit search test since all admits have SIR'
-        else
-          @homepage.enter_string_and_hit_enter @admit.sis_id
-          @search_results_page.no_results_msg.when_visible Utils.short_wait
-        end
-      end
-    end
-
-    context 'looking for admin functions' do
+    context 'with assigned students' do
 
       before(:all) do
-        @homepage.load_page
-        @homepage.click_header_dropdown
+        plan = '25000U'
+        @test.advisor = NessieUtils.get_my_students_test_advisor plan
+        my_students_filter = CohortFilter.new
+        my_students_filter.set_custom_filters cohort_owner_academic_plans: [plan]
+        @my_students_cohort = FilteredCohort.new(search_criteria: my_students_filter, name: "My Students cohort #{@test.id}")
+
+        @homepage.dev_auth @test.advisor
       end
 
-      it('can access the settings page') { expect(@homepage.settings_link?).to be true }
-      it('cannot access the flight deck page') { expect(@homepage.flight_deck_link?).to be false }
-      it('cannot access the passenger manifest page') { expect(@homepage.pax_manifest_link?).to be false }
-
-      it 'cannot toggle demo mode' do
-        @settings_page.load_advisor_page
-        @settings_page.my_profile_heading_element.when_visible Utils.short_wait
-        expect(@settings_page.demo_mode_toggle?).to be false
-      end
-
-      it('cannot post status alerts') { expect(@settings_page.status_heading?).to be false }
-
-      it 'cannot hit the cachejob page' do
-        @api_admin_page.load_cachejob
-        @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
-      end
-    end
-  end
-
-  context 'with CoE' do
-
-    before(:all) { @homepage.dev_auth @test_coe.advisor }
-
-    after(:all) do
-      @homepage.load_page
-      @homepage.log_out
-    end
-
-    context 'visiting Everyone\'s Cohorts' do
-
-      it 'sees only filtered cohorts created by CoE advisors' do
-        expected = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::COE).map(&:id).sort
-        visible = (@cohort_page.visible_everyone_cohorts.map &:id).sort
-        @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
-      end
-
-      it 'cannot hit an admin filtered cohort URL' do
-        @admin_cohorts.any? ?
-            @cohort_page.hit_non_auth_cohort(@admin_cohorts.first) :
-            logger.warn('Skipping test for ASC access to admin cohorts because admins have no cohorts.')
-      end
-
-      it 'cannot hit a non-COE filtered cohort URL' do
-        asc_cohorts = BOACUtils.get_everyone_filtered_cohorts({default: true}, BOACDepartments::ASC)
-        asc_cohorts.any? ?
-            @cohort_page.hit_non_auth_cohort(asc_cohorts.first) :
-            logger.warn('Skipping test for COE access to ASC cohorts because ASC has no cohorts.')
-      end
-
-      it('cannot hit a filtered admit cohort URL') { @cohort_page.hit_non_auth_cohort @ce3_cohort }
-
-    end
-
-    context 'visiting Everyone\'s Groups' do
-
-      it 'sees only curated groups created by CoE advisors' do
-        expected = BOACUtils.get_everyone_curated_groups(BOACDepartments::COE).map(&:id).sort
-        visible = (@group_page.visible_everyone_groups.map &:id).sort
-        @group_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
-      end
-
-      it 'cannot hit an admin curated group URL' do
-        @admin_groups.any? ?
-            @group_page.hit_non_auth_group(@admin_groups.first) :
-            logger.warn('Skipping test for ASC access to admin curated groups because admins have no groups.')
-      end
-
-      it 'cannot hit a non-COE curated group URL' do
-        asc_groups = BOACUtils.get_everyone_curated_groups BOACDepartments::ASC
-        asc_groups.any? ?
-            @group_page.hit_non_auth_group(asc_groups.first) :
-            logger.warn('Skipping test for COE access to ASC curated groups because ASC has no groups.')
-      end
-    end
-
-    context 'visiting a COE student page' do
-
-      before(:all) { @student_page.load_page @coe_test_student }
-
-      it('sees COE Inactive information') { expect(@student_page.inactive_coe_flag?).to be true }
-    end
-
-    context 'visiting an ASC student page' do
-
-      before(:all) { @student_page.load_page @asc_test_student }
-
-      it('sees team information') { expect(@student_page.sports.sort).to eql(@asc_test_student_sports.sort) }
-      it('sees no ASC Inactive information') { expect(@student_page.inactive_asc_flag?).to be false }
-    end
-
-    context 'hitting an admit page' do
-
-      it 'sees a 404' do
-        @admit_page.hit_page_url @admit.sis_id
-        @admit_page.wait_for_title 'Page not found'
-      end
-    end
-
-    context 'hitting an admit endpoint' do
-
-      it 'sees no data' do
-        if @admit
-          api_page = BOACApiAdmitPage.new @driver
-          api_page.hit_endpoint @admit
-          expect(api_page.message).to eql('Unauthorized')
-        else
-          skip
-        end
-      end
-    end
-
-    context 'visiting a cohort page' do
-
-      before(:all) do
-        @inactive_search = CohortFilter.new
-        @inactive_search.set_custom_filters({:asc_inactive => true})
-        @inactive_cohort = FilteredCohort.new({:search_criteria => @inactive_search})
-
-        @homepage.load_page
+      it 'can perform a cohort search for My Students' do
         @homepage.click_sidebar_create_filtered
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
-      end
-
-      it('sees a College filter') { expect(@cohort_page.new_filter_option('colleges').visible?).to be true }
-      it('sees an Entering Term filter') { expect(@cohort_page.new_filter_option('enteringTerms').visible?).to be true }
-      it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
-      it('sees a GPA (Cumulative) filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
-      it('sees a GPA (Last Term) filter') { expect(@cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
-      it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
-      it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
-      it('sees a Midpoint Deficient Grade filter') { expect(@cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
-      it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
-      it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
-
-      it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
-      it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
-      it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented').visible?).to be true }
-      it('sees a Visa Type filter') { expect(@cohort_page.new_filter_option('visaTypes').visible?).to be true }
-
-      it('sees an Inactive ASC filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
-      it('sees an Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
-      it('sees a Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
-
-      it('sees an Advisor (COE) filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be true }
-      it('sees a Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').visible?).to be true }
-      it('sees a Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').visible?).to be true }
-      it('sees an Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').visible?).to be true }
-      it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
-      it('sees a My Curated Groups filter') { expect(@cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
-      it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
-      it('sees a PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').visible?).to be true }
-      it('sees a Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').visible?).to be true }
-      it('sees an Underrepresented Minority (COE) filter') { expect(@cohort_page.new_filter_option('coeUnderrepresented').visible?).to be true }
-
-    end
-
-    context 'performing a search' do
-
-      it 'sees no Admits option' do
-        @homepage.expand_search_options
-        expect(@homepage.include_admits_cbx?).to be false
-      end
-
-      it 'sees no admit results' do
-        if @admit.is_sir
-          logger.warn 'Skipping admit search test since all admits have SIR'
-        else
-          @homepage.enter_string_and_hit_enter @admit.sis_id
-          @search_results_page.no_results_msg.when_visible Utils.short_wait
+        @cohort_page.perform_student_search @my_students_cohort
+        @cohort_page.set_cohort_members(@my_students_cohort, @test)
+        expected = @my_students_cohort.members.map &:sis_id
+        visible = @cohort_page.visible_sids
+        @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
+          visible.sort == expected.sort
         end
       end
-    end
 
-    context 'looking for admin functions' do
-
-      before(:all) do
-        @homepage.load_page
-        @homepage.click_header_dropdown
+      it 'can export a My Students cohort with default columns' do
+        parsed_csv = @cohort_page.export_student_list @my_students_cohort
+        @cohort_page.verify_student_list_default_export(@my_students_cohort.members, parsed_csv)
       end
 
-      it('can access the settings page') { expect(@homepage.settings_link?).to be true }
-      it('cannot access the flight deck page') { expect(@homepage.flight_deck_link?).to be false }
-      it('cannot access the passenger manifest page') { expect(@homepage.pax_manifest_link?).to be false }
-
-      it 'cannot toggle demo mode' do
-        @settings_page.load_advisor_page
-        @settings_page.my_profile_heading_element.when_visible Utils.short_wait
-        expect(@settings_page.demo_mode_toggle?).to be false
+      it 'can export a My Students cohort with custom columns' do
+        parsed_csv = @cohort_page.export_custom_student_list @my_students_cohort
+        @cohort_page.verify_student_list_custom_export(@my_students_cohort.members, parsed_csv)
       end
 
-      it('cannot post status alerts') { expect(@settings_page.status_heading?).to be false }
-
-      it 'cannot hit the cachejob page' do
-        @api_admin_page.load_cachejob
-        @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
-      end
-    end
-  end
-
-  context 'with a department other than ASC or COE' do
-
-    before(:all) { @homepage.dev_auth @test_l_and_s.advisor }
-
-    after(:all) do
-      @homepage.load_page
-      @homepage.log_out
-    end
-
-    context 'visiting Everyone\'s Cohorts' do
-
-      it 'sees only filtered cohorts created by advisors in its own department' do
-        expected = @l_and_s_cohorts.map(&:id).sort
-        visible = (@cohort_page.visible_everyone_cohorts.map &:id).sort
-        @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
-      end
-
-      it 'cannot hit an admin filtered cohort URL' do
-        @admin_cohorts.any? ?
-            @cohort_page.hit_non_auth_cohort(@admin_cohorts.first) :
-            logger.warn('Skipping test for ASC access to admin cohorts because admins have no cohorts.')
-      end
-
-      it('cannot hit a filtered admit cohort URL') { @cohort_page.hit_non_auth_cohort @ce3_cohort }
-    end
-
-    context 'visiting another user\'s cohort' do
-
-      before(:all) { @cohort_page.load_cohort @l_and_s_cohorts.find { |c| ![@test_l_and_s.advisor.uid, '70143'].include? c.owner_uid } }
-
-      it('can view the filters') { @cohort_page.show_filters }
-      it('cannot edit the filters') { expect(@cohort_page.cohort_edit_button_elements).to be_empty }
-      it('can export the student list') { expect(@cohort_page.export_list_button?).to be true }
-      it('cannot rename the cohort') { expect(@cohort_page.rename_cohort_button?).to be false }
-      it('cannot delete the cohort') { expect(@cohort_page.delete_cohort_button?).to be false }
-    end
-
-    context 'visiting Everyone\'s Groups' do
-
-      it 'sees only curated groups created by advisors in its own department' do
-        expected = @l_and_s_groups.map(&:id).sort
-        visible = (@group_page.visible_everyone_groups.map &:id).sort
-        @group_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") { visible == expected }
-      end
-
-      it 'cannot hit an admin curated group URL' do
-        @admin_groups.any? ?
-            @group_page.hit_non_auth_group(@admin_groups.first) :
-            logger.warn('Skipping test for ASC access to admin curated groups because admins have no groups.')
-      end
-    end
-
-    context 'visiting another user\'s curated group' do
-
-      before(:all) { @group_page.load_page @l_and_s_groups.find { |g| g.owner_uid != @test_l_and_s.advisor.uid } }
-
-      it('can export the student list') { expect(@group_page.export_list_button?).to be true }
-      it('cannot add students') { expect(@group_page.add_students_button?).to be false }
-      it('cannot rename the cohort') { expect(@group_page.rename_cohort_button?).to be false }
-      it('cannot delete the cohort') { expect(@group_page.delete_cohort_button?).to be false }
-    end
-
-    context 'visiting an ASC student page' do
-
-      before(:all) { @student_page.load_page @asc_test_student }
-
-      it('sees team information') { expect(@student_page.sports.sort).to eql(@asc_test_student_sports.sort) }
-      it('sees no ASC Inactive information') { expect(@student_page.inactive_asc_flag?).to be false }
-    end
-
-    context 'visiting a COE student page' do
-
-      before(:all) { @student_page.load_page @coe_test_student }
-
-      it('sees no COE Inactive information') { expect(@student_page.inactive_coe_flag?).to be false }
-    end
-
-    context 'visiting a student API page' do
-
-      it 'cannot see COE profile data on the student API page' do
-        api_page = BOACApiStudentPage.new @driver
-        api_page.get_data(@driver, @coe_test_student)
-        api_page.coe_profile.each_value { |v| expect(v).to be_nil }
-      end
-    end
-
-    context 'hitting an admit page' do
-
-      it 'sees a 404' do
-        @admit_page.hit_page_url @admit.sis_id
-        @admit_page.wait_for_title 'Page not found'
-      end
-    end
-
-    context 'hitting an admit endpoint' do
-
-      it 'sees no data' do
-        if @admit
-          api_page = BOACApiAdmitPage.new @driver
-          api_page.hit_endpoint @admit
-          expect(api_page.message).to eql('Unauthorized')
-        else
-          skip
+      it 'has a My Students cohort visible to others' do
+        @cohort_page.create_new_cohort @my_students_cohort
+        @cohort_page.log_out
+        @homepage.dev_auth
+        @cohort_page.load_cohort @my_students_cohort
+        expected = @my_students_cohort.members.map &:sis_id
+        visible = @cohort_page.visible_sids
+        @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
+          visible.sort == expected.sort
         end
       end
-    end
 
-    context 'performing a filtered cohort search' do
-
-      before(:all) do
-        @homepage.load_page
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.wait_for_update_and_click @cohort_page.new_filter_button_element
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+      it 'has a My Students cohort that can be exported with default columns by another user' do
+        parsed_csv = @cohort_page.export_student_list @my_students_cohort
+        @cohort_page.verify_student_list_default_export(@my_students_cohort.members, parsed_csv)
       end
 
-      it('sees a College filter') { expect(@cohort_page.new_filter_option('colleges').visible?).to be true }
-      it('sees an Entering Term filter') { expect(@cohort_page.new_filter_option('enteringTerms').visible?).to be true }
-      it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
-      it('sees a GPA (Cumulative) filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
-      it('sees a GPA (Last Term) filter') { expect(@cohort_page.new_filter_option('lastTermGpaRanges').visible?).to be true }
-      it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
-      it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
-      it('sees a Midpoint Deficient Grade filter') { expect(@cohort_page.new_filter_option('midpointDeficient').visible?).to be true }
-      it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
-      it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
-
-      it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
-      it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
-      it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented').visible?).to be true }
-      it('sees a Visa Type filter') { expect(@cohort_page.new_filter_option('visaTypes').visible?).to be true }
-
-      it('sees an Inactive ASC filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
-      it('sees an Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
-      it('sees a Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
-
-      it('sees an Advisor (COE) filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').visible?).to be false }
-      it('sees a Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').visible?).to be false }
-      it('sees a Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').visible?).to be false }
-      it('sees an Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').visible?).to be false }
-      it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
-      it('sees a My Curated Groups filter') { expect(@cohort_page.new_filter_option('curatedGroupIds').visible?).to be true }
-      it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
-      it('sees a PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').visible?).to be false }
-      it('sees a Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').visible?).to be false }
-      it('sees an Underrepresented Minority (COE) filter') { expect(@cohort_page.new_filter_option('coeUnderrepresented').visible?).to be false }
-
-    end
-
-    context 'performing a search' do
-
-      it 'sees no Admits option' do
-        @homepage.expand_search_options
-        expect(@homepage.include_admits_cbx?).to be false
+      it 'has a My Students cohort that can be exported with custom columns by another user' do
+        parsed_csv = @cohort_page.export_custom_student_list @my_students_cohort
+        @cohort_page.verify_student_list_custom_export(@my_students_cohort.members, parsed_csv)
       end
-
-      it 'sees no admit results' do
-        if @admit.is_sir
-          logger.warn 'Skipping admit search test since all admits have SIR'
-        else
-          @homepage.enter_string_and_hit_enter @admit.sis_id
-          @search_results_page.no_results_msg.when_visible Utils.short_wait
-        end
-      end
-    end
-
-    context 'looking for admin functions' do
-
-      before(:all) do
-        @homepage.load_page
-        @homepage.click_header_dropdown
-      end
-
-      it('can access the settings page') { expect(@homepage.settings_link?).to be true }
-      it('cannot access the flight deck page') { expect(@homepage.flight_deck_link?).to be false }
-      it('cannot access the passenger manifest page') { expect(@homepage.pax_manifest_link?).to be false }
-
-      it 'cannot toggle demo mode' do
-        @settings_page.load_advisor_page
-        @settings_page.my_profile_heading_element.when_visible Utils.short_wait
-        expect(@settings_page.demo_mode_toggle?).to be false
-      end
-
-      it('cannot post status alerts') do
-        @settings_page.load_advisor_page
-        @settings_page.my_profile_heading_element.when_visible Utils.short_wait
-        expect(@settings_page.status_heading?).to be false
-      end
-
-      it 'cannot hit the cachejob page' do
-        @api_admin_page.load_cachejob
-        @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
-      end
-    end
-  end
-
-  context 'with assigned students' do
-
-    before(:all) do
-      plan = '25000U'
-      @test.advisor = NessieUtils.get_my_students_test_advisor plan
-      my_students_filter = CohortFilter.new
-      my_students_filter.set_custom_filters cohort_owner_academic_plans: [plan]
-      @my_students_cohort = FilteredCohort.new(search_criteria: my_students_filter, name: "My Students cohort #{@test.id}")
-
-      @homepage.dev_auth @test.advisor
-    end
-
-    it 'can perform a cohort search for My Students' do
-      @homepage.click_sidebar_create_filtered
-      @cohort_page.perform_student_search @my_students_cohort
-      @cohort_page.set_cohort_members(@my_students_cohort, @test)
-      expected = @my_students_cohort.members.map &:sis_id
-      visible = @cohort_page.visible_sids
-      @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
-        visible.sort == expected.sort
-      end
-    end
-
-    it 'can export a My Students cohort with default columns' do
-      parsed_csv = @cohort_page.export_student_list @my_students_cohort
-      @cohort_page.verify_student_list_default_export(@my_students_cohort.members, parsed_csv)
-    end
-
-    it 'can export a My Students cohort with custom columns' do
-      parsed_csv = @cohort_page.export_custom_student_list @my_students_cohort
-      @cohort_page.verify_student_list_custom_export(@my_students_cohort.members, parsed_csv)
-    end
-
-    it 'has a My Students cohort visible to others' do
-      @cohort_page.create_new_cohort @my_students_cohort
-      @cohort_page.log_out
-      @homepage.dev_auth
-      @cohort_page.load_cohort @my_students_cohort
-      expected = @my_students_cohort.members.map &:sis_id
-      visible = @cohort_page.visible_sids
-      @cohort_page.wait_until(1, "Missing: #{expected - visible}. Unexpected: #{visible - expected}") do
-        visible.sort == expected.sort
-      end
-    end
-
-    it 'has a My Students cohort that can be exported with default columns by another user' do
-      parsed_csv = @cohort_page.export_student_list @my_students_cohort
-      @cohort_page.verify_student_list_default_export(@my_students_cohort.members, parsed_csv)
-    end
-
-    it 'has a My Students cohort that can be exported with custom columns by another user' do
-      parsed_csv = @cohort_page.export_custom_student_list @my_students_cohort
-      @cohort_page.verify_student_list_custom_export(@my_students_cohort.members, parsed_csv)
     end
   end
 end

--- a/spec/boac/boac_user_role_director_spec.rb
+++ b/spec/boac/boac_user_role_director_spec.rb
@@ -1,63 +1,66 @@
 require_relative '../../util/spec_helper'
 
-test = BOACTestConfig.new
-test.user_role_director
+if (ENV['DEPS'] || ENV['DEPS'].nil?) && !ENV['NO_DEPS']
 
-test_cases = test.test_students.map do |student|
-  boa_notes = BOACUtils.get_student_notes student
-  sis_notes = NessieUtils.get_sis_notes student
-  ei_notes = NessieUtils.get_e_and_i_notes student
-  asc_notes = NessieUtils.get_asc_notes student
-  data_sci_notes = NessieUtils.get_data_sci_notes student
-  {student: student, notes: (boa_notes + sis_notes + ei_notes + asc_notes + data_sci_notes)}
-end
+  test = BOACTestConfig.new
+  test.user_role_director
 
-describe 'A BOA director' do
-
-  include Logging
-
-  before(:all) do
-
-    @driver = Utils.launch_browser
-    @homepage = BOACHomePage.new @driver
-    @student_page = BOACStudentPage.new @driver
-    @settings_page = BOACFlightDeckPage.new @driver
-    @api_admin_page = BOACApiAdminPage.new @driver
-
-    @homepage.dev_auth test.advisor
+  test_cases = test.test_students.map do |student|
+    boa_notes = BOACUtils.get_student_notes student
+    sis_notes = NessieUtils.get_sis_notes student
+    ei_notes = NessieUtils.get_e_and_i_notes student
+    asc_notes = NessieUtils.get_asc_notes student
+    data_sci_notes = NessieUtils.get_data_sci_notes student
+    {student: student, notes: (boa_notes + sis_notes + ei_notes + asc_notes + data_sci_notes)}
   end
 
-  after(:all) { Utils.quit_browser @driver }
+  describe 'A BOA director' do
 
-  it 'can enable a drop-in advising role' do
-    @settings_page.load_advisor_page
-    @settings_page.enable_drop_in_advising_role(test.advisor.dept_memberships.first)
-    @homepage.load_page
-    @homepage.new_appt_button_element.when_visible Utils.short_wait
-  end
+    include Logging
 
-  test_cases.each do |test_case|
-    it "can download a notes zip file for UID #{test_case[:student].uid}" do
-      @student_page.load_page test_case[:student]
-      @student_page.show_notes
-      @student_page.download_notes test_case[:student]
+    before(:all) do
+
+      @driver = Utils.launch_browser
+      @homepage = BOACHomePage.new @driver
+      @student_page = BOACStudentPage.new @driver
+      @settings_page = BOACFlightDeckPage.new @driver
+      @api_admin_page = BOACApiAdminPage.new @driver
+
+      @homepage.dev_auth test.advisor
     end
 
-    it "receives the right note export files for UID #{test_case[:student].uid}" do
-      expected_files = @student_page.expected_note_export_file_names(test_case[:student], test_case[:notes]).sort
-      actual_files = @student_page.note_export_file_names(test_case[:student]).sort
-      expect(actual_files).to eql(expected_files)
+    after(:all) { Utils.quit_browser @driver }
+
+    it 'can enable a drop-in advising role' do
+      @settings_page.load_advisor_page
+      @settings_page.enable_drop_in_advising_role(test.advisor.dept_memberships.first)
+      @homepage.load_page
+      @homepage.new_appt_button_element.when_visible Utils.short_wait
     end
 
-    it "receives a CSV containing the right number of notes for UID #{test_case[:student].uid}" do
-      csv = @student_page.parse_note_export_csv_to_table test_case[:student]
-      test_case.merge!({csv: csv})
-      expect(csv.entries.length).to eql(test_case[:notes].length)
-    end
+    test_cases.each do |test_case|
+      it "can download a notes zip file for UID #{test_case[:student].uid}" do
+        @student_page.load_page test_case[:student]
+        @student_page.show_notes
+        @student_page.download_notes test_case[:student]
+      end
 
-    test_case[:notes].each do |note|
-      it "receives a CSV containing the right data for UID #{test_case[:student].uid} note ID #{note.id}" do
-        @student_page.verify_note_in_export_csv(test_case[:student], note, test_case[:csv])
+      it "receives the right note export files for UID #{test_case[:student].uid}" do
+        expected_files = @student_page.expected_note_export_file_names(test_case[:student], test_case[:notes]).sort
+        actual_files = @student_page.note_export_file_names(test_case[:student]).sort
+        expect(actual_files).to eql(expected_files)
+      end
+
+      it "receives a CSV containing the right number of notes for UID #{test_case[:student].uid}" do
+        csv = @student_page.parse_note_export_csv_to_table test_case[:student]
+        test_case.merge!({csv: csv})
+        expect(csv.entries.length).to eql(test_case[:notes].length)
+      end
+
+      test_case[:notes].each do |note|
+        it "receives a CSV containing the right data for UID #{test_case[:student].uid} note ID #{note.id}" do
+          @student_page.verify_note_in_export_csv(test_case[:student], note, test_case[:csv])
+        end
       end
     end
   end

--- a/spec/boac/boac_user_role_restricted_spec.rb
+++ b/spec/boac/boac_user_role_restricted_spec.rb
@@ -1,431 +1,434 @@
 require_relative '../../util/spec_helper'
 
-describe 'A restricted BOA user' do
+if (ENV['NO_DEPS'] || ENV['NO_DEPS'].nil?) && !ENV['DEPS']
 
-  include Logging
+  describe 'A restricted BOA user' do
 
-  before(:all) do
-    @test = BOACTestConfig.new
-    @test.user_role_notes_only
-    @test_student = @test.test_students.sample
-
-    @driver = Utils.launch_browser @test.chrome_profile
-
-    @homepage = BOACHomePage.new @driver
-    @class_page = BOACClassListViewPage.new @driver
-    @flight_data_recorder = BOACFlightDataRecorderPage.new @driver
-    @flight_deck_page = BOACFlightDeckPage.new @driver
-    @group_page = BOACGroupPage.new @driver
-    @pax_manifest_page = BOACPaxManifestPage.new @driver
-    @search_results_page = BOACSearchResultsPage.new @driver
-    @settings_page = BOACFlightDeckPage.new @driver
-    @student_page = BOACStudentPage.new @driver
-
-    @api_admin_page = BOACApiAdminPage.new @driver
-    @api_notes_page = BOACApiNotesPage.new @driver
-    @api_section_page = BOACApiSectionPage.new @driver
-    @api_student_page = BOACApiStudentPage.new @driver
-  end
-
-  after(:all) { Utils.quit_browser @driver }
-
-  describe 'with no-Canvas-data BOA access' do
+    include Logging
 
     before(:all) do
-      @test.set_advisor { |advisor| !advisor.can_access_canvas_data && advisor.can_access_advising_data && advisor.depts.length == 1 }
-      @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-      @homepage.dev_auth @test.advisor
+      @test = BOACTestConfig.new
+      @test.user_role_notes_only
+      @test_student = @test.test_students.sample
+
+      @driver = Utils.launch_browser @test.chrome_profile
+
+      @homepage = BOACHomePage.new @driver
+      @class_page = BOACClassListViewPage.new @driver
+      @flight_data_recorder = BOACFlightDataRecorderPage.new @driver
+      @flight_deck_page = BOACFlightDeckPage.new @driver
+      @group_page = BOACGroupPage.new @driver
+      @pax_manifest_page = BOACPaxManifestPage.new @driver
+      @search_results_page = BOACSearchResultsPage.new @driver
+      @settings_page = BOACFlightDeckPage.new @driver
+      @student_page = BOACStudentPage.new @driver
+
+      @api_admin_page = BOACApiAdminPage.new @driver
+      @api_notes_page = BOACApiNotesPage.new @driver
+      @api_section_page = BOACApiSectionPage.new @driver
+      @api_student_page = BOACApiStudentPage.new @driver
     end
 
-    after(:all) { @homepage.log_out }
+    after(:all) { Utils.quit_browser @driver }
 
-    context 'visiting a student page' do
+    describe 'with no-Canvas-data BOA access' do
 
       before(:all) do
-        @api_student_page.get_data(@driver, @test_student)
-        @student_page.load_page @test_student
-        @student_page.click_view_previous_semesters if @api_student_page.terms.length > 1
-      end
-
-      it('sees a New Note button') { expect(@student_page.new_note_button_element).to be_visible }
-      it('sees a Notes tab') { expect(@student_page.notes_button_element).to be_visible }
-      it('sees an Appointments tab') { expect(@student_page.appts_button_element).to be_visible }
-
-      it 'sees notes' do
-        @student_page.show_notes
-        expect(@student_page.note_msg_row_elements.any?).to be true
-      end
-
-      it 'cannot expand courses' do
-        @api_student_page.terms.each do |term|
-          term['enrollments'].each do |course|
-            course['sections'].each do |section|
-              expect(@student_page.course_expand_toggle(term['termId'], section['ccn'])).not_to be_visible
-            end
-          end
-        end
-      end
-
-      it 'sees no links to course pages' do
-        @api_student_page.terms.each do |term|
-          term['enrollments'].each do |course|
-            course['sections'].each do |section|
-              expect(@student_page.class_page_link(term['termId'], section['ccn'])).not_to be_visible
-            end
-          end
-        end
-      end
-
-      it 'cannot see bCourses data in the API response' do
-        @api_student_page.get_data(@driver, @test_student)
-        @api_student_page.terms.each do |term|
-          term['enrollments'].each do |course|
-            expect(course['canvasSites']).to be_empty
-          end
-        end
-      end
-    end
-
-    context 'visiting a class page' do
-
-      it 'sees a 404 page' do
-        @class_page.hit_class_page_url('2178', '13826')
-        @class_page.wait_for_title 'Page not found'
-      end
-
-      it 'is forbidden' do
-        @api_section_page.get_data(@driver, '2178', '13826')
-        expect(@api_section_page).to be_unauthorized
-      end
-    end
-
-    context 'visiting a cohort page' do
-      before(:all) do
+        @test.set_advisor { |advisor| !advisor.can_access_canvas_data && advisor.can_access_advising_data && advisor.depts.length == 1 }
         @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-
-        @homepage.load_page
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        @homepage.dev_auth @test.advisor
       end
 
-      it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
-      it('sees a GPA filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
-      it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
-      it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
-      it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
-      it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+      after(:all) { @homepage.log_out }
 
-      it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
-      it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
-      it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented')) }
+      context 'visiting a student page' do
 
-      it('sees no Inactive (ASC) filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
-      it('sees no Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
-      it('sees no Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
+        before(:all) do
+          @api_student_page.get_data(@driver, @test_student)
+          @student_page.load_page @test_student
+          @student_page.click_view_previous_semesters if @api_student_page.terms.length > 1
+        end
 
-      it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
-      it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+        it('sees a New Note button') { expect(@student_page.new_note_button_element).to be_visible }
+        it('sees a Notes tab') { expect(@student_page.notes_button_element).to be_visible }
+        it('sees an Appointments tab') { expect(@student_page.appts_button_element).to be_visible }
 
-      it('sees no Advisor filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').exists?).to be false }
-      it('sees no Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').exists?).to be false }
-      it('sees no Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').exists?).to be false }
-      it('sees no Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').exists?).to be false }
-      it('sees no PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').exists?).to be false }
-      it('sees no Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').exists?).to be false }
+        it 'sees notes' do
+          @student_page.show_notes
+          expect(@student_page.note_msg_row_elements.any?).to be true
+        end
 
-      context 'with results' do
+        it 'cannot expand courses' do
+          @api_student_page.terms.each do |term|
+            term['enrollments'].each do |course|
+              course['sections'].each do |section|
+                expect(@student_page.course_expand_toggle(term['termId'], section['ccn'])).not_to be_visible
+              end
+            end
+          end
+        end
+
+        it 'sees no links to course pages' do
+          @api_student_page.terms.each do |term|
+            term['enrollments'].each do |course|
+              course['sections'].each do |section|
+                expect(@student_page.class_page_link(term['termId'], section['ccn'])).not_to be_visible
+              end
+            end
+          end
+        end
+
+        it 'cannot see bCourses data in the API response' do
+          @api_student_page.get_data(@driver, @test_student)
+          @api_student_page.terms.each do |term|
+            term['enrollments'].each do |course|
+              expect(course['canvasSites']).to be_empty
+            end
+          end
+        end
+      end
+
+      context 'visiting a class page' do
+
+        it 'sees a 404 page' do
+          @class_page.hit_class_page_url('2178', '13826')
+          @class_page.wait_for_title 'Page not found'
+        end
+
+        it 'is forbidden' do
+          @api_section_page.get_data(@driver, '2178', '13826')
+          expect(@api_section_page).to be_unauthorized
+        end
+      end
+
+      context 'visiting a cohort page' do
+        before(:all) do
+          @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
+
+          @homepage.load_page
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        end
+
+        it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
+        it('sees a GPA filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
+        it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
+        it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
+        it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
+        it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+
+        it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
+        it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
+        it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented')) }
+
+        it('sees no Inactive (ASC) filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
+        it('sees no Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
+        it('sees no Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
+
+        it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
+        it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+
+        it('sees no Advisor filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').exists?).to be false }
+        it('sees no Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').exists?).to be false }
+        it('sees no Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').exists?).to be false }
+        it('sees no Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').exists?).to be false }
+        it('sees no PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').exists?).to be false }
+        it('sees no Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').exists?).to be false }
+
+        context 'with results' do
+
+          before(:all) do
+            @homepage.load_page
+            @homepage.click_sidebar_create_filtered
+            @cohort_search = CohortFilter.new
+            @cohort_search.set_custom_filters({major: ['Art BA']})
+            @cohort = FilteredCohort.new({search_criteria: @cohort_search})
+
+            @cohort_page.perform_student_search @cohort
+            @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count > 0 }
+          end
+
+          it('sees no bCourses data') { expect(@cohort_page.site_activity_header_elements).to be_empty }
+        end
+      end
+
+      context 'visiting a group page' do
+
+        before(:all) do
+          @group_no_canvas = CuratedGroup.new(name: "Group #{@test.id}")
+          @homepage.click_sidebar_create_curated_group
+          @group_page.create_group_with_bulk_sids(@test.test_students, @group_no_canvas)
+        end
+
+        it('sees no bCourses data') { expect(@group_page.site_activity_header_elements).to be_empty }
+      end
+
+      context 'visiting the sidebar' do
+
+        it('sees no admitted students link') { expect(@homepage.all_admits_link?).to be false }
+        it('sees no link to create a CE3 cohort') { expect(@homepage.create_ce3_filtered_link?).to be false }
+        it('sees a batch note button') { expect(@homepage.batch_note_button_element).to be_visible }
+      end
+
+      context 'performing a search' do
 
         before(:all) do
           @homepage.load_page
-          @homepage.click_sidebar_create_filtered
-          @cohort_search = CohortFilter.new
-          @cohort_search.set_custom_filters({major: ['Art BA']})
-          @cohort = FilteredCohort.new({search_criteria: @cohort_search})
-
-          @cohort_page.perform_student_search @cohort
-          @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count > 0 }
+          @homepage.expand_search_options
         end
 
-        it('sees no bCourses data') { expect(@cohort_page.site_activity_header_elements).to be_empty }
+        it('sees a students search option') { expect(@homepage.include_students_cbx_element).to be_visible }
+        it('sees no admits search option') { expect(@homepage.include_admits_cbx_element).not_to be_visible }
+        it('sees no courses search option') { expect(@homepage.include_classes_cbx_element).not_to be_visible }
+        it('sees a notes/appointments search option') { expect(@homepage.include_notes_cbx_element).to be_visible }
+
+        context 'with results' do
+
+          before(:all) do
+            @homepage.type_non_note_string_and_enter 'Math'
+          end
+
+          it('sees student results') { expect(@search_results_page.student_search_results_count).to be_nonzero }
+          it('sees no course results') { expect(@search_results_page.class_results_count_element).not_to be_visible }
+          it('sees note results') { expect(@search_results_page.note_results_count).to be_nonzero }
+        end
+      end
+
+      context 'looking for admin functions' do
+        before(:all) do
+          @homepage.load_page
+          @homepage.click_header_dropdown
+        end
+
+        it('can see a Settings link') { expect(@homepage.settings_link?).to be true }
+        it('cannot see a Flight Deck link') { expect(@homepage.flight_deck_link?).to be false }
+        it('cannot see a Flight Data Recorder link') { expect(@homepage.flight_data_recorder_link?).to be false }
+        it('cannot see a Passenger Manifest link') { expect(@homepage.pax_manifest_link?).to be false }
+
+        it 'cannot post status alerts' do
+          @homepage.wait_for_update_and_click @homepage.settings_link_element
+          expect(@settings_page.status_heading?).to be false
+        end
+
+        it 'cannot reach the Passenger Manifest' do
+          @pax_manifest_page.hit_page_url
+          @pax_manifest_page.wait_for_title 'Page not found'
+        end
+
+        it 'cannot hit the cachejob page' do
+          @api_admin_page.load_cachejob
+          @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
+        end
       end
     end
 
-    context 'visiting a group page' do
+    describe 'with no-Canvas-data, no-notes, and no-appointments BOA access' do
 
       before(:all) do
-        @group_no_canvas = CuratedGroup.new(name: "Group #{@test.id}")
-        @homepage.click_sidebar_create_curated_group
-        @group_page.create_group_with_bulk_sids(@test.test_students, @group_no_canvas)
+        @test.set_advisor do |advisor|
+          advisor.depts.include?(BOACDepartments::OTHER.code) &&
+              advisor.depts.length == 1 &&
+              !advisor.can_access_canvas_data &&
+              !advisor.can_access_advising_data
+        end
+        @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
+        @homepage.dev_auth @test.advisor
       end
 
-      it('sees no bCourses data') { expect(@group_page.site_activity_header_elements).to be_empty }
-    end
+      after(:all) { @homepage.log_out }
 
-    context 'visiting the sidebar' do
-
-      it('sees no admitted students link') { expect(@homepage.all_admits_link?).to be false }
-      it('sees no link to create a CE3 cohort') { expect(@homepage.create_ce3_filtered_link?).to be false }
-      it('sees a batch note button') { expect(@homepage.batch_note_button_element).to be_visible }
-    end
-
-    context 'performing a search' do
-
-      before(:all) do
-        @homepage.load_page
-        @homepage.expand_search_options
-      end
-
-      it('sees a students search option') { expect(@homepage.include_students_cbx_element).to be_visible }
-      it('sees no admits search option') { expect(@homepage.include_admits_cbx_element).not_to be_visible }
-      it('sees no courses search option') { expect(@homepage.include_classes_cbx_element).not_to be_visible }
-      it('sees a notes/appointments search option') { expect(@homepage.include_notes_cbx_element).to be_visible }
-
-      context 'with results' do
+      context 'visiting a student page' do
 
         before(:all) do
-          @homepage.type_non_note_string_and_enter 'Math'
+          @api_student_page.get_data(@driver, @test_student)
+          @student_page.load_page @test_student
+          @student_page.click_view_previous_semesters if @api_student_page.terms.length > 1
         end
 
-        it('sees student results') { expect(@search_results_page.student_search_results_count).to be_nonzero }
-        it('sees no course results') { expect(@search_results_page.class_results_count_element).not_to be_visible }
-        it('sees note results') { expect(@search_results_page.note_results_count).to be_nonzero }
-      end
-    end
+        it('sees no New Note button') { expect(@student_page.new_note_button?).to be false }
+        it('sees no Notes tab') { expect(@student_page.notes_button?).to be false }
+        it('sees no Appointments tab') { expect(@student_page.appts_button?).to be false }
+        it('cannot see notes data in the API response') { expect(@api_student_page.notes).to be_nil }
+        it('cannot see appointments data in the API response') { expect(@api_student_page.appointments).to be_nil }
 
-    context 'looking for admin functions' do
-      before(:all) do
-        @homepage.load_page
-        @homepage.click_header_dropdown
-      end
+        it 'cannot expand courses' do
+          @api_student_page.terms.each do |term|
+            term['enrollments'].each do |course|
+              course['sections'].each do |section|
+                expect(@student_page.course_expand_toggle(term['termId'], section['ccn'])).not_to be_visible
+              end
+            end
+          end
+        end
 
-      it('can see a Settings link') { expect(@homepage.settings_link?).to be true }
-      it('cannot see a Flight Deck link') { expect(@homepage.flight_deck_link?).to be false }
-      it('cannot see a Flight Data Recorder link') { expect(@homepage.flight_data_recorder_link?).to be false }
-      it('cannot see a Passenger Manifest link') { expect(@homepage.pax_manifest_link?).to be false }
+        it 'sees no links to course pages' do
+          @api_student_page.terms.each do |term|
+            term['enrollments'].each do |course|
+              course['sections'].each do |section|
+                expect(@student_page.class_page_link(term['termId'], section['ccn'])).not_to be_visible
+              end
+            end
+          end
+        end
 
-      it 'cannot post status alerts' do
-        @homepage.wait_for_update_and_click @homepage.settings_link_element
-        expect(@settings_page.status_heading?).to be false
-      end
-
-      it 'cannot reach the Passenger Manifest' do
-        @pax_manifest_page.hit_page_url
-        @pax_manifest_page.wait_for_title 'Page not found'
-      end
-
-      it 'cannot hit the cachejob page' do
-        @api_admin_page.load_cachejob
-        @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
-      end
-    end
-  end
-
-  describe 'with no-Canvas-data, no-notes, and no-appointments BOA access' do
-
-    before(:all) do
-      @test.set_advisor do |advisor|
-            advisor.depts.include?(BOACDepartments::OTHER.code) &&
-            advisor.depts.length == 1 &&
-            !advisor.can_access_canvas_data &&
-            !advisor.can_access_advising_data
-      end
-      @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-      @homepage.dev_auth @test.advisor
-    end
-
-    after(:all) { @homepage.log_out }
-
-    context 'visiting a student page' do
-
-      before(:all) do
-        @api_student_page.get_data(@driver, @test_student)
-        @student_page.load_page @test_student
-        @student_page.click_view_previous_semesters if @api_student_page.terms.length > 1
-      end
-
-      it('sees no New Note button') { expect(@student_page.new_note_button?).to be false }
-      it('sees no Notes tab') { expect(@student_page.notes_button?).to be false }
-      it('sees no Appointments tab') { expect(@student_page.appts_button?).to be false }
-      it('cannot see notes data in the API response') { expect(@api_student_page.notes).to be_nil }
-      it('cannot see appointments data in the API response') { expect(@api_student_page.appointments).to be_nil }
-
-      it 'cannot expand courses' do
-        @api_student_page.terms.each do |term|
-          term['enrollments'].each do |course|
-            course['sections'].each do |section|
-              expect(@student_page.course_expand_toggle(term['termId'], section['ccn'])).not_to be_visible
+        it 'cannot see bCourses data in the API response' do
+          @api_student_page.get_data(@driver, @test_student)
+          @api_student_page.terms.each do |term|
+            term['enrollments'].each do |course|
+              expect(course['canvasSites']).to be_empty
             end
           end
         end
       end
 
-      it 'sees no links to course pages' do
-        @api_student_page.terms.each do |term|
-          term['enrollments'].each do |course|
-            course['sections'].each do |section|
-              expect(@student_page.class_page_link(term['termId'], section['ccn'])).not_to be_visible
-            end
-          end
+      it 'cannot download a note attachment' do
+        Utils.prepare_download_dir
+        attachment = BOACUtils.get_note_attachments.sample
+        @api_notes_page.load_attachment_page attachment.id
+        @api_notes_page.unauth_msg_element.when_visible Utils.short_wait
+        expect(Utils.downloads_empty?).to be true
+      end
+
+      context 'visiting a class page' do
+
+        it 'sees a 404 page' do
+          @class_page.hit_class_page_url('2178', '13826')
+          @class_page.wait_for_title 'Page not found'
+        end
+
+        it 'is forbidden' do
+          @api_section_page.get_data(@driver, '2178', '13826')
+          expect(@api_section_page).to be_unauthorized
         end
       end
 
-      it 'cannot see bCourses data in the API response' do
-        @api_student_page.get_data(@driver, @test_student)
-        @api_student_page.terms.each do |term|
-          term['enrollments'].each do |course|
-            expect(course['canvasSites']).to be_empty
+      context 'visiting a cohort page' do
+        before(:all) do
+          @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
+
+          @homepage.load_page
+          @homepage.click_sidebar_create_filtered
+          @cohort_page.click_new_filter_button
+          @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        end
+
+        it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
+        it('sees a GPA filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
+        it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
+        it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
+        it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
+        it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
+
+        it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
+        it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
+        it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented')) }
+
+        it('sees no Inactive (ASC) filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
+        it('sees no Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
+        it('sees no Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
+
+        it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
+        it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
+
+        it('sees no Advisor filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').exists?).to be false }
+        it('sees no Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').exists?).to be false }
+        it('sees no Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').exists?).to be false }
+        it('sees no Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').exists?).to be false }
+        it('sees no PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').exists?).to be false }
+        it('sees no Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').exists?).to be false }
+
+        context 'with results' do
+
+          before(:all) do
+            @homepage.load_page
+            @homepage.click_sidebar_create_filtered
+            @cohort_search = CohortFilter.new
+            @cohort_search.set_custom_filters({major: ['Art BA']})
+            @cohort = FilteredCohort.new({search_criteria: @cohort_search})
+
+            @cohort_page.perform_student_search @cohort
+            @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count > 0 }
           end
+
+          it('sees no bCourses data') { expect(@cohort_page.site_activity_header_elements).to be_empty }
         end
       end
-    end
 
-    it 'cannot download a note attachment' do
-      Utils.prepare_download_dir
-      attachment = BOACUtils.get_note_attachments.sample
-      @api_notes_page.load_attachment_page attachment.id
-      @api_notes_page.unauth_msg_element.when_visible Utils.short_wait
-      expect(Utils.downloads_empty?).to be true
-    end
+      context 'visiting a group page' do
 
-    context 'visiting a class page' do
+        before(:all) do
+          @group_no_canvas = CuratedGroup.new(name: "Group #{@test.id}")
+          @homepage.click_sidebar_create_curated_group
+          @group_page.create_group_with_bulk_sids(@test.test_students, @group_no_canvas)
+        end
 
-      it 'sees a 404 page' do
-        @class_page.hit_class_page_url('2178', '13826')
-        @class_page.wait_for_title 'Page not found'
+        it('sees no bCourses data') { expect(@group_page.site_activity_header_elements).to be_empty }
       end
 
-      it 'is forbidden' do
-        @api_section_page.get_data(@driver, '2178', '13826')
-        expect(@api_section_page).to be_unauthorized
-      end
-    end
+      context 'visiting the sidebar' do
 
-    context 'visiting a cohort page' do
-      before(:all) do
-        @cohort_page = BOACFilteredCohortPage.new(@driver, @test.advisor)
-
-        @homepage.load_page
-        @homepage.click_sidebar_create_filtered
-        @cohort_page.click_new_filter_button
-        @cohort_page.wait_until(1) { @cohort_page.new_filter_option_elements.any? &:visible? }
+        it('sees no admitted students link') { expect(@homepage.all_admits_link?).to be false }
+        it('sees no link to create a CE3 cohort') { expect(@homepage.create_ce3_filtered_link?).to be false }
+        it('sees no batch note button') { expect(@homepage.batch_note_button_element).not_to be_visible }
       end
 
-      it('sees an Expected Graduation Term filter') { expect(@cohort_page.new_filter_option('expectedGradTerms').visible?).to be true }
-      it('sees a GPA filter') { expect(@cohort_page.new_filter_option('gpaRanges').visible?).to be true }
-      it('sees a Level filter') { expect(@cohort_page.new_filter_option('levels').visible?).to be true }
-      it('sees a Major filter') { expect(@cohort_page.new_filter_option('majors').visible?).to be true }
-      it('sees a Transfer Student filter') { expect(@cohort_page.new_filter_option('transfer').visible?).to be true }
-      it('sees a Units Completed filter') { expect(@cohort_page.new_filter_option('unitRanges').visible?).to be true }
-
-      it('sees an Ethnicity filter') { expect(@cohort_page.new_filter_option('ethnicities').visible?).to be true }
-      it('sees a Gender filter') { expect(@cohort_page.new_filter_option('genders').visible?).to be true }
-      it('sees an Underrepresented Minority filter') { expect(@cohort_page.new_filter_option('underrepresented')) }
-
-      it('sees no Inactive (ASC) filter') { expect(@cohort_page.new_filter_option('isInactiveAsc').visible?).to be false }
-      it('sees no Intensive filter') { expect(@cohort_page.new_filter_option('inIntensiveCohort').visible?).to be false }
-      it('sees no Team filter') { expect(@cohort_page.new_filter_option('groupCodes').visible?).to be false }
-
-      it('sees a Last Name filter') { expect(@cohort_page.new_filter_option('lastNameRanges').visible?).to be true }
-      it('sees a My Students filter') { expect(@cohort_page.new_filter_option('cohortOwnerAcademicPlans').visible?).to be true }
-
-      it('sees no Advisor filter') { expect(@cohort_page.new_filter_option('coeAdvisorLdapUids').exists?).to be false }
-      it('sees no Ethnicity (COE) filter') { expect(@cohort_page.new_filter_option('coeEthnicities').exists?).to be false }
-      it('sees no Gender (COE) filter') { expect(@cohort_page.new_filter_option('coeGenders').exists?).to be false }
-      it('sees no Inactive (COE) filter') { expect(@cohort_page.new_filter_option('isInactiveCoe').exists?).to be false }
-      it('sees no PREP filter') { expect(@cohort_page.new_filter_option('coePrepStatuses').exists?).to be false }
-      it('sees no Probation filter') { expect(@cohort_page.new_filter_option('coeProbation').exists?).to be false }
-
-      context 'with results' do
+      context 'performing a search' do
 
         before(:all) do
           @homepage.load_page
-          @homepage.click_sidebar_create_filtered
-          @cohort_search = CohortFilter.new
-          @cohort_search.set_custom_filters({major: ['Art BA']})
-          @cohort = FilteredCohort.new({search_criteria: @cohort_search})
-
-          @cohort_page.perform_student_search @cohort
-          @cohort_page.wait_until(Utils.short_wait) { @cohort_page.results_count > 0 }
+          @homepage.expand_search_options
         end
 
-        it('sees no bCourses data') { expect(@cohort_page.site_activity_header_elements).to be_empty }
-      end
-    end
+        it('sees a students search option') { expect(@homepage.include_students_cbx_element).to be_visible }
+        it('sees no admits search option') { expect(@homepage.include_admits_cbx_element).not_to be_visible }
+        it('sees no courses search option') { expect(@homepage.include_classes_cbx_element).not_to be_visible }
+        it('sees no notes/appointments search option') { expect(@homepage.include_notes_cbx_element).not_to be_visible }
 
-    context 'visiting a group page' do
+        context 'with results' do
 
-      before(:all) do
-        @group_no_canvas = CuratedGroup.new(name: "Group #{@test.id}")
-        @homepage.click_sidebar_create_curated_group
-        @group_page.create_group_with_bulk_sids(@test.test_students, @group_no_canvas)
-      end
+          before(:all) do
+            @homepage.type_non_note_string_and_enter 'Math'
+          end
 
-      it('sees no bCourses data') { expect(@group_page.site_activity_header_elements).to be_empty }
-    end
-
-    context 'visiting the sidebar' do
-
-      it('sees no admitted students link') { expect(@homepage.all_admits_link?).to be false }
-      it('sees no link to create a CE3 cohort') { expect(@homepage.create_ce3_filtered_link?).to be false }
-      it('sees no batch note button') { expect(@homepage.batch_note_button_element).not_to be_visible }
-    end
-
-    context 'performing a search' do
-
-      before(:all) do
-        @homepage.load_page
-        @homepage.expand_search_options
+          it('sees student results') { expect(@search_results_page.student_search_results_count).to be_nonzero }
+          it('sees no course results') { expect(@search_results_page.class_results_count?).to be false }
+          it('sees no note results') { expect(@search_results_page.note_results_count_heading?).to be false }
+        end
       end
 
-      it('sees a students search option') { expect(@homepage.include_students_cbx_element).to be_visible }
-      it('sees no admits search option') { expect(@homepage.include_admits_cbx_element).not_to be_visible }
-      it('sees no courses search option') { expect(@homepage.include_classes_cbx_element).not_to be_visible }
-      it('sees no notes/appointments search option') { expect(@homepage.include_notes_cbx_element).not_to be_visible }
-
-      context 'with results' do
-
+      context 'looking for admin functions' do
         before(:all) do
-          @homepage.type_non_note_string_and_enter 'Math'
+          @homepage.load_page
+          @homepage.click_header_dropdown
         end
 
-        it('sees student results') { expect(@search_results_page.student_search_results_count).to be_nonzero }
-        it('sees no course results') { expect(@search_results_page.class_results_count?).to be false }
-        it('sees no note results') { expect(@search_results_page.note_results_count_heading?).to be false }
-      end
-    end
+        it('can see a Settings link') { expect(@homepage.settings_link?).to be true }
+        it('cannot see a Flight Deck link') { expect(@homepage.flight_deck_link?).to be false }
+        it('cannot see a Flight Data Recorder link') { expect(@homepage.flight_data_recorder_link?).to be false }
+        it('cannot see a Passenger Manifest link') { expect(@homepage.pax_manifest_link?).to be false }
 
-    context 'looking for admin functions' do
-      before(:all) do
-        @homepage.load_page
-        @homepage.click_header_dropdown
-      end
+        it 'cannot post status alerts' do
+          @homepage.wait_for_update_and_click @homepage.settings_link_element
+          expect(@settings_page.status_heading?).to be false
+        end
 
-      it('can see a Settings link') { expect(@homepage.settings_link?).to be true }
-      it('cannot see a Flight Deck link') { expect(@homepage.flight_deck_link?).to be false }
-      it('cannot see a Flight Data Recorder link') { expect(@homepage.flight_data_recorder_link?).to be false }
-      it('cannot see a Passenger Manifest link') { expect(@homepage.pax_manifest_link?).to be false }
+        it('cannot toggle drop-in advising') do
+          dept = BOACDepartments::DEPARTMENTS.find { |d| d.code == @test.advisor.depts.first }
+          expect(@settings_page.drop_in_advising_toggle_el(dept).exists?).to be false
+        end
 
-      it 'cannot post status alerts' do
-        @homepage.wait_for_update_and_click @homepage.settings_link_element
-        expect(@settings_page.status_heading?).to be false
-      end
+        it('cannot manage drop-in schedulers') { expect(@settings_page.add_scheduler_input?).to be false }
 
-      it('cannot toggle drop-in advising') do
-        dept = BOACDepartments::DEPARTMENTS.find { |d| d.code == @test.advisor.depts.first }
-        expect(@settings_page.drop_in_advising_toggle_el(dept).exists?).to be false
-      end
+        it 'cannot reach the Passenger Manifest' do
+          @pax_manifest_page.hit_page_url
+          @pax_manifest_page.wait_for_title 'Page not found'
+        end
 
-      it('cannot manage drop-in schedulers') { expect(@settings_page.add_scheduler_input?).to be false }
-
-      it 'cannot reach the Passenger Manifest' do
-        @pax_manifest_page.hit_page_url
-        @pax_manifest_page.wait_for_title 'Page not found'
-      end
-
-      it 'cannot hit the cachejob page' do
-        @api_admin_page.load_cachejob
-        @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
+        it 'cannot hit the cachejob page' do
+          @api_admin_page.load_cachejob
+          @api_admin_page.unauth_msg_element.when_visible Utils.medium_wait
+        end
       end
     end
   end

--- a/util/utils.rb
+++ b/util/utils.rb
@@ -343,7 +343,7 @@ class Utils
   def self.test_results(app_and_version)
     results_dir = File.join(output_dir, 'test-results')
     FileUtils.mkdir_p(results_dir) unless File.exist?(results_dir)
-    File.join(results_dir, "test-results-#{app_and_version}.log")
+    File.join(results_dir, "test-results-#{Time.now.to_s}-#{app_and_version}.log")
   end
 
   # TEST ACCOUNTS


### PR DESCRIPTION
Review with the ?w=1 cuz this is almost all indent change.  Separates BOA scripts into ones that must never be run simultaneously since they can trip over each other (DEPS) and those that can be (NO_DEPS).  Suite can then be run in two threads, significantly reducing overall run time.