### PR TITLE
Revert LTI perms changes

### DIFF
--- a/models/oec/oec_departments.rb
+++ b/models/oec/oec_departments.rb
@@ -61,6 +61,7 @@ class OECDepartments
       DUTCH = new('DUTCH', 'German', 'GERMAN', %w(F), true),
       EA_LANG = new('EA LANG', 'East Asian Languages and Cultures', 'EA LANG', %w(F G), true),
       ECON = new('ECON', 'Economics', 'ECON', %w(F G), true),
+      EDSTEM = new('EDSTEM', 'CalTeach', 'CALTEACH', %w(F G), true),
       EDUC = new('EDUC', 'Education', 'EDUC', %w(F G), true),
       EECS = new('EECS', 'Electrical Engineering and Computer Sciences', 'EL ENG', nil, false),
       EGYPT = new('EGYPT', 'Near Eastern Studies', 'EGYPT', %w(F G), true),

--- a/spec/junction/canvas_lti_course_add_user_spec.rb
+++ b/spec/junction/canvas_lti_course_add_user_spec.rb
@@ -252,8 +252,8 @@ describe 'bCourses Find a Person to Add', order: :defined do
       [test.observer, test.students.first, test.wait_list_student].each do |user|
         it "denies #{user.role} #{user.uid} access to the tool" do
           @canvas.masquerade_as(user, course)
-          @course_add_user_page.hit_embedded_tool_url course
-          @canvas.access_denied_msg_element.when_visible Utils.short_wait
+          @course_add_user_page.load_embedded_tool course
+          @course_add_user_page.no_access_msg_element.when_visible Utils.medium_wait
         end
 
         it "offers #{user.role} an Academic Policies link" do

--- a/spec/junction/canvas_lti_e_grades_export_spec.rb
+++ b/spec/junction/canvas_lti_e_grades_export_spec.rb
@@ -369,8 +369,8 @@ unless ENV['STANDALONE']
       [test.observer, test.students.first, test.wait_list_student].each do |user|
         it "denies #{user.role} #{user.uid} access to the tool" do
           @canvas.masquerade_as(user, course)
-          @e_grades_export_page.hit_embedded_tool_url course
-          @canvas.access_denied_msg_element.when_visible Utils.short_wait
+          @e_grades_export_page.load_embedded_tool course
+          @e_grades_export_page.not_auth_msg_element.when_visible Utils.medium_wait
         end
       end
     end

--- a/spec/junction/canvas_lti_mailing_lists_spec.rb
+++ b/spec/junction/canvas_lti_mailing_lists_spec.rb
@@ -44,22 +44,22 @@ unless ENV['STANDALONE']
     users.each do |user|
       it "can be managed by a course #{user.role} if the user has permission to reach the instructor-facing tool" do
         @canvas_page.masquerade_as(user, course_site_1)
-        @mailing_list_page.hit_embedded_tool_url course_site_1
-        if [test.manual_teacher, test.lead_ta, test.ta, test.designer, test.reader].include? user
+        @mailing_list_page.load_embedded_tool course_site_1
+        if [test.manual_teacher, test.lead_ta, test.ta, test.reader].include? user
           logger.debug "Verifying that #{user.role} UID #{user.uid} has access to the instructor-facing mailing list tool"
-          @mailing_list_page.switch_to_canvas_iframe
           @mailing_list_page.create_list_button_element.when_present(Utils.medium_wait)
         else
           logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the instructor-facing mailing list tool"
-          @canvas_page.access_denied_msg_element.when_visible Utils.short_wait
+          @mailing_list_page.unexpected_error_element.when_visible(Utils.medium_wait)
         end
       end
 
       it "cannot be managed by a course #{user.role} via the admin tool" do
-        logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the admin mailing lists tool"
         @canvas_page.masquerade_as(user, course_site_1)
-        @mailing_lists_page.hit_embedded_tool_url
-        @canvas_page.access_denied_msg_element.when_visible Utils.short_wait
+        @mailing_lists_page.load_embedded_tool
+        @mailing_lists_page.search_for_list course_site_1.site_id
+        logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the admin mailing lists tool"
+        @mailing_lists_page.unexpected_error_element.when_visible Utils.medium_wait
       end
     end
 

--- a/spec/junction/canvas_lti_official_sections_spec.rb
+++ b/spec/junction/canvas_lti_official_sections_spec.rb
@@ -391,8 +391,9 @@ describe 'bCourses Official Sections tool' do
           [test.observer, test.students.first, test.wait_list_student].each do |user|
             has_no_perms = @canvas.verify_block do
               @canvas.masquerade_as(user, site[:course])
-              @official_sections_page.hit_embedded_tool_url site[:course]
-              @canvas.access_denied_msg_element.when_visible Utils.short_wait
+              @official_sections_page.load_embedded_tool site[:course]
+              @official_sections_page.unexpected_error_element.when_present Utils.medium_wait
+              @official_sections_page.current_sections_table.when_not_visible 1
             end
             it("denies #{user.role} #{user.uid} access to the tool") { expect(has_no_perms).to be true }
           end

--- a/spec/junction/canvas_lti_rosters_spec.rb
+++ b/spec/junction/canvas_lti_rosters_spec.rb
@@ -168,8 +168,8 @@ describe 'bCourses Roster Photos' do
       [test.observer, test.students.first, test.wait_list_student].each do |user|
         it "denies #{user.role} #{user.uid} access to the tool" do
           @canvas.masquerade_as(user, course)
-          @roster_photos_page.hit_embedded_tool_url course
-          @canvas.access_denied_msg_element.when_visible Utils.short_wait
+          @roster_photos_page.load_embedded_tool course
+          @roster_photos_page.no_access_msg_element.when_visible Utils.short_wait
         end
       end
     end


### PR DESCRIPTION
Canvas changed the way non-authorized users were blocked from Junction tools... and now they've changed it back.