### PR TITLE
Fix tests for tool access denial

### DIFF
--- a/spec/junction/canvas_lti_course_add_user_spec.rb
+++ b/spec/junction/canvas_lti_course_add_user_spec.rb
@@ -253,8 +253,11 @@ describe 'bCourses Find a Person to Add', order: :defined do
       [test.observer, test.students.first, test.wait_list_student].each do |user|
         it "denies #{user.role} #{user.uid} access to the tool" do
           @canvas.masquerade_as(user, course)
-          @course_add_user_page.load_embedded_tool course
-          @course_add_user_page.no_access_msg_element.when_visible Utils.medium_wait
+          @course_add_user_page.hit_embedded_tool_url course
+          @canvas.access_denied_msg_element.when_present Utils.short_wait
+        rescue
+          @course_add_user_page.switch_to_canvas_iframe
+          @course_add_user_page.no_access_msg_element.when_visible Utils.short_wait
         end
 
         it "offers #{user.role} an Academic Policies link" do

--- a/spec/junction/canvas_lti_e_grades_export_spec.rb
+++ b/spec/junction/canvas_lti_e_grades_export_spec.rb
@@ -369,7 +369,10 @@ unless ENV['STANDALONE']
       [test.observer, test.students.first, test.wait_list_student].each do |user|
         it "denies #{user.role} #{user.uid} access to the tool" do
           @canvas.masquerade_as(user, course)
-          @e_grades_export_page.load_embedded_tool course
+          @e_grades_export_page.hit_embedded_tool_url course
+          @canvas.access_denied_msg_element.when_present Utils.short_wait
+        rescue
+          @e_grades_export_page.switch_to_canvas_iframe
           @e_grades_export_page.not_auth_msg_element.when_visible Utils.medium_wait
         end
       end

--- a/spec/junction/canvas_lti_mailing_lists_spec.rb
+++ b/spec/junction/canvas_lti_mailing_lists_spec.rb
@@ -44,19 +44,28 @@ unless ENV['STANDALONE']
     users.each do |user|
       it "can be managed by a course #{user.role} if the user has permission to reach the instructor-facing tool" do
         @canvas_page.masquerade_as(user, course_site_1)
-        @mailing_list_page.load_embedded_tool course_site_1
+        @mailing_list_page.hit_embedded_tool_url course_site_1
         if [test.manual_teacher, test.lead_ta, test.ta, test.reader].include? user
           logger.debug "Verifying that #{user.role} UID #{user.uid} has access to the instructor-facing mailing list tool"
+          @mailing_list_page.switch_to_canvas_iframe
           @mailing_list_page.create_list_button_element.when_present(Utils.medium_wait)
         else
-          logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the instructor-facing mailing list tool"
-          @mailing_list_page.unexpected_error_element.when_visible(Utils.medium_wait)
+          begin
+            logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the instructor-facing mailing list tool"
+            @canvas_page.access_denied_msg_element.when_visible Utils.short_wait
+          rescue
+            @mailing_list_page.switch_to_canvas_iframe
+            @mailing_list_page.unexpected_error_element.when_visible Utils.short_wait
+          end
         end
       end
 
       it "cannot be managed by a course #{user.role} via the admin tool" do
         @canvas_page.masquerade_as(user, course_site_1)
-        @mailing_lists_page.load_embedded_tool
+        @mailing_lists_page.hit_embedded_tool_url
+        @canvas_page.access_denied_msg_element.when_visible Utils.short_wait
+      rescue
+        @mailing_lists_page.switch_to_canvas_iframe
         @mailing_lists_page.search_for_list course_site_1.site_id
         logger.debug "Verifying that #{user.role} UID #{user.uid} has no access to the admin mailing lists tool"
         @mailing_lists_page.unexpected_error_element.when_visible Utils.medium_wait

--- a/spec/junction/canvas_lti_official_sections_spec.rb
+++ b/spec/junction/canvas_lti_official_sections_spec.rb
@@ -391,9 +391,11 @@ describe 'bCourses Official Sections tool' do
           [test.observer, test.students.first, test.wait_list_student].each do |user|
             has_no_perms = @canvas.verify_block do
               @canvas.masquerade_as(user, site[:course])
-              @official_sections_page.load_embedded_tool site[:course]
-              @official_sections_page.unexpected_error_element.when_present Utils.medium_wait
-              @official_sections_page.current_sections_table.when_not_visible 1
+              @official_sections_page.hit_embedded_tool_url site[:course]
+              @canvas.access_denied_msg_element.when_present Utils.short_wait
+            rescue
+              @official_sections_page.switch_to_canvas_iframe
+              @official_sections_page.unexpected_error_element.when_present Utils.short_wait
             end
             it("denies #{user.role} #{user.uid} access to the tool") { expect(has_no_perms).to be true }
           end

--- a/spec/junction/canvas_lti_rosters_spec.rb
+++ b/spec/junction/canvas_lti_rosters_spec.rb
@@ -168,7 +168,10 @@ describe 'bCourses Roster Photos' do
       [test.observer, test.students.first, test.wait_list_student].each do |user|
         it "denies #{user.role} #{user.uid} access to the tool" do
           @canvas.masquerade_as(user, course)
-          @roster_photos_page.load_embedded_tool course
+          @roster_photos_page.hit_embedded_tool_url course
+          @canvas.access_denied_msg_element.when_present Utils.short_wait
+        rescue
+          @roster_photos_page.switch_to_canvas_iframe
           @roster_photos_page.no_access_msg_element.when_visible Utils.short_wait
         end
       end


### PR DESCRIPTION
Canvas is blocking tool access again, so update tests to handle either means of verifying that non-auth users are blocked from tools.