### PR TITLE
Reduce Squiggy test execution time

### DIFF
--- a/models/squiggy/squiggy_course.rb
+++ b/models/squiggy/squiggy_course.rb
@@ -1,6 +1,7 @@
 class SquiggyCourse < Course
 
   attr_accessor :asset_library_url,
+                :is_copy,
                 :engagement_index_url,
                 :impact_studio_url,
                 :lti_tools,

--- a/models/test_config.rb
+++ b/models/test_config.rb
@@ -17,7 +17,9 @@ class TestConfig
   # Sets a unique ID (the epoch) for a test run
   def initialize(test_name = nil)
     @id = "QA Test #{Time.now.to_i}"
-    @admin = User.new uid: Utils.super_admin_uid, username: Utils.super_admin_username
+    @admin = User.new uid: Utils.super_admin_uid,
+                      username: Utils.super_admin_username,
+                      canvas_id: Utils.super_admin_canvas_id
   end
 
   # Parses a JSON file containing test data

--- a/settings.yml
+++ b/settings.yml
@@ -155,4 +155,5 @@ squiggy:
   db_password: secret
   poller_retries: 10
   load_test_reps: 10
+  template_course_id: 1234567
   whiteboards: [123, 456, 789]

--- a/util/squiggy_utils.rb
+++ b/util/squiggy_utils.rb
@@ -28,6 +28,10 @@ class SquiggyUtils < Utils
     squiggy_config['load_test_reps']
   end
 
+  def SquiggyUtils.template_course_id
+    squiggy_config['template_course_id']
+  end
+
   def SquiggyUtils.whiteboards
     squiggy_config['whiteboards']
   end


### PR DESCRIPTION
Instead of configuring LTI tools for each test, copy a test course site maintained in Canvas Prod with tools already configured.  Appears to reduce execution time of the suite by ~30 minutes overall.