### PR TITLE
Work around Chrome/Chromedriver visibility and JS injection issues

### DIFF
--- a/pages/boac/boac_cohort_student_pages.rb
+++ b/pages/boac/boac_cohort_student_pages.rb
@@ -99,8 +99,8 @@ module BOACCohortStudentPages
 
   def select_term(term_id)
     logger.info "Selecting term ID #{term_id}"
-    wait_for_update_and_click_js term_select_button_element
-    wait_for_update_and_click_js button_element(id: "term-select-option-#{term_id}")
+    wait_for_update_and_click term_select_button_element
+    wait_for_update_and_click button_element(id: "term-select-option-#{term_id}")
   end
 
   # Returns the XPath to the div containing data for a single student

--- a/pages/boac/boac_degree_check_page.rb
+++ b/pages/boac/boac_degree_check_page.rb
@@ -890,7 +890,7 @@ class BOACDegreeCheckPage < BOACDegreeTemplatePage
   text_area(:recommended_note_textarea, id: 'recommendation-note-textarea')
 
   def click_ignore_reqt
-    wait_for_update_and_click_js ignore_reqt_cbx_element
+    wait_for_update_and_click ignore_reqt_cbx_element
   end
 
   def enter_reqt_grade(grade)

--- a/pages/boac/boac_degree_template_page.rb
+++ b/pages/boac/boac_degree_template_page.rb
@@ -191,7 +191,7 @@ class BOACDegreeTemplatePage
   end
 
   def click_transfer_course
-    wait_for_update_and_click_js col_req_transfer_course_cbx_element
+    wait_for_update_and_click col_req_transfer_course_cbx_element
   end
 
   def col_req_unit_req_pill_xpath(unit_req)

--- a/pages/boac/boac_home_page.rb
+++ b/pages/boac/boac_home_page.rb
@@ -119,8 +119,8 @@ class BOACHomePage
   def expand_member_rows(cohort)
     unless view_all_members_link(cohort).visible?
       cohort.instance_of?(FilteredCohort) ?
-          wait_for_update_and_click_js(button_element(id: "sortable-cohort-#{cohort.id}-toggle")) :
-          wait_for_update_and_click_js(button_element(id: "sortable-curated-#{cohort.id}-toggle"))
+          wait_for_update_and_click(button_element(id: "sortable-cohort-#{cohort.id}-toggle")) :
+          wait_for_update_and_click(button_element(id: "sortable-curated-#{cohort.id}-toggle"))
     end
   end
 
@@ -181,7 +181,7 @@ class BOACHomePage
   def click_filtered_cohort(cohort)
     logger.debug "Clicking link to my cohort '#{cohort.name}'"
     wait_until(Utils.short_wait) { filtered_cohort_elements.any? }
-    wait_for_update_and_click_js view_all_members_link(cohort)
+    wait_for_update_and_click view_all_members_link(cohort)
   end
 
 end

--- a/pages/boac/boac_list_view_student_pages.rb
+++ b/pages/boac/boac_list_view_student_pages.rb
@@ -115,7 +115,7 @@ module BOACListViewStudentPages
   # @param student [BOACUser]
   def click_student_link(student)
     logger.info "Clicking the link for UID #{student.uid}"
-    wait_for_load_and_click_js link_element(id: "link-to-student-#{student.uid}")
+    wait_for_load_and_click link_element(id: "link-to-student-#{student.uid}")
     student_name_heading_element.when_visible Utils.medium_wait
   end
 

--- a/pages/boac/boac_pages.rb
+++ b/pages/boac/boac_pages.rb
@@ -149,7 +149,7 @@ module BOACPages
   # Clicks link to create new curated group
   def click_sidebar_create_student_group
     logger.debug 'Clicking sidebar button to create a curated group'
-    wait_for_load_and_click_js create_curated_group_link_element
+    wait_for_load_and_click create_curated_group_link_element
     sleep 2
   end
 
@@ -282,7 +282,7 @@ module BOACPages
 
   def click_draft_notes
     logger.info 'Clicking link to Draft Notes page'
-    wait_for_update_and_click_js draft_notes_link_element
+    wait_for_update_and_click draft_notes_link_element
   end
 
   def wait_for_draft_note(note, manual_update=false)

--- a/pages/boac/boac_pages_create_note_modal.rb
+++ b/pages/boac/boac_pages_create_note_modal.rb
@@ -15,13 +15,13 @@ module BOACPagesCreateNoteModal
 
   def click_save_as_draft
     logger.info 'Clicking the save-as-draft button'
-    wait_for_update_and_click_js save_as_draft_button_element
+    wait_for_update_and_click save_as_draft_button_element
     save_as_draft_button_element.when_not_present Utils.medium_wait
   end
 
   def click_update_note_draft
     logger.info 'Clicking the update draft button'
-    wait_for_update_and_click_js update_draft_button_element
+    wait_for_update_and_click update_draft_button_element
   end
 
   #### CREATE NOTE, SHARED ELEMENTS ####
@@ -148,7 +148,7 @@ module BOACPagesCreateNoteModal
   def remove_attachments_from_new_note(note, attachments)
     attachments.each do |attach|
       logger.info "Removing attachment '#{attach.file_name}' from an unsaved note"
-      wait_for_update_and_click_js new_note_attachment_delete_button(attach)
+      wait_for_update_and_click new_note_attachment_delete_button(attach)
       new_note_attachment_delete_button(attach).when_not_visible Utils.short_wait
       note.attachments.delete attach
       note.updated_date = Time.now

--- a/pages/boac/boac_search_form.rb
+++ b/pages/boac/boac_search_form.rb
@@ -37,7 +37,7 @@ module BOACSearchForm
 
   def click_simple_search_button
     logger.info 'Clicking search button'
-    wait_for_update_and_click_js search_button_element
+    wait_for_update_and_click search_button_element
   end
 
   # Search history

--- a/pages/canvas/canvas_announce_discuss_page.rb
+++ b/pages/canvas/canvas_announce_discuss_page.rb
@@ -48,7 +48,7 @@ module Page
       discussion_title_element.send_keys announcement.title
       html_editor_link if html_editor_link_element.visible?
       wait_for_element_and_type_js(announcement_msg_element, announcement.body)
-      wait_for_update_and_click_js save_button_element
+      wait_for_update_and_click save_button_element
       announcement_title_heading_element.when_visible Utils.medium_wait
       announcement.url = current_url
       logger.info "Announcement URL is #{announcement.url}"
@@ -103,25 +103,25 @@ module Page
       hide_canvas_footer_and_popup
       if index.nil?
         logger.info "Creating new discussion entry with body '#{reply_body}'"
-        wait_for_load_and_click_js primary_reply_link_element
+        wait_for_load_and_click primary_reply_link_element
         primary_reply_iframe_element.when_present Utils.short_wait
         replies = discussion_reply_elements.length
         switch_to_frame primary_reply_iframe_element.attribute('id')
         wait_for_element_and_type_js(paragraph_element(xpath: '//p'), reply_body)
         switch_to_main_content
         reply_prompt_dismiss_button_element.click if reply_prompt_dismiss_button_element.exists?
-        wait_for_load_and_click_js primary_post_reply_button_element
+        wait_for_load_and_click primary_post_reply_button_element
       else
         logger.info "Replying to a discussion entry at index #{index} with body '#{reply_body}'"
         wait_until(Utils.short_wait) { secondary_reply_link_elements.any? }
         replies = discussion_reply_elements.length
-        wait_for_load_and_click_js secondary_reply_link_elements[index]
+        wait_for_load_and_click secondary_reply_link_elements[index]
         secondary_reply_iframe_element.when_present Utils.short_wait
         switch_to_frame secondary_reply_iframe_element.attribute('id')
         wait_for_element_and_type_js(paragraph_element(xpath: '//p'), reply_body)
         switch_to_main_content
         reply_prompt_dismiss_button_element.click if reply_prompt_dismiss_button_element.exists?
-        wait_for_load_and_click_js secondary_post_reply_button_elements[index]
+        wait_for_load_and_click secondary_post_reply_button_elements[index]
       end
       wait_until(Utils.medium_wait) { discussion_reply_elements.length == replies + 1 }
     end
@@ -160,7 +160,7 @@ module Page
       pages = (discussion_page_link_elements.map &:text).uniq if discussion_page_link_elements.any?
       if pages&.any?
         pages.each do |page|
-          wait_for_update_and_click_js(discussion_page_link_elements.find { |el| el.text == page })
+          wait_for_update_and_click(discussion_page_link_elements.find { |el| el.text == page })
           author_els = wait_for_discussion
           replies << get_page_discussion_entries(author_els)
         end

--- a/pages/canvas/canvas_assignments_page.rb
+++ b/pages/canvas/canvas_assignments_page.rb
@@ -83,7 +83,7 @@ module Page
       navigate_to assignment.url
       wait_for_load_and_click edit_assignment_link_element
       wait_for_element_and_type(assignment_name_element, (assignment.title = "#{assignment.title} - Edited"))
-      wait_for_update_and_click_js save_assignment_button_element
+      wait_for_update_and_click save_assignment_button_element
       wait_until(Utils.short_wait) { assignment_title_heading_element.exists? && assignment_title_heading.include?(assignment.title) }
     end
 
@@ -110,19 +110,19 @@ module Page
         wait_for_update_and_click upload_file_button_element
         file_upload_input_element.when_visible Utils.short_wait
         self.file_upload_input_element.send_keys SquiggyUtils.asset_file_path(submission.file_name)
-        wait_for_update_and_click_js file_upload_submit_button_element
+        wait_for_update_and_click file_upload_submit_button_element
       else
-        wait_for_update_and_click_js assignment_site_url_tab_element
+        wait_for_update_and_click assignment_site_url_tab_element
         url_upload_input_element.when_visible Utils.short_wait
         self.url_upload_input = submission.url
-        wait_for_update_and_click_js url_upload_submit_button_element
+        wait_for_update_and_click url_upload_submit_button_element
       end
     end
 
     def submit_assignment(assignment, user, submission)
       logger.info "Submitting #{submission.title} for #{user.full_name}"
       navigate_to assignment.url
-      wait_for_load_and_click_js submit_assignment_button_element
+      wait_for_load_and_click submit_assignment_button_element
       upload_assignment submission
       assignment_submission_conf_element.when_visible Utils.long_wait
     end

--- a/pages/canvas/canvas_grades_page.rb
+++ b/pages/canvas/canvas_grades_page.rb
@@ -56,7 +56,7 @@ module Page
 
     # Clicks the update button and waits for confirmation
     def update_course_settings
-      wait_for_update_and_click_js update_course_button_element
+      wait_for_update_and_click update_course_button_element
       sleep 2
       update_course_success_element.when_visible Utils.medium_wait
     end
@@ -113,7 +113,7 @@ module Page
         hit_escape
       else
         wait_for_update_and_click gradebook_manual_posting_input_element
-        wait_for_update_and_click_js gradebook_settings_update_button_element
+        wait_for_update_and_click gradebook_settings_update_button_element
         wait_for_flash_msg('Gradebook Settings updated', Utils.medium_wait)
       end
     end
@@ -147,18 +147,18 @@ module Page
     # @param course [Course]
     def load_gradebook(course)
       navigate_to "#{Utils.canvas_base_url}/courses/#{course.site_id}/gradebook"
-      e_grades_export_link_element.when_visible Utils.short_wait
+      e_grades_export_link_element.when_present Utils.short_wait
     rescue
       if title.include? 'Individual View'
         logger.error 'Individual view is present, switching to gradebook view.'
         wait_for_update_and_click individual_view_input_element
         arrow_down
         hit_enter
-        e_grades_export_link_element.when_visible Utils.medium_wait
+        e_grades_export_link_element.when_present Utils.medium_wait
       else
         logger.error 'E-Grades export button has not appeared, hard-refreshing the page'
         browser.execute_script('location.reload(true);')
-        e_grades_export_link_element.when_visible Utils.medium_wait
+        e_grades_export_link_element.when_present Utils.medium_wait
       end
     end
 
@@ -320,7 +320,7 @@ module Page
     # Clicks the allow-override checkbox and saves
     def toggle_allow_grade_override
       js_click allow_grade_override_cbx_element
-      wait_for_update_and_click_js update_gradebook_settings_element
+      wait_for_update_and_click update_gradebook_settings_element
       flash_msg_element.when_visible Utils.short_wait
       wait_until(1) { flash_msg_element.text.include? 'Gradebook Settings updated' }
     end

--- a/pages/canvas/canvas_page.rb
+++ b/pages/canvas/canvas_page.rb
@@ -103,7 +103,7 @@ module Page
 
     def expand_mobile_menu
       logger.info 'Clicking the hamburger to reveal the menu'
-      wait_for_update_and_click_js hamburger_button_element
+      wait_for_update_and_click hamburger_button_element
     end
 
     def click_user_prov
@@ -115,7 +115,7 @@ module Page
     # Clicks the 'save and publish' button using JavaScript rather than WebDriver
     def click_save_and_publish
       scroll_to_bottom
-      wait_for_update_and_click_js save_and_publish_button_element
+      wait_for_update_and_click save_and_publish_button_element
     end
 
     def wait_for_flash_msg(text, wait)
@@ -164,9 +164,9 @@ module Page
     span(:copy_course_success_msg, xpath: '//span[text()="Completed"]')
 
     def click_create_site_settings_link
-      wait_for_update_and_click_js profile_link_element
+      wait_for_update_and_click profile_link_element
       sleep 1
-      wait_for_update_and_click_js profile_form_element
+      wait_for_update_and_click profile_form_element
       wait_for_update_and_click create_site_settings_link_element
       switch_to_canvas_iframe
     end
@@ -237,7 +237,7 @@ module Page
         unless course.term.nil?
           navigate_to "#{Utils.canvas_base_url}/courses/#{course.site_id}/settings"
           wait_for_element_and_select(term_element, course.term)
-          wait_for_update_and_click_js update_course_button_element
+          wait_for_update_and_click update_course_button_element
           update_course_success_element.when_visible Utils.medium_wait
         end
       else
@@ -265,7 +265,7 @@ module Page
         if site.term
           navigate_to "#{Utils.canvas_base_url}/courses/#{site.site_id}/settings"
           wait_for_element_and_select(term_element, site.term.name)
-          wait_for_update_and_click_js update_course_button_element
+          wait_for_update_and_click update_course_button_element
           update_course_success_element.when_visible Utils.medium_wait
         end
       end
@@ -365,7 +365,7 @@ module Page
     def add_section(site, section)
       logger.info "Adding section #{section.sis_id}"
       load_course_settings site
-      wait_for_update_and_click_js sections_tab_element
+      wait_for_update_and_click sections_tab_element
       wait_for_element_and_type(section_name_element, section.sis_id)
       wait_for_update_and_click add_section_button_element
       # Add SIS id to section
@@ -517,7 +517,7 @@ module Page
       wait_for_update_and_click link_element(xpath: "//ul[@id='nav_disabled_list']/li[contains(.,'#{tool.name}')]//a")
       wait_for_update_and_click link_element(xpath: "//ul[@id='nav_disabled_list']/li[contains(.,'#{tool.name}')]//a[@title='Enable this item']")
       list_item_element(xpath: "//ul[@id='nav_enabled_list']/li[contains(.,'#{tool.name}')]").when_visible Utils.medium_wait
-      wait_for_update_and_click_js save_button_element
+      wait_for_update_and_click save_button_element
       tool_nav_link(tool).when_visible Utils.medium_wait
     end
 
@@ -574,10 +574,10 @@ module Page
               link_element(xpath: "//td[@title='#{tool.name}']").when_present Utils.medium_wait
 
               # Enable tool placement in sidebar navigation
-              wait_for_update_and_click_js button_element(xpath: "//tr[contains(., '#{tool.name}')]//button")
-              wait_for_update_and_click_js app_placements_button_element
-              wait_for_update_and_click_js activate_navigation_button_element
-              wait_for_update_and_click_js close_placements_button_element
+              wait_for_update_and_click button_element(xpath: "//tr[contains(., '#{tool.name}')]//button")
+              wait_for_update_and_click app_placements_button_element
+              wait_for_update_and_click activate_navigation_button_element
+              wait_for_update_and_click close_placements_button_element
               sleep 1
               enable_tool(tool, test.course_site)
             end
@@ -614,7 +614,7 @@ module Page
       tool.dev_key = el.text
     end
 
-    def add_ripley_tool(site, tool)
+    def add_ripley_tool(tool)
       if ripley_tool_installed? tool
         logger.info "Tool #{tool.name} is already installed"
       else
@@ -633,7 +633,7 @@ module Page
     def click_tool_link(tool)
       switch_to_main_content
       hide_canvas_footer_and_popup
-      wait_for_update_and_click_js tool_nav_link(tool)
+      wait_for_update_and_click tool_nav_link(tool)
       wait_until(Utils.medium_wait) { title == "#{tool.name}" }
       logger.info "#{tool.name} URL is #{url = current_url}"
       url.delete '#'

--- a/pages/canvas/canvas_people_page.rb
+++ b/pages/canvas/canvas_people_page.rb
@@ -11,7 +11,7 @@ module CanvasPeoplePage
   select_list(:enrollment_roles, name: 'enrollment_role_id')
   elements(:section_label, :div, xpath: '//div[@class="section"]')
   link(:add_people_button, id: 'addUsers')
-  link(:find_person_to_add_link, xpath: '//a[contains(.,"Find a Person to Add")]')
+  link(:find_person_to_add_link, xpath: '//a[text()="    Find a Person to Add  "]')
   div(:add_user_by_email, xpath: '//input[@id="peoplesearch_radio_cc_path"]/..')
   element(:add_user_by_email_label, xpath: '//label[@for="peoplesearch_radio_cc_path"]')
   div(:add_user_by_uid, xpath: '//input[@id="peoplesearch_radio_unique_id"]/..')
@@ -143,10 +143,10 @@ module CanvasPeoplePage
           wait_for_update_and_click user_role_element
           wait_for_update_and_click(user_role_option_elements.find { |el| el.text == user_role })
           wait_for_element_and_select(user_section_element, section.sis_id) if section
-          wait_for_update_and_click_js next_button_element
+          wait_for_update_and_click next_button_element
           users_ready_to_add_msg_element.when_visible Utils.medium_wait
           hide_canvas_footer_and_popup
-          wait_for_update_and_click_js next_button_element
+          wait_for_update_and_click next_button_element
           users_with_role.each { |u| wait_for_added_user u }
         rescue => e
           logger.error "#{e.message}\n#{e.backtrace}"
@@ -164,16 +164,16 @@ module CanvasPeoplePage
         begin
           tries ||= 3
           logger.info "Adding UID #{user.uid} to section #{section.sis_id}"
-          wait_for_load_and_click_js add_people_button_element
+          wait_for_load_and_click add_people_button_element
           wait_for_update_and_click add_user_by_uid_element
           wait_for_element_and_type_js(user_list_element, user.uid)
           wait_for_update_and_click user_role_element
           wait_for_update_and_click(user_role_option_elements.find { |el| el.text == user.role })
           wait_for_update_and_click user_section_element
           wait_for_update_and_click(user_role_option_elements.find { |el| el.text == section.sis_id })
-          wait_for_update_and_click_js next_button_element
+          wait_for_update_and_click next_button_element
           users_ready_to_add_msg_element.when_visible Utils.medium_wait
-          wait_for_update_and_click_js next_button_element
+          wait_for_update_and_click next_button_element
           wait_for_users [user]
         rescue => e
           logger.error "#{e.message}"
@@ -190,7 +190,7 @@ module CanvasPeoplePage
     wait_for_load_and_click add_people_button_element
     wait_for_update_and_click add_user_by_uid_element
     wait_for_element_and_type_js(user_list_element, '123456')
-    wait_for_update_and_click_js next_button_element
+    wait_for_update_and_click next_button_element
   end
 
   def click_edit_user(user)
@@ -207,7 +207,7 @@ module CanvasPeoplePage
     users.each do |user|
       logger.info "Removing #{user.role} UID #{user.uid} from course site ID #{course.site_id}"
       click_edit_user user
-      alert { wait_for_update_and_click_js link_element(xpath: "//tr[@id='user_#{user.canvas_id}']//a[@data-event='removeFromCourse']") }
+      alert { wait_for_update_and_click link_element(xpath: "//tr[@id='user_#{user.canvas_id}']//a[@data-event='removeFromCourse']") }
       remove_user_success_element.when_present Utils.short_wait
     end
   end
@@ -300,8 +300,7 @@ module CanvasPeoplePage
   # Clicks the Canvas Add People button followed by the Find a Person to Add button and switches to the LTI tool
   def click_find_person_to_add(url=JunctionUtils.junction_base_url)
     logger.debug 'Clicking Find a Person to Add button'
-    add_people_button_element.when_present Utils.medium_wait
-    js_click add_people_button_element
+    wait_for_update_and_click add_people_button_element
     wait_for_load_and_click find_person_to_add_link_element
     switch_to_canvas_iframe url
   end

--- a/pages/element.rb
+++ b/pages/element.rb
@@ -112,7 +112,8 @@ class Element
 
   def when_visible(timeout)
     wait = Selenium::WebDriver::Wait.new timeout: timeout
-    wait.until { visible? }
+    # TODO - remove when Chrome / Chromedriver handle visibility properly again
+    wait.until { exists? }
   end
 
   def when_not_visible(timeout)

--- a/pages/junction/canvas_course_manage_sections_page.rb
+++ b/pages/junction/canvas_course_manage_sections_page.rb
@@ -50,14 +50,14 @@ module Page
       # Clicks the Edit Sections button and waits for the available sections table to appear
       def click_edit_sections
         logger.debug 'Clicking edit sections button'
-        wait_for_load_and_click_js edit_sections_button_element
+        wait_for_load_and_click edit_sections_button_element
         save_changes_button_element.when_visible Utils.short_wait
       end
 
       # Clicks the Save Changes button on the editing interface
       def click_save_changes
         logger.debug 'Clicking save changes button'
-        wait_for_update_and_click_js save_changes_button_element
+        wait_for_update_and_click save_changes_button_element
       end
 
       def save_changes_and_wait_for_success
@@ -69,7 +69,7 @@ module Page
       # Closes the 'success' message after sections are updated
       def close_section_update_success
         logger.debug 'Closing the section update success message'
-        wait_for_update_and_click_js update_msg_close_button_element
+        wait_for_update_and_click update_msg_close_button_element
       end
 
       # CURRENT SECTIONS
@@ -127,7 +127,7 @@ module Page
       # @param section [Section]
       def click_update_section(section)
         logger.debug "Clicking update button for section #{section.id}"
-        wait_for_update_and_click_js section_update_button(section)
+        wait_for_update_and_click section_update_button(section)
         sleep 1
       end
 
@@ -142,7 +142,7 @@ module Page
       # @param section [Section]
       def click_delete_section(section)
         logger.debug "Clicking delete button for section #{section.id}"
-        wait_for_update_and_click_js section_delete_button(section)
+        wait_for_update_and_click section_delete_button(section)
         sleep 1
       end
 
@@ -164,7 +164,7 @@ module Page
       # @param section [Section]
       def click_undo_add_section(section)
         logger.debug "Clicking undo add button for section #{section.id}"
-        wait_for_update_and_click_js section_undo_add_button(section)
+        wait_for_update_and_click section_undo_add_button(section)
         sleep 1
       end
 
@@ -259,7 +259,7 @@ module Page
       # @param section [Section]
       def click_add_section(course, section)
         logger.debug "Clicking add button for section #{section.id}"
-        wait_for_update_and_click_js section_add_button(course, section)
+        wait_for_update_and_click section_add_button(course, section)
         sleep 1
       end
 
@@ -292,7 +292,7 @@ module Page
       # @param section [Section]
       def click_undo_delete_section(course, section)
         logger.debug "Clicking undo delete button section #{section.id}"
-        wait_for_update_and_click_js section_undo_delete_button(course, section)
+        wait_for_update_and_click section_undo_delete_button(course, section)
         sleep 1
       end
 

--- a/pages/junction/canvas_course_sections_page.rb
+++ b/pages/junction/canvas_course_sections_page.rb
@@ -45,7 +45,7 @@ module Page
         if available_sections_table(course_code).exists? && available_sections_table(course_code).visible?
           logger.debug "The sections table is already expanded for #{course_code}"
         else
-          available_sections_form_button(course_code).click
+          wait_for_update_and_click available_sections_form_button(course_code)
           sleep Utils.click_wait
         end
       end
@@ -54,7 +54,7 @@ module Page
       # @param course_code [String]
       def collapse_available_sections(course_code)
         if available_sections_table(course_code).exists? && available_sections_table(course_code).visible?
-          available_sections_form_button(course_code).click
+          wait_for_update_and_click available_sections_form_button(course_code)
           available_sections_table(course_code).when_not_visible Utils.short_wait
         else
           logger.debug "The sections table is already collapsed for #{course_code}"

--- a/pages/junction/canvas_create_course_site_page.rb
+++ b/pages/junction/canvas_create_course_site_page.rb
@@ -82,7 +82,7 @@ module Page
 
       # Clicks the 'need help' button
       def click_need_help
-        button_element(xpath: '//button[contains(.,"Need help deciding which official sections to select")]').click
+        wait_for_update_and_click button_element(xpath: '//button[contains(.,"Need help deciding which official sections to select")]')
       end
 
       # Given a section ID, returns a hash of section data displayed on that row
@@ -176,13 +176,13 @@ module Page
       # Clicks the 'next' button once it is enabled
       def click_next
         wait_until(Utils.short_wait) { !next_button_element.attribute('disabled') }
-        wait_for_update_and_click_js next_button_element
+        wait_for_update_and_click next_button_element
         site_name_input_element.when_visible Utils.medium_wait
       end
 
       def click_cancel
         logger.debug 'Clicking cancel button'
-        wait_for_update_and_click_js cancel_button_element
+        wait_for_update_and_click cancel_button_element
       end
 
       # Enters a unique course site name and abbreviation and returns the abbreviation

--- a/pages/junction/canvas_e_grades_export_page.rb
+++ b/pages/junction/canvas_e_grades_export_page.rb
@@ -62,7 +62,7 @@ module Page
       # Clicks the Continue button
       def click_continue
         logger.debug 'Clicking continue'
-        wait_for_load_and_click_js continue_button_element
+        wait_for_load_and_click continue_button_element
       end
 
       # Selects a given P/NP grade cutoff

--- a/pages/junction/canvas_mailing_lists_page.rb
+++ b/pages/junction/canvas_mailing_lists_page.rb
@@ -65,7 +65,7 @@ module Page
       def search_for_list(search_term)
         logger.info "Searching for mailing list for course site ID #{search_term}"
         wait_for_element_and_type(site_id_input_element, search_term)
-        wait_for_update_and_click_js get_list_button_element
+        wait_for_update_and_click get_list_button_element
       end
 
       # Returns the element containing the 'no results' message for an unsuccessful mailing list search

--- a/pages/junction/canvas_rosters_page.rb
+++ b/pages/junction/canvas_rosters_page.rb
@@ -50,7 +50,7 @@ module Page
       # Clicks the sidebar Roster Photos link and shifts focus to the tool
       def click_roster_photos_link
         logger.info 'Clicking Roster Photos link'
-        wait_for_load_and_click_js roster_photos_link_element
+        wait_for_load_and_click roster_photos_link_element
         switch_to_canvas_iframe JunctionUtils.junction_base_url
       end
 

--- a/pages/junction/splash_page.rb
+++ b/pages/junction/splash_page.rb
@@ -42,7 +42,7 @@ module Page
         wait_for_element_and_type_js(basic_auth_password_input_element, JunctionUtils.junction_basic_auth_password)
         # The log in button element will disappear and reappear
         button = basic_auth_log_in_button_element
-        button.click
+        wait_for_update_and_click button
         button.when_not_present timeout=Utils.medium_wait
         sleep 1
       end

--- a/pages/page.rb
+++ b/pages/page.rb
@@ -163,22 +163,10 @@ module Page
     click_element(element, Utils.short_wait, click_wait)
   end
 
-  # Awaits an element for a short time then clicks it using JavaScript. Intended for DOM updates rather than page loads.
-  # @param element [PageObject::Elements::Element]
-  def wait_for_update_and_click_js(element)
-    click_element_js(element, Utils.short_wait)
-  end
-
   # Awaits an element for a moderate time then clicks it using WebDriver. Intended for page loads rather than DOM updates.
   # @param element [PageObject::Elements::Element]
   def wait_for_load_and_click(element, click_wait=nil)
     click_element(element, Utils.medium_wait, click_wait)
-  end
-
-  # Awaits an element for a moderate time then clicks it using JavaScript. Intended for page loads rather than DOM updates.
-  # @param element [PageObject::Elements::Element]
-  def wait_for_load_and_click_js(element)
-    click_element_js(element, Utils.medium_wait)
   end
 
   # Awaits an element for a short time, clicks it using WebDriver, removes existing text, and sends new text. Intended for placing text
@@ -214,7 +202,7 @@ module Page
   # @param element [PageObject::Elements::Element]
   # @param text [String]
   def wait_for_element_and_type_js(element, text)
-    wait_for_update_and_click_js element
+    wait_for_update_and_click element
     clear_input_value element
     element.send_keys text
   end

--- a/pages/ripley/ripley_course_sections_module.rb
+++ b/pages/ripley/ripley_course_sections_module.rb
@@ -28,7 +28,7 @@ module RipleyCourseSectionsModule
     if available_sections_table(course_code).exists? && available_sections_table(course_code).visible?
       logger.debug "The sections table is already expanded for #{course_code}"
     else
-      wait_for_update_and_click_js available_sections_form_button(course_code)
+      wait_for_update_and_click available_sections_form_button(course_code)
       available_sections_table(course_code).when_visible Utils.short_wait
       sleep Utils.click_wait
     end
@@ -36,7 +36,7 @@ module RipleyCourseSectionsModule
 
   def collapse_available_sections(course_code)
     if available_sections_table(course_code).exists? && available_sections_table(course_code).visible?
-      wait_for_update_and_click_js available_sections_form_button(course_code)
+      wait_for_update_and_click available_sections_form_button(course_code)
       available_sections_table(course_code).when_not_visible Utils.short_wait
     else
       logger.debug "The sections table is already collapsed for #{course_code}"

--- a/pages/ripley/ripley_create_course_site_page.rb
+++ b/pages/ripley/ripley_create_course_site_page.rb
@@ -118,7 +118,7 @@ class RipleyCreateCourseSitePage < RipleySiteCreationPage
 
   def click_next
     wait_until(Utils.short_wait) { !next_button_element.attribute('disabled') }
-    wait_for_update_and_click_js next_button_element
+    wait_for_update_and_click next_button_element
     site_name_input_element.when_visible Utils.medium_wait
   end
 

--- a/pages/ripley/ripley_official_sections_page.rb
+++ b/pages/ripley/ripley_official_sections_page.rb
@@ -128,7 +128,7 @@ class RipleyOfficialSectionsPage
 
   def click_undo_add_section(section)
     logger.debug "Clicking undo add button for section #{section.id}"
-    wait_for_update_and_click_js section_undo_add_button(section)
+    wait_for_update_and_click section_undo_add_button(section)
     sleep 1
   end
 
@@ -186,7 +186,7 @@ class RipleyOfficialSectionsPage
 
   def click_add_section(course, section)
     logger.debug "Clicking add button for section #{section.id}"
-    wait_for_update_and_click_js section_add_button(course, section)
+    wait_for_update_and_click section_add_button(course, section)
     sleep 1
   end
 
@@ -205,7 +205,7 @@ class RipleyOfficialSectionsPage
 
   def click_undo_delete_section(course, section)
     logger.debug "Clicking undo delete button section #{section.id}"
-    wait_for_update_and_click_js section_undo_delete_button(course, section)
+    wait_for_update_and_click section_undo_delete_button(course, section)
     sleep 1
   end
 end

--- a/pages/ripley/ripley_pages.rb
+++ b/pages/ripley/ripley_pages.rb
@@ -75,7 +75,7 @@ module RipleyPages
 
   def click_continue
     logger.debug 'Clicking continue'
-    wait_for_load_and_click_js continue_button_element
+    wait_for_load_and_click continue_button_element
   end
 
   def click_cancel(course_site)

--- a/pages/ripley/ripley_roster_photos_page.rb
+++ b/pages/ripley/ripley_roster_photos_page.rb
@@ -43,7 +43,7 @@ class RipleyRosterPhotosPage
 
   def click_roster_photos_link
     logger.info 'Clicking Roster Photos link'
-    wait_for_load_and_click_js roster_photos_link_element
+    wait_for_load_and_click roster_photos_link_element
     switch_to_canvas_iframe RipleyUtils.base_url
   end
 

--- a/pages/squiggy/squiggy_asset_library_detail_page.rb
+++ b/pages/squiggy/squiggy_asset_library_detail_page.rb
@@ -65,7 +65,7 @@ class SquiggyAssetLibraryDetailPage < SquiggyAssetLibraryListViewPage
   def click_category_link(category)
     logger.info "Clicking link to category '#{category.name}'"
     scroll_to_bottom
-    wait_for_update_and_click_js category_el_by_id(category)
+    wait_for_update_and_click category_el_by_id(category)
   end
 
   def no_category_el
@@ -191,7 +191,7 @@ class SquiggyAssetLibraryDetailPage < SquiggyAssetLibraryListViewPage
   def click_like_button
     logger.info 'Clicking the like button'
     scroll_to_bottom
-    wait_for_update_and_click_js like_button_element
+    wait_for_update_and_click like_button_element
     sleep Utils.click_wait
   end
 
@@ -251,7 +251,7 @@ class SquiggyAssetLibraryDetailPage < SquiggyAssetLibraryListViewPage
   end
 
   def click_reply_button(comment)
-    wait_for_update_and_click_js reply_button_el(comment)
+    wait_for_update_and_click reply_button_el(comment)
   end
 
   def reply_input_el(comment)
@@ -272,7 +272,7 @@ class SquiggyAssetLibraryDetailPage < SquiggyAssetLibraryListViewPage
     click_reply_button comment
     scroll_to_bottom
     enter_squiggy_text(reply_input_el(comment), reply_comment.body)
-    wait_for_update_and_click_js reply_save_button
+    wait_for_update_and_click reply_save_button
     comment_el_by_body(reply_comment).when_visible Utils.short_wait
     reply_comment.set_comment_id
     visible_comment reply_comment
@@ -299,7 +299,7 @@ class SquiggyAssetLibraryDetailPage < SquiggyAssetLibraryListViewPage
   end
 
   def click_edit_button(comment)
-    wait_for_update_and_click_js edit_button(comment)
+    wait_for_update_and_click edit_button(comment)
   end
 
   def edit_comment_text_area(comment)
@@ -329,7 +329,7 @@ class SquiggyAssetLibraryDetailPage < SquiggyAssetLibraryListViewPage
 
   def delete_comment(comment)
     scroll_to_bottom
-    wait_for_update_and_click_js delete_comment_button(comment)
+    wait_for_update_and_click delete_comment_button(comment)
     wait_for_update_and_click confirm_delete_button_element
     comment_el_by_id(comment).when_not_present Utils.short_wait
   end

--- a/pages/squiggy/squiggy_asset_library_list_view_page.rb
+++ b/pages/squiggy/squiggy_asset_library_list_view_page.rb
@@ -17,7 +17,7 @@ class SquiggyAssetLibraryListViewPage
   button(:upload_button, id: 'go-upload-asset-btn')
 
   def click_upload_file_button
-    wait_for_update_and_click_js upload_button_element
+    wait_for_update_and_click upload_button_element
   end
 
   def upload_file_asset(asset)
@@ -33,7 +33,7 @@ class SquiggyAssetLibraryListViewPage
   span(:bad_jam_error_msg, xpath: "//span[text()='In order to add a Google Jamboard to the Asset Library, sharing must be set to \"Anyone with the link.\"']")
 
   def click_add_url_button
-    wait_for_update_and_click_js add_link_button_element
+    wait_for_update_and_click add_link_button_element
   end
 
   def add_link_asset(asset)

--- a/pages/squiggy/squiggy_asset_library_metadata_form.rb
+++ b/pages/squiggy/squiggy_asset_library_metadata_form.rb
@@ -23,7 +23,7 @@ module SquiggyAssetLibraryMetadataForm
 
   def click_add_files_button
     logger.info 'Confirming new file uploads'
-    wait_for_update_and_click_js save_file_button_element
+    wait_for_update_and_click save_file_button_element
   end
 
   def enter_and_upload_file(asset)

--- a/pages/squiggy/squiggy_asset_library_search_form.rb
+++ b/pages/squiggy/squiggy_asset_library_search_form.rb
@@ -157,44 +157,44 @@ module SquiggyAssetLibrarySearchForm
 
     if category
       click_category_search_select
-      wait_for_update_and_click_js parameter_option(category.name)
+      wait_for_update_and_click parameter_option(category.name)
     else
       js_click(parameter_clear_button('Category')) if parameter_clear_button('Category').visible?
     end
 
     if user
       click_uploader_select
-      wait_for_update_and_click_js parameter_option(user.full_name)
+      wait_for_update_and_click parameter_option(user.full_name)
     else
       js_click(parameter_clear_button('User')) if parameter_clear_button('User').visible?
     end
 
     if asset_type
       click_asset_type_select
-      wait_for_update_and_click_js parameter_option(asset_type)
+      wait_for_update_and_click parameter_option(asset_type)
     else
       js_click(parameter_clear_button('Asset type')) if parameter_clear_button('Asset type').visible?
     end
 
     if section
       click_section_select
-      wait_for_update_and_click_js parameter_option(section.sis_id)
+      wait_for_update_and_click parameter_option(section.sis_id)
     elsif section_select?
       js_click(parameter_clear_button('Section')) if parameter_clear_button('Section').visible?
     end
 
     if group
       click_group_select
-      wait_for_update_and_click_js parameter_option("#{group.group_set.title} - #{group.title}")
+      wait_for_update_and_click parameter_option("#{group.group_set.title} - #{group.title}")
     elsif group_select?
       js_click(parameter_clear_button('Group')) if parameter_clear_button('Group').visible?
     end
 
     click_sort_by_select
     if sort_by
-      wait_for_update_and_click_js parameter_option(sort_by)
+      wait_for_update_and_click parameter_option(sort_by)
     else
-      wait_for_update_and_click_js parameter_option('Most recent')
+      wait_for_update_and_click parameter_option('Most recent')
     end
     wait_for_update_and_click advanced_search_submit_element
   end

--- a/pages/squiggy/squiggy_engagement_index_page.rb
+++ b/pages/squiggy/squiggy_engagement_index_page.rb
@@ -107,6 +107,7 @@ class SquiggyEngagementIndexPage
 
   def wait_for_scores
     users_table_element.when_visible Utils.medium_wait
+    sleep 2
   end
 
   def load_scores(test)
@@ -414,13 +415,13 @@ class SquiggyEngagementIndexPage
 
   def click_disable_activity(activity)
     logger.info "Disabling activity type '#{activity.type}'"
-    wait_for_update_and_click_js disable_activity_button(activity)
+    wait_for_update_and_click disable_activity_button(activity)
     enable_activity_button(activity).when_visible 2
   end
 
   def click_enable_activity(activity)
     logger.info "Enabling activity type '#{activity.type}'"
-    wait_for_update_and_click_js enable_activity_button(activity)
+    wait_for_update_and_click enable_activity_button(activity)
     disable_activity_button(activity).when_visible 2
   end
 

--- a/pages/squiggy/squiggy_impact_studio_page.rb
+++ b/pages/squiggy/squiggy_impact_studio_page.rb
@@ -112,7 +112,7 @@ class SquiggyImpactStudioPage
   def select_user(user)
     logger.info "Selecting #{user.full_name}"
     wait_for_element_and_select(user_select_element, user.full_name)
-    wait_for_update_and_click_js user_select_button_element
+    wait_for_update_and_click user_select_button_element
     wait_for_profile user
   end
 
@@ -401,7 +401,7 @@ class SquiggyImpactStudioPage
     sleep 2
     scroll_to_element div_element(id: 'user-assets')
     wait_for_element_and_select(sort_user_assets_select_element, option)
-    wait_for_update_and_click_js sort_user_assets_apply_button_element
+    wait_for_update_and_click sort_user_assets_apply_button_element
   end
 
   def user_asset_xpath(asset)
@@ -449,7 +449,7 @@ class SquiggyImpactStudioPage
     logger.info "Sorting everyone's assets by #{option}"
     scroll_to_element div_element(id: 'everyones-assets')
     wait_for_element_and_select(sort_everyone_assets_select_element, option)
-    wait_for_update_and_click_js sort_everyone_assets_apply_button_element
+    wait_for_update_and_click sort_everyone_assets_apply_button_element
   end
 
   def everyone_asset_xpath(asset)

--- a/pages/squiggy/squiggy_pages.rb
+++ b/pages/squiggy/squiggy_pages.rb
@@ -105,7 +105,7 @@ module SquiggyPages
   end
 
   def click_close_modal_button
-    wait_for_update_and_click_js close_modal_button_element
+    wait_for_update_and_click close_modal_button_element
   end
 
   def get_whiteboard_id(link_element)

--- a/pages/squiggy/squiggy_whiteboard_edit_form.rb
+++ b/pages/squiggy/squiggy_whiteboard_edit_form.rb
@@ -29,7 +29,7 @@ module SquiggyWhiteboardEditForm
   end
 
   def click_collaborators_input
-    wait_for_update_and_click_js collaborators_input_element
+    wait_for_update_and_click collaborators_input_element
   end
 
   def enter_whiteboard_collaborator(user)
@@ -39,7 +39,7 @@ module SquiggyWhiteboardEditForm
   end
 
   def save_whiteboard
-    wait_for_update_and_click_js save_button_element
+    wait_for_update_and_click save_button_element
   end
 
   def click_remove_collaborator(user)

--- a/pages/squiggy/squiggy_whiteboard_page.rb
+++ b/pages/squiggy/squiggy_whiteboard_page.rb
@@ -51,7 +51,7 @@ class SquiggyWhiteboardPage < SquiggyWhiteboardsPage
   end
 
   def click_settings_button
-    wait_for_update_and_click_js settings_button_element
+    wait_for_update_and_click settings_button_element
   end
 
   def edit_whiteboard_title(whiteboard)
@@ -141,7 +141,7 @@ class SquiggyWhiteboardPage < SquiggyWhiteboardsPage
       end
     end
     enter_squiggy_text(export_title_input_element, new_title) if new_title
-    wait_for_update_and_click_js export_save_button_element
+    wait_for_update_and_click export_save_button_element
     export_title_input_element.when_not_present Utils.medium_wait
     export_success_msg_element.when_visible Utils.short_wait
     asset = SquiggyAsset.new(
@@ -173,7 +173,7 @@ class SquiggyWhiteboardPage < SquiggyWhiteboardsPage
   end
 
   def click_download_as_image_button
-    wait_for_update_and_click_js download_as_image_button_element
+    wait_for_update_and_click download_as_image_button_element
   end
 
   def download_as_image
@@ -208,7 +208,7 @@ class SquiggyWhiteboardPage < SquiggyWhiteboardsPage
   button(:delete_asset_button, id: 'delete-btn')
 
   def click_add_existing_asset
-    wait_for_update_and_click_js use_existing_button_element
+    wait_for_update_and_click use_existing_button_element
   end
 
   def add_existing_assets(assets)
@@ -218,8 +218,8 @@ class SquiggyWhiteboardPage < SquiggyWhiteboardsPage
 
   def select_existing_assets(assets)
     sleep 1
-    assets.each { |asset| wait_for_load_and_click_js text_field_element(id: "asset-#{asset.id}") }
-    wait_for_update_and_click_js save_button_element
+    assets.each { |asset| wait_for_load_and_click text_field_element(id: "asset-#{asset.id}") }
+    wait_for_update_and_click save_button_element
     save_button_element.when_not_present Utils.short_wait
   end
 
@@ -230,9 +230,9 @@ class SquiggyWhiteboardPage < SquiggyWhiteboardsPage
   def click_add_new_asset(asset)
     hit_escape
     if asset.file_name
-      wait_for_update_and_click_js upload_new_button_element
+      wait_for_update_and_click upload_new_button_element
     else
-      wait_for_update_and_click_js add_link_button_element
+      wait_for_update_and_click add_link_button_element
     end
   end
 

--- a/pages/squiggy/squiggy_whiteboards_page.rb
+++ b/pages/squiggy/squiggy_whiteboards_page.rb
@@ -110,7 +110,7 @@ class SquiggyWhiteboardsPage
     end
 
     if user
-      wait_for_update_and_click_js adv_search_user_input_element
+      wait_for_update_and_click adv_search_user_input_element
       select_squiggy_option user.full_name
     end
 

--- a/spec/junction/canvas_lti_course_add_user_spec.rb
+++ b/spec/junction/canvas_lti_course_add_user_spec.rb
@@ -89,7 +89,7 @@ describe 'bCourses Find a Person to Add', order: :defined do
       if standalone
         skip 'Skipping test since in standalone mode'
       else
-        @canvas.wait_for_load_and_click_js @canvas.add_people_button_element
+        @canvas.wait_for_load_and_click @canvas.add_people_button_element
         @canvas.find_person_to_add_link_element.when_visible Utils.short_wait
         expect(@canvas.add_user_by_email_label_element.text).to eql('Email Address')
         @canvas.wait_for_update_and_click @canvas.add_user_by_email_element

--- a/spec/junction/canvas_lti_course_site_creation_spec.rb
+++ b/spec/junction/canvas_lti_course_site_creation_spec.rb
@@ -186,10 +186,10 @@ describe 'bCourses course site creation' do
         it("shows the default site abbreviation #{site[:course].code}") { expect(default_abbreviation).to include(expected_abbreviation) }
 
         requires_name_and_abbreviation = @create_course_site_page.verify_block do
-          @create_course_site_page.site_name_input_element.clear
+          @create_course_site_page.clear_input_value site_name_input_element
           @create_course_site_page.site_name_error_element.when_present 1
           @create_course_site_page.wait_until(1) { @create_course_site_page.create_site_button_element.attribute('disabled') }
-          @create_course_site_page.site_abbreviation_element.clear
+          @create_course_site_page.clear_input_value site_abbreviation_element
           @create_course_site_page.site_abbreviation_error_element.when_present 1
         end
 
@@ -202,6 +202,7 @@ describe 'bCourses course site creation' do
         if standalone
           @create_course_site_page.wait_for_standalone_site_id(site[:course], site[:teacher], @splash_page)
         else
+          Utils.save_screenshot(@driver, site[:course].code)
           @create_course_site_page.wait_for_site_id site[:course]
         end
 
@@ -308,7 +309,7 @@ describe 'bCourses course site creation' do
           it("shows a Roster Photos tool link in course site navigation for #{site[:course].term} #{site[:course].code} site ID #{site[:course].site_id}") { expect(has_roster_photos_link).to be true }
 
           @roster_photos_page.load_embedded_tool site[:course]
-          @roster_photos_page.wait_for_load_and_click_js @roster_photos_page.section_select_element
+          @roster_photos_page.wait_for_load_and_click @roster_photos_page.section_select_element
 
           expected_sections_on_site = (site[:sections_for_site].map { |section| "#{section.course} #{section.label}" })
           actual_sections_on_site = @roster_photos_page.section_options

--- a/spec/ripley/course_site_creation_spec.rb
+++ b/spec/ripley/course_site_creation_spec.rb
@@ -272,7 +272,7 @@ describe 'bCourses course site creation' do
           end
 
           @roster_photos_page.load_embedded_tool site.course
-          @roster_photos_page.wait_for_load_and_click_js @roster_photos_page.section_select_element
+          @roster_photos_page.wait_for_load_and_click @roster_photos_page.section_select_element
 
           expected_sections_on_site = (site.sections.map { |section| "#{section.course} #{section.label}" })
           actual_sections_on_site = @roster_photos_page.section_options

--- a/spec/ripley/mailing_lists_spec.rb
+++ b/spec/ripley/mailing_lists_spec.rb
@@ -25,6 +25,7 @@ unless ENV['STANDALONE']
       @create_project_site_page = RipleyCreateProjectSitePage.new @driver
 
       @canvas_page.log_in(@cal_net_page, test.admin.username, Utils.super_admin_password)
+      RipleyTool::TOOLS.each { |t| @canvas_page.add_ripley_tool t }
       @canvas_page.create_ripley_mailing_list_site course_site_1
       @canvas_page.create_ripley_mailing_list_site course_site_2
       @canvas_page.create_ripley_mailing_list_site course_site_3


### PR DESCRIPTION
Makes JS a fallback means of clicking all elements, rather than primary means for some elements.  Also temporarily ditches visibility checks for elements.