### PR TITLE
Ditch standalone mode in Ripley tests

### DIFF
--- a/pages/canvas/canvas_api_page.rb
+++ b/pages/canvas/canvas_api_page.rb
@@ -12,6 +12,11 @@ class CanvasAPIPage
     @parsed.map { |s| s['sis_section_id'].gsub('SEC:', '') }
   end
 
+  def get_course_site_section_ccns(site_id)
+    ids = get_course_site_sis_section_ids site_id
+    ids.map { |i| i.split('-')[2] }
+  end
+
   def get_tool_id(tool)
     tries ||= Utils.short_wait
     logger.info "Getting #{tool.name} id from #{Utils.canvas_base_url}/api/v1/accounts/#{tool.account}/external_tools"

--- a/pages/ripley/ripley_create_course_site_page.rb
+++ b/pages/ripley/ripley_create_course_site_page.rb
@@ -31,6 +31,12 @@ class RipleyCreateCourseSitePage < RipleySiteCreationPage
 
   def choose_term(course)
     wait_for_update_and_click button_element(xpath: "//button[contains(., '#{course.term.name}')]")
+  rescue => e
+    if h2_element(xpath: "//h2[text()='#{course.term.name} Official Sections']").exists?
+      logger.warn 'Only one term exists'
+    else
+      fail Utils.error e
+    end
   end
 
   def search_for_course(site)
@@ -194,15 +200,15 @@ class RipleyCreateCourseSitePage < RipleySiteCreationPage
   end
 
   def provision_course_site(site, opts={})
-    opts[:standalone] ? load_standalone_tool : load_embedded_tool(site.course.teachers.first)
+    load_embedded_tool site.course.teachers.first
     click_create_course_site
     site.course.create_site_workflow = 'ccn' if opts[:admin]
     search_for_course site
-    expand_available_course_sections(site.course.code, site.sections.first)
+    expand_available_course_sections(site.course, site.sections.first)
     select_sections site.sections
     click_next
     site.course.title = enter_site_titles site.course
     click_create_site
-    wait_for_site_id(site) unless opts[:standalone]
+    wait_for_site_id site
   end
 end

--- a/spec/ripley/course_site_creation_spec.rb
+++ b/spec/ripley/course_site_creation_spec.rb
@@ -249,6 +249,8 @@ describe 'bCourses course site creation' do
           expect(actual_sections_on_site).to eql(expected_sections_on_site.sort)
         end
 
+        # TODO - Verify TA has edit access to official sections if only secondary sections on course site
+
         # CONFERENCES TOOL - verify it's hidden
 
         conf_nav_present = @canvas.conf_tool_link?

--- a/spec/ripley/e_grades_export_spec.rb
+++ b/spec/ripley/e_grades_export_spec.rb
@@ -1,350 +1,347 @@
-unless ENV['STANDALONE']
+require_relative '../../util/spec_helper'
 
-  require_relative '../../util/spec_helper'
+describe 'bCourses E-Grades Export' do
 
-  describe 'bCourses E-Grades Export' do
+  include Logging
 
-    include Logging
+  test = RipleyTestConfig.new
+  site = test.get_e_grades_export_site
+  non_teachers = [
+    test.lead_ta,
+    test.ta,
+    test.designer,
+    test.reader,
+    test.observer,
+    test.students.first,
+    test.wait_list_student
+  ]
 
-    test = RipleyTestConfig.new
-    site = test.get_e_grades_export_site
-    non_teachers = [
-      test.lead_ta,
-      test.ta,
-      test.designer,
-      test.reader,
-      test.observer,
-      test.students.first,
-      test.wait_list_student
-    ]
+  before(:all) do
+    @driver = Utils.launch_browser
+    @cal_net = Page::CalNetPage.new @driver
+    @canvas_api = CanvasAPIPage.new @driver
+    @canvas = Page::CanvasGradesPage.new @driver
+    @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
+    @splash_page = RipleySplashPage.new @driver
+    @e_grades_export_page = RipleyEGradesPage.new @driver
+    @course_add_user_page = RipleyAddUserPage.new @driver
+
+    @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
+    RipleyTool::TOOLS.each { |t| @canvas.add_ripley_tool t }
+    section_ids = @canvas_api.get_course_site_sis_section_ids site.site_id
+    test.get_existing_site_data(site, section_ids)
+    @teacher = site.course.teachers.find { |t| t.role_code == 'PI' } || site.course.teachers.first
+    @canvas.set_canvas_ids([@teacher] + non_teachers)
+
+    @primary_enrollments = site.course.sections.select(&:primary).map(&:enrollments).flatten
+    @primary_section = site.sections.find &:primary
+    @secondary_section = site.sections.reject(&:primary).first
+
+    # Create an ungraded assignment to use for testing manual grading policy
+    @canvas.masquerade_as @teacher
+    @ungraded_assignment = Assignment.new title: test.id
+    @canvas.set_grade_policy_manual site
+    @canvas_assignments_page.create_assignment(site, @ungraded_assignment)
+  end
+
+  after(:all) { Utils.quit_browser @driver }
+
+  it 'offers an E-Grades Export button on the Gradebook' do
+    @canvas.load_gradebook site
+    @canvas.click_e_grades_export_button
+    @e_grades_export_page.wait_until(Utils.medium_wait) { @e_grades_export_page.title == RipleyTool::E_GRADES.name }
+    expect(@e_grades_export_page.i_frame_form_element? test.base_url).to be true
+  end
+
+  context 'when no grading scheme is enabled and an assignment is un-posted' do
+
+    before(:all) { @canvas.disable_grading_scheme site }
+
+    before(:each) { @e_grades_export_page.load_embedded_tool site }
+
+    it('offers a "Course Settings" link') { @e_grades_export_page.click_course_settings_button site }
+
+    it 'offers a "How do I post grades for an assignment?" link' do
+      title = 'How do I post grades for an assignment'
+      expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
+    end
+
+    it('allows the user to Cancel') { @e_grades_export_page.click_cancel site }
+
+    it 'prevents the user continuing' do
+      @e_grades_export_page.continue_button_element.when_visible Utils.medium_wait
+      expect(@e_grades_export_page.continue_button_element.attribute('disabled')).to eql('true')
+    end
+  end
+
+  context 'when a grading scheme is enabled and an assignment is un-posted' do
+
+    before(:all) { @canvas.enable_grading_scheme site }
+
+    before(:each) { @e_grades_export_page.load_embedded_tool site }
+
+    it('offers a "Course Settings" link') { @e_grades_export_page.click_course_settings_button site }
+
+    it 'offers a "How do I post grades for an assignment?" link' do
+      title = 'How do I post grades for an assignment'
+      expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
+    end
+
+    it('allows the user to Cancel') { @e_grades_export_page.click_cancel site }
+
+    it 'allows the user to Continue' do
+      @e_grades_export_page.click_continue
+      @e_grades_export_page.download_final_grades_element.when_visible Utils.medium_wait
+    end
+  end
+
+  context 'when no assignment is muted and a grading scheme is enabled' do
 
     before(:all) do
-      @driver = Utils.launch_browser
-      @cal_net = Page::CalNetPage.new @driver
-      @canvas_api = CanvasAPIPage.new @driver
-      @canvas = Page::CanvasGradesPage.new @driver
-      @canvas_assignments_page = Page::CanvasAssignmentsPage.new @driver
-      @splash_page = RipleySplashPage.new @driver
-      @e_grades_export_page = RipleyEGradesPage.new @driver
-      @course_add_user_page = RipleyAddUserPage.new @driver
+      @prim_sec_sids = @primary_section.enrollments.map { |e| e.user.sis_id }
+      @sec_sec_sids = @secondary_section.enrollments.map { |e| e.user.sis_id } if @secondary_section
 
-      @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
-      RipleyTool::TOOLS.each { |t| @canvas.add_ripley_tool t }
-      section_ids = @canvas_api.get_course_site_sis_section_ids site.site_id
-      test.get_existing_site_data(site, section_ids)
-      @teacher = site.course.teachers.find { |t| t.role_code == 'PI' } || site.course.teachers.first
-      @canvas.set_canvas_ids([@teacher] + non_teachers)
-
-      @primary_enrollments = site.course.sections.select(&:primary).map(&:enrollments).flatten
-      @primary_section = site.sections.find &:primary
-      @secondary_section = site.sections.reject(&:primary).first
-
-      # Create an ungraded assignment to use for testing manual grading policy
-      @canvas.masquerade_as @teacher
-      @ungraded_assignment = Assignment.new title: test.id
-      @canvas.set_grade_policy_manual site
-      @canvas_assignments_page.create_assignment(site, @ungraded_assignment)
+      @e_grades_export_page.load_embedded_tool site
+      @e_grades_export_page.click_continue
     end
 
-    after(:all) { Utils.quit_browser @driver }
+    it 'allows the user the select any section on the course site' do
+      expected_options = site.sections.map { |s| "#{s.course} #{s.label}" }
+      expected_options << 'Choose...'
+      visible_options = @e_grades_export_page.sections_select_options.map &:strip
+      if expected_options.length > 1
+        expect(visible_options.sort).to eql(expected_options.sort)
+      end
+    end
 
-    it 'offers an E-Grades Export button on the Gradebook' do
+    it 'requires the user to select a pass / no pass cutoff grade' do
+      expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
+      expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
+    end
+
+    shared_examples 'CSV downloads' do |cutoff|
+
+      it 'allows the user to download current grades for a primary section' do
+        csv = @e_grades_export_page.download_current_grades(site, @primary_section, cutoff)
+        if site.course.term == test.current_term.name
+          expect(csv.any?).to be true
+        else
+          expected_sids = @prim_sec_sids.sort
+          actual_sids = csv.map { |k| k[:id] }.sort
+          @e_grades_export_page.wait_until(1, "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+            expected_sids == actual_sids
+          end
+        end
+      end
+
+      it 'allows the user to download current grades for a secondary section' do
+        if @secondary_section
+          csv = @e_grades_export_page.download_current_grades(site, @secondary_section, cutoff)
+          if site.course.term.name == test.current_term.name
+            expect(csv.any?).to be true
+          else
+            expected_sids = @sec_sec_sids.sort
+            actual_sids = csv.map { |k| k[:id] }.sort
+            @e_grades_export_page.wait_until(1, "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+              expected_sids == actual_sids
+            end
+          end
+        end
+      end
+
+      it 'allows the user to download final grades for a primary section' do
+        csv = @e_grades_export_page.download_final_grades(site, @primary_section, cutoff)
+        if site.course.term == test.current_term.name
+          expect(csv.any?).to be true
+        else
+          expected_sids = @prim_sec_sids.sort
+          actual_sids = csv.map { |k| k[:id] }.sort
+          @e_grades_export_page.wait_until(1, "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+            expected_sids == actual_sids
+          end
+        end
+      end
+
+      it 'allows the user to download final grades for a secondary section' do
+        if @secondary_section
+          csv = @e_grades_export_page.download_final_grades(site, @secondary_section, cutoff)
+          if site.course.term == test.current_term.name
+            expect(csv.any?).to be true
+          else
+            expected_sids = @sec_sec_sids.sort
+            actual_sids = csv.map { |k| k[:id] }.sort
+            @e_grades_export_page.wait_until(1, "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+              expected_sids == actual_sids
+            end
+          end
+        end
+      end
+    end
+
+    context 'and the user selects a pass / no pass cutoff' do
+
+      include_examples 'CSV downloads', 'C-'
+
+    end
+
+    context 'and the user does not select a pass / no pass cutoff' do
+
+      include_examples 'CSV downloads', nil
+
+    end
+  end
+
+  describe 'CSV export' do
+
+    before(:all) do
+      @e_grades = @e_grades_export_page.download_final_grades(site, @primary_section, 'C-')
+    end
+
+    it 'has the right column headers' do
+      expected_header = %w(id name grade grading_basis comments).map { |h| h.to_sym }
+      actual_header = (@e_grades.map { |h| h.keys }).flatten.uniq
+      logger.debug "Expecting #{expected_header} and got #{actual_header}"
+      expect(actual_header).to eql(expected_header)
+    end
+
+    it 'has the right SIDs' do
+      expected_sids = @primary_enrollments.map(&:user).map(&:sis_id).sort
+      actual_sids = @e_grades.map { |s| s[:id] }.sort
+      logger.debug "Expecting #{expected_sids} and got #{actual_sids}"
+      expect(actual_sids.any? &:empty?).to be false
+      @e_grades_export_page.wait_until(1, "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
+        expected_sids == actual_sids
+      end
+    end
+
+    it 'has the right names' do
+      # Compare last names only, since preferred names can cause mismatches
+      expected_names = @primary_enrollments.map(&:user).map { |u| u.last_name.strip.downcase }.sort
+      actual_names = @e_grades.map { |n| n[:name].split(',')[0].strip.downcase }.sort
+      logger.debug "Expecting #{expected_names} and got #{actual_names}"
+      expect(actual_names.any? &:empty?).to be false
+      @e_grades_export_page.wait_until(1, "Missing: #{expected_names - actual_names}. Unexpected: #{actual_names - expected_names}") do
+        expected_names == actual_names
+      end
+    end
+
+    it 'has reasonable grades' do
+      expected_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F P NP S U)
+      actual_grades = @e_grades.map { |g| g[:grade] }
+      logger.debug "Expecting #{expected_grades} and got #{actual_grades.uniq}"
+      expect(actual_grades.any? &:empty?).to be false
+      expect((actual_grades - expected_grades).any?).to be false
+    end
+
+    it 'has reasonable grading bases' do
+      expected_grading_bases = %w(CPN DPN EPN ESU FRZ GRD)
+      actual_grading_bases = @e_grades.map { |b| b[:grading_basis] }
+      logger.debug "Expecting #{expected_grading_bases} and got #{actual_grading_bases.uniq}"
+      expect(actual_grading_bases.any? &:empty?).to be false
+      expect(actual_grading_bases - expected_grading_bases).to be_empty
+    end
+  end
+
+  describe 'final grade' do
+
+    before(:all) do
+      students = @canvas.get_students(site, @primary_section, nil, { enrollments: true })
+      @canvas.enable_grading_scheme site
       @canvas.load_gradebook site
-      @canvas.click_e_grades_export_button
-      @e_grades_export_page.wait_until(Utils.medium_wait) { @e_grades_export_page.title == RipleyTool::E_GRADES.name }
-      expect(@e_grades_export_page.i_frame_form_element? test.base_url).to be true
+      @grades_are_final = @canvas.grades_final?
+      logger.info "Grades are final is #{@grades_are_final}"
+      @canvas.hit_escape
+
+      # Get actual grade data for one student
+      test_data = nil
+      students.each do |user|
+        sis_enrollment = @primary_enrollments.find { |e| e.user.uid == user.uid }
+        if sis_enrollment
+          sis_student = sis_enrollment.user
+          user.sis_id = sis_student.sis_id
+          user.full_name = "#{sis_student.first_name} #{sis_student.last_name}"
+          score = user.sis_id.nil? ? nil : @canvas.student_score(user)
+          if score.instance_of? Hash
+            test_data = score
+            break
+          end
+        end
+      end
+      logger.debug "Test data: #{test_data}"
+
+      @test_student = test_data[:student]
+      @test_grade = test_data[:grade]
+      @override_grade = %w(A A- B+ B B- C+ C C- D+ D D- F).find { |g| g != @test_grade }
     end
 
-    context 'when no grading scheme is enabled and an assignment is un-posted' do
-
-      before(:all) { @canvas.disable_grading_scheme site }
-
-      before(:each) { @e_grades_export_page.load_embedded_tool site }
-
-      it('offers a "Course Settings" link') { @e_grades_export_page.click_course_settings_button site }
-
-      it 'offers a "How do I post grades for an assignment?" link' do
-        title = 'How do I post grades for an assignment'
-        expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
-      end
-
-      it('allows the user to Cancel') { @e_grades_export_page.click_cancel site }
-
-      it 'prevents the user continuing' do
-        @e_grades_export_page.continue_button_element.when_visible Utils.medium_wait
-        expect(@e_grades_export_page.continue_button_element.attribute('disabled')).to eql('true')
-      end
-    end
-
-    context 'when a grading scheme is enabled and an assignment is un-posted' do
-
-      before(:all) { @canvas.enable_grading_scheme site }
-
-      before(:each) { @e_grades_export_page.load_embedded_tool site }
-
-      it('offers a "Course Settings" link') { @e_grades_export_page.click_course_settings_button site }
-
-      it 'offers a "How do I post grades for an assignment?" link' do
-        title = 'How do I post grades for an assignment'
-        expect(@e_grades_export_page.external_link_valid?(@e_grades_export_page.how_to_post_grades_link_element, title)).to be true
-      end
-
-      it('allows the user to Cancel') { @e_grades_export_page.click_cancel site }
-
-      it 'allows the user to Continue' do
-        @e_grades_export_page.click_continue
-        @e_grades_export_page.download_final_grades_element.when_visible Utils.medium_wait
-      end
-    end
-
-    context 'when no assignment is muted and a grading scheme is enabled' do
+    context 'when override is enabled' do
 
       before(:all) do
-        @prim_sec_sids = @primary_section.enrollments.map { |e| e.user.sis_id }
-        @sec_sec_sids = @secondary_section.enrollments.map { |e| e.user.sis_id } if @secondary_section
-
-        @e_grades_export_page.load_embedded_tool site
-        @e_grades_export_page.click_continue
-      end
-
-      it 'allows the user the select any section on the course site' do
-        expected_options = site.sections.map { |s| "#{s.course} #{s.label}" }
-        expected_options << 'Choose...'
-        visible_options = @e_grades_export_page.sections_select_options.map &:strip
-        if expected_options.length > 1
-          expect(visible_options.sort).to eql(expected_options.sort)
-        end
-      end
-
-      it 'requires the user to select a pass / no pass cutoff grade' do
-        expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
-        expect(@e_grades_export_page.download_current_grades_element.enabled?).to be false
-      end
-
-      shared_examples 'CSV downloads' do |cutoff|
-
-        it 'allows the user to download current grades for a primary section' do
-          csv = @e_grades_export_page.download_current_grades(site, @primary_section, cutoff)
-          if site.course.term == test.current_term.name
-            expect(csv.any?).to be true
-          else
-            expected_sids = @prim_sec_sids.sort
-            actual_sids = csv.map { |k| k[:id] }.sort
-            @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-              expected_sids == actual_sids
-            end
-          end
-        end
-
-        it 'allows the user to download current grades for a secondary section' do
-          if @secondary_section
-            csv = @e_grades_export_page.download_current_grades(site, @secondary_section, cutoff)
-            if site.course.term.name == test.current_term.name
-              expect(csv.any?).to be true
-            else
-              expected_sids = @sec_sec_sids.sort
-              actual_sids = csv.map { |k| k[:id] }.sort
-              @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-                expected_sids == actual_sids
-              end
-            end
-          end
-        end
-
-        it 'allows the user to download final grades for a primary section' do
-          csv = @e_grades_export_page.download_final_grades(site, @primary_section, cutoff)
-          if site.course.term == test.current_term.name
-            expect(csv.any?).to be true
-          else
-            expected_sids = @prim_sec_sids.sort
-            actual_sids = csv.map { |k| k[:id] }.sort
-            @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-              expected_sids == actual_sids
-            end
-          end
-        end
-
-        it 'allows the user to download final grades for a secondary section' do
-          if @secondary_section
-            csv = @e_grades_export_page.download_final_grades(site, @secondary_section, cutoff)
-            if site.course.term == test.current_term.name
-              expect(csv.any?).to be true
-            else
-              expected_sids = @sec_sec_sids.sort
-              actual_sids = csv.map { |k| k[:id] }.sort
-              @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-                expected_sids == actual_sids
-              end
-            end
-          end
-        end
-      end
-
-      context 'and the user selects a pass / no pass cutoff' do
-
-        include_examples 'CSV downloads', 'C-'
-
-      end
-
-      context 'and the user does not select a pass / no pass cutoff' do
-
-        include_examples 'CSV downloads', nil
-
-      end
-    end
-
-    describe 'CSV export' do
-
-      before(:all) do
-        @e_grades = @e_grades_export_page.download_final_grades(site, @primary_section, 'C-')
-      end
-
-      it 'has the right column headers' do
-        expected_header = %w(id name grade grading_basis comments).map { |h| h.to_sym }
-        actual_header = (@e_grades.map { |h| h.keys }).flatten.uniq
-        logger.debug "Expecting #{expected_header} and got #{actual_header}"
-        expect(actual_header).to eql(expected_header)
-      end
-
-      it 'has the right SIDs' do
-        expected_sids = @primary_enrollments.map(&:user).map(&:sis_id).sort
-        actual_sids = @e_grades.map { |s| s[:id] }.sort
-        logger.debug "Expecting #{expected_sids} and got #{actual_sids}"
-        expect(actual_sids.any? &:empty?).to be false
-        @e_grades_export_page.wait_until(1,  "Missing: #{expected_sids - actual_sids}. Unexpected: #{actual_sids - expected_sids}") do
-          expected_sids == actual_sids
-        end
-      end
-
-      it 'has the right names' do
-        # Compare last names only, since preferred names can cause mismatches
-        expected_names = @primary_enrollments.map(&:user).map { |u| u.last_name.strip.downcase }.sort
-        actual_names = @e_grades.map { |n| n[:name].split(',')[0].strip.downcase }.sort
-        logger.debug "Expecting #{expected_names} and got #{actual_names}"
-        expect(actual_names.any? &:empty?).to be false
-        @e_grades_export_page.wait_until(1,  "Missing: #{expected_names - actual_names}. Unexpected: #{actual_names - expected_names}") do
-          expected_names == actual_names
-        end
-      end
-
-      it 'has reasonable grades' do
-        expected_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F P NP S U)
-        actual_grades = @e_grades.map { |g| g[:grade] }
-        logger.debug "Expecting #{expected_grades} and got #{actual_grades.uniq}"
-        expect(actual_grades.any? &:empty?).to be false
-        expect((actual_grades - expected_grades).any?).to be false
-      end
-
-      it 'has reasonable grading bases' do
-        expected_grading_bases = %w(CPN DPN EPN ESU FRZ GRD)
-        actual_grading_bases = @e_grades.map { |b| b[:grading_basis] }
-        logger.debug "Expecting #{expected_grading_bases} and got #{actual_grading_bases.uniq}"
-        expect(actual_grading_bases.any? &:empty?).to be false
-        expect(actual_grading_bases - expected_grading_bases).to be_empty
-      end
-    end
-
-    describe 'final grade' do
-
-      before(:all) do
-        students = @canvas.get_students(site, @primary_section, nil, {enrollments: true})
-        @canvas.enable_grading_scheme site
         @canvas.load_gradebook site
-        @grades_are_final = @canvas.grades_final?
-        logger.info "Grades are final is #{@grades_are_final}"
-        @canvas.hit_escape
-
-        # Get actual grade data for one student
-        test_data = nil
-        students.each do |user|
-          sis_enrollment = @primary_enrollments.find { |e| e.user.uid == user.uid }
-          if sis_enrollment
-            sis_student = sis_enrollment.user
-            user.sis_id = sis_student.sis_id
-            user.full_name = "#{sis_student.first_name} #{sis_student.last_name}"
-            score = user.sis_id.nil? ? nil : @canvas.student_score(user)
-            if score.instance_of? Hash
-              test_data = score
-              break
-            end
-          end
-        end
-        logger.debug "Test data: #{test_data}"
-
-        @test_student = test_data[:student]
-        @test_grade = test_data[:grade]
-        @override_grade = %w(A A- B+ B B- C+ C C- D+ D D- F).find { |g| g != @test_grade }
+        @canvas.allow_grade_override
+        @canvas.enter_override_grade(site, @test_student, @override_grade)
       end
 
-      context 'when override is enabled' do
-
-        before(:all) do
-          @canvas.load_gradebook site
-          @canvas.allow_grade_override
-          @canvas.enter_override_grade(site, @test_student, @override_grade)
-        end
-
-        it 'downloads the override grade rather than the calculated grade in current grades' do
-          e_grades = @e_grades_export_page.download_current_grades(site, @primary_section)
-          e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
-          expect(e_grades_row[:grade]).to eql(@override_grade)
-        end
-
-        it 'downloads the override grade rather than the calculated grade in final grades' do
-          e_grades = @e_grades_export_page.download_final_grades(site, @primary_section)
-          e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
-          expect(e_grades_row[:grade]).to eql(@override_grade)
-        end
+      it 'downloads the override grade rather than the calculated grade in current grades' do
+        e_grades = @e_grades_export_page.download_current_grades(site, @primary_section)
+        e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
+        expect(e_grades_row[:grade]).to eql(@override_grade)
       end
 
-      context 'when override is disabled' do
-
-        before(:all) do
-          @canvas.load_gradebook site
-          @canvas.disallow_grade_override
-        end
-
-        it 'downloads the calculated grade rather than the override grade' do
-          e_grades = if @grades_are_final
-                       @e_grades_export_page.download_final_grades(site, @primary_section)
-                     else
-                       @e_grades_export_page.download_current_grades(site, @primary_section)
-                     end
-
-          e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
-          expect(e_grades_row[:grade]).to eql(@test_grade)
-        end
+      it 'downloads the override grade rather than the calculated grade in final grades' do
+        e_grades = @e_grades_export_page.download_final_grades(site, @primary_section)
+        e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
+        expect(e_grades_row[:grade]).to eql(@override_grade)
       end
     end
 
-    describe 'user role restrictions' do
+    context 'when override is disabled' do
 
       before(:all) do
-        non_teachers.each do |user|
-          @course_add_user_page.load_embedded_tool site
-          @course_add_user_page.search(user.uid, 'CalNet UID')
-          @course_add_user_page.add_user_by_uid(user, @primary_section)
-        end
+        @canvas.load_gradebook site
+        @canvas.disallow_grade_override
       end
 
-      [test.lead_ta, test.ta, test.reader].each do |user|
-        it "denies #{user.role} #{user.uid} access to the tool" do
-          @canvas.masquerade_as(user, site)
-          # TODO - reinstate when button works
-          # @canvas.load_gradebook site
-          # @canvas.click_e_grades_export_button
-          # @e_grades_export_page.switch_to_canvas_iframe
-          @e_grades_export_page.load_embedded_tool site
-          @e_grades_export_page.unauthorized_msg_element.when_visible Utils.medium_wait
-        end
-      end
+      it 'downloads the calculated grade rather than the override grade' do
+        e_grades = if @grades_are_final
+                     @e_grades_export_page.download_final_grades(site, @primary_section)
+                   else
+                     @e_grades_export_page.download_current_grades(site, @primary_section)
+                   end
 
-      [test.designer, test.observer, test.students.first, test.wait_list_student].each do |user|
-        it "denies #{user.role} #{user.uid} access to the tool" do
-          @canvas.masquerade_as(user, site)
-          @e_grades_export_page.load_embedded_tool site
-          @e_grades_export_page.non_teacher_msg_element.when_visible Utils.medium_wait
-        end
+        e_grades_row = e_grades.find { |r| r[:id] == @test_student.sis_id }
+        expect(e_grades_row[:grade]).to eql(@test_grade)
+      end
+    end
+  end
+
+  describe 'user role restrictions' do
+
+    before(:all) do
+      non_teachers.each do |user|
+        @course_add_user_page.load_embedded_tool site
+        @course_add_user_page.search(user.uid, 'CalNet UID')
+        @course_add_user_page.add_user_by_uid(user, @primary_section)
+      end
+    end
+
+    [test.lead_ta, test.ta, test.reader].each do |user|
+      it "denies #{user.role} #{user.uid} access to the tool" do
+        @canvas.masquerade_as(user, site)
+        # TODO - reinstate when button works
+        # @canvas.load_gradebook site
+        # @canvas.click_e_grades_export_button
+        # @e_grades_export_page.switch_to_canvas_iframe
+        @e_grades_export_page.load_embedded_tool site
+        @e_grades_export_page.unauthorized_msg_element.when_visible Utils.medium_wait
+      end
+    end
+
+    [test.designer, test.observer, test.students.first, test.wait_list_student].each do |user|
+      it "denies #{user.role} #{user.uid} access to the tool" do
+        @canvas.masquerade_as(user, site)
+        @e_grades_export_page.load_embedded_tool site
+        @e_grades_export_page.non_teacher_msg_element.when_visible Utils.medium_wait
       end
     end
   end

--- a/spec/ripley/e_grades_validation_spec.rb
+++ b/spec/ripley/e_grades_validation_spec.rb
@@ -1,183 +1,179 @@
-unless ENV['STANDALONE']
+require_relative '../../util/spec_helper'
 
-  require_relative '../../util/spec_helper'
+include Logging
 
-  include Logging
+describe 'bCourses E-Grades Export' do
 
-  describe 'bCourses E-Grades Export' do
+  begin
 
-    begin
+    test = RipleyTestConfig.new
+    test.get_e_grades_test_sites
+    letter_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F)
 
-      test = RipleyTestConfig.new
-      test.get_e_grades_test_sites
-      letter_grades = %w(A+ A A- B+ B B- C+ C C- D+ D D- F)
+    @driver = Utils.launch_browser
+    @cal_net = Page::CalNetPage.new @driver
+    @canvas = Page::CanvasGradesPage.new @driver
+    @canvas_api = CanvasAPIPage.new @driver
+    @splash_page = RipleySplashPage.new @driver
+    @e_grades_export_page = RipleyEGradesPage.new @driver
 
-      @driver = Utils.launch_browser
-      @cal_net = Page::CalNetPage.new @driver
-      @canvas = Page::CanvasGradesPage.new @driver
-      @canvas_api = CanvasAPIPage.new @driver
-      @splash_page = RipleySplashPage.new @driver
-      @e_grades_export_page = RipleyEGradesPage.new @driver
+    @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
+    RipleyTool::TOOLS.each { |t| @canvas.add_ripley_tool t }
 
-      @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
-      RipleyTool::TOOLS.each { |t| @canvas.add_ripley_tool t }
+    test.course_sites.each_with_index do |site, i|
 
-      test.course_sites.each_with_index do |site, i|
+      begin
+        @canvas.stop_masquerading
+        section_ids = @canvas_api.get_course_site_sis_section_ids site.site_id
+        test.get_existing_site_data(site, section_ids)
 
-        begin
-          @canvas.stop_masquerading
-          section_ids = @canvas_api.get_course_site_sis_section_ids site.site_id
-          test.get_existing_site_data(site, section_ids)
+        instructor = site.course.teachers.find { |t| t.role_code == 'PI' } || site.course.teachers.first
+        primary_section = site.sections.find &:primary
+        test_case = "#{site.course.term} #{site.course.code} site #{site.site_id}"
+        @canvas.set_canvas_ids [instructor]
 
-          instructor = site.course.teachers.find { |t| t.role_code == 'PI' } || site.course.teachers.first
-          primary_section = site.sections.find &:primary
-          test_case = "#{site.course.term} #{site.course.code} site #{site.site_id}"
-          @canvas.set_canvas_ids [instructor]
+        # Disable existing grading scheme in case it is not default, then set default scheme
+        @canvas.masquerade_as(instructor, site)
+        students = @canvas.get_students(site, primary_section, nil, { enrollments: true })
 
-          # Disable existing grading scheme in case it is not default, then set default scheme
-          @canvas.masquerade_as(instructor, site)
-          students = @canvas.get_students(site, primary_section, nil, {enrollments: true})
+        %w(letter letter-only pnp sus).each do |scheme|
 
-          %w(letter letter-only pnp sus).each do |scheme|
+          @canvas.enable_grading_scheme site
+          @canvas.set_grading_scheme({ scheme: scheme })
 
-            @canvas.enable_grading_scheme site
-            @canvas.set_grading_scheme({scheme: scheme})
+          # Get grades in Canvas
+          @canvas.load_gradebook site
+          grades_are_final = @canvas.grades_final?
+          logger.info "Grades are final is #{grades_are_final}"
+          @canvas.hit_escape
+          gradebook_grades = students.first(RipleyUtils.e_grades_student_count).map do |stud|
+            @canvas.student_score stud if stud.sis_id
+          end
+          gradebook_grades.compact!
 
-            # Get grades in Canvas
-            @canvas.load_gradebook site
-            grades_are_final = @canvas.grades_final?
-            logger.info "Grades are final is #{grades_are_final}"
-            @canvas.hit_escape
-            gradebook_grades = students.first(RipleyUtils.e_grades_student_count).map do |stud|
-              @canvas.student_score stud if stud.sis_id
-            end
-            gradebook_grades.compact!
+          ### WITH A P/NP CUTOFF ###
 
-            ### WITH A P/NP CUTOFF ###
+          # Get grades in export CSV
+          cutoff = i.even? ? 'C-' : 'A'
+          e_grades = grades_are_final ?
+                       @e_grades_export_page.download_final_grades(site, primary_section, cutoff) :
+                       @e_grades_export_page.download_current_grades(site, primary_section, cutoff)
 
-            # Get grades in export CSV
-            cutoff = i.even? ? 'C-' : 'A'
-            e_grades = grades_are_final ?
-                         @e_grades_export_page.download_final_grades(site, primary_section, cutoff) :
-                         @e_grades_export_page.download_current_grades(site, primary_section, cutoff)
+          if gradebook_grades.any?
+            # Match the grade for each student
+            gradebook_grades.each do |gradebook_row|
+              begin
 
-            if gradebook_grades.any?
-              # Match the grade for each student
-              gradebook_grades.each do |gradebook_row|
-                begin
+                # If an error occurred fetching a grade, then the row might cause an error in the test
+                e_grades_row = e_grades.find do |e_grade|
+                  e_grade[:id] == gradebook_row[:student].sis_id if gradebook_row.instance_of? Hash
+                end
+                if e_grades_row && gradebook_row[:grade]
 
-                  # If an error occurred fetching a grade, then the row might cause an error in the test
-                  e_grades_row = e_grades.find do |e_grade|
-                    e_grade[:id] == gradebook_row[:student].sis_id if gradebook_row.instance_of? Hash
-                  end
-                  if e_grades_row && gradebook_row[:grade]
-
-                    expected_grade = if %w(letter letter-only).include? scheme
-                                       if e_grades_row[:grading_basis] == 'GRD'
-                                         gradebook_row[:grade]
-                                       else
-                                         pass = letter_grades.index(gradebook_row[:grade]) <= letter_grades.index(cutoff)
-                                         if %w(ESU SUS).include? e_grades_row[:grading_basis]
-                                           pass ? 'S' : 'U'
-                                         else
-                                           pass ? 'P' : 'NP'
-                                         end
-                                       end
-                                     else
+                  expected_grade = if %w(letter letter-only).include? scheme
+                                     if e_grades_row[:grading_basis] == 'GRD'
                                        gradebook_row[:grade]
-                                     end
-
-
-                    it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:student].uid} in #{test_case}
-                        with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
-                      expect(e_grades_row[:grade]).to eql(expected_grade)
-                    end
-
-                    expected_comment = case e_grades_row[:grading_basis]
-                                       when 'CPN', 'DPN', 'EPN', 'PNP'
-                                         'P/NP grade'
-                                       when 'ESU', 'SUS'
-                                         'S/U grade'
-                                       when 'CNC'
-                                         'C/NC grade'
+                                     else
+                                       pass = letter_grades.index(gradebook_row[:grade]) <= letter_grades.index(cutoff)
+                                       if %w(ESU SUS).include? e_grades_row[:grading_basis]
+                                         pass ? 'S' : 'U'
                                        else
-                                         nil
+                                         pass ? 'P' : 'NP'
                                        end
-                    it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:student].uid} in #{test_case}
+                                     end
+                                   else
+                                     gradebook_row[:grade]
+                                   end
+
+                  it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:student].uid} in #{test_case}
                         with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
-                      expect(e_grades_row[:comments]).to eql(expected_comment)
-                    end
+                    expect(e_grades_row[:grade]).to eql(expected_grade)
                   end
 
-                rescue => e
-                  Utils.log_error e
-                  it("encountered an unexpected error with #{site.course.code} #{gradebook_row}") { fail e.message }
+                  expected_comment = case e_grades_row[:grading_basis]
+                                     when 'CPN', 'DPN', 'EPN', 'PNP'
+                                       'P/NP grade'
+                                     when 'ESU', 'SUS'
+                                       'S/U grade'
+                                     when 'CNC'
+                                       'C/NC grade'
+                                     else
+                                       nil
+                                     end
+                  it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:student].uid} in #{test_case}
+                        with grading scheme #{scheme} and a P/NP cutoff of #{cutoff}" do
+                    expect(e_grades_row[:comments]).to eql(expected_comment)
+                  end
                 end
-              end
 
-            else
-              it("found no Canvas grades for #{site.course.code}") { fail }
+              rescue => e
+                Utils.log_error e
+                it("encountered an unexpected error with #{site.course.code} #{gradebook_row}") { fail e.message }
+              end
             end
 
-            ### WITH NO P/NP CUTOFF
+          else
+            it("found no Canvas grades for #{site.course.code}") { fail }
+          end
 
-            # Get grades in export CSV
-            cutoff = nil
-            e_grades = grades_are_final ?
-                         @e_grades_export_page.download_final_grades(site, primary_section, cutoff) :
-                         @e_grades_export_page.download_current_grades(site, primary_section, cutoff)
+          ### WITH NO P/NP CUTOFF
 
-            if gradebook_grades.any?
-              # Match the grade for each student
-              gradebook_grades.each do |gradebook_row|
-                begin
+          # Get grades in export CSV
+          cutoff = nil
+          e_grades = grades_are_final ?
+                       @e_grades_export_page.download_final_grades(site, primary_section, cutoff) :
+                       @e_grades_export_page.download_current_grades(site, primary_section, cutoff)
 
-                  # If an error occurred fetching a grade, then the row might cause an error in the test
-                  e_grades_row = e_grades.find do |e_grade|
-                    e_grade[:id] == gradebook_row[:student].sis_id if gradebook_row.instance_of? Hash
-                  end
-                  if e_grades_row && gradebook_row[:grade]
+          if gradebook_grades.any?
+            # Match the grade for each student
+            gradebook_grades.each do |gradebook_row|
+              begin
 
-                    expected_grade = gradebook_row[:grade]
-
-                    it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:student].uid} in #{test_case}
-                        with grading scheme #{scheme} and no P/NP cutoff" do
-                      expect(e_grades_row[:grade]).to eql(expected_grade)
-                    end
-
-                    expected_comment = case e_grades_row[:grading_basis]
-                                       when 'CPN', 'DPN', 'EPN', 'PNP'
-                                         'P/NP grade'
-                                       when 'ESU', 'SUS'
-                                         'S/U grade'
-                                       when 'CNC'
-                                         'C/NC grade'
-                                       else
-                                         nil
-                                       end
-                    it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:student].uid} #{test_case}
-                        with grading scheme #{scheme} and no P/NP cutoff" do
-                      expect(e_grades_row[:comments]).to eql(expected_comment)
-                    end
-                  end
-
-                rescue => e
-                  Utils.log_error e
-                  it("encountered an unexpected error with #{site.course.code} #{gradebook_row}") { fail e.message }
+                # If an error occurred fetching a grade, then the row might cause an error in the test
+                e_grades_row = e_grades.find do |e_grade|
+                  e_grade[:id] == gradebook_row[:student].sis_id if gradebook_row.instance_of? Hash
                 end
+                if e_grades_row && gradebook_row[:grade]
+
+                  expected_grade = gradebook_row[:grade]
+
+                  it "shows the grade '#{expected_grade}' for UID #{gradebook_row[:student].uid} in #{test_case}
+                        with grading scheme #{scheme} and no P/NP cutoff" do
+                    expect(e_grades_row[:grade]).to eql(expected_grade)
+                  end
+
+                  expected_comment = case e_grades_row[:grading_basis]
+                                     when 'CPN', 'DPN', 'EPN', 'PNP'
+                                       'P/NP grade'
+                                     when 'ESU', 'SUS'
+                                       'S/U grade'
+                                     when 'CNC'
+                                       'C/NC grade'
+                                     else
+                                       nil
+                                     end
+                  it "shows the comment '#{expected_comment}' for UID #{gradebook_row[:student].uid} #{test_case}
+                        with grading scheme #{scheme} and no P/NP cutoff" do
+                    expect(e_grades_row[:comments]).to eql(expected_comment)
+                  end
+                end
+
+              rescue => e
+                Utils.log_error e
+                it("encountered an unexpected error with #{site.course.code} #{gradebook_row}") { fail e.message }
               end
             end
           end
-        rescue => e
-          Utils.log_error e
-          it("encountered an unexpected error with #{site.course.code}") { fail e.message }
         end
+      rescue => e
+        Utils.log_error e
+        it("encountered an unexpected error with #{site.course.code}") { fail e.message }
       end
-    rescue => e
-      Utils.log_error e
-      it('encountered an unexpected error') { fail e.message }
-    ensure
-      Utils.quit_browser @driver
     end
+  rescue => e
+    Utils.log_error e
+    it('encountered an unexpected error') { fail e.message }
+  ensure
+    Utils.quit_browser @driver
   end
 end

--- a/spec/ripley/mailing_lists_spec.rb
+++ b/spec/ripley/mailing_lists_spec.rb
@@ -194,7 +194,7 @@ unless ENV['STANDALONE']
         end
 
         it 'updates a mailing list member\'s email address' do
-          RipleyUtils.set_mailing_list_member_email(test.students[0], 'foo@bar.com')
+          RipleyUtils.set_mailing_list_member_email(test.students[0], "foo#{Time.now.to_i}@bar.com")
           @mailing_lists_page.load_embedded_tool
           @mailing_lists_page.search_for_list course_site_1.site_id
           @mailing_lists_page.click_update_memberships
@@ -233,7 +233,7 @@ unless ENV['STANDALONE']
         end
 
         it 'updates a mailing list member\'s email address' do
-          RipleyUtils.set_mailing_list_member_email(test.students[0], 'bar@foo.com')
+          RipleyUtils.set_mailing_list_member_email(test.students[0], "bar#{Time.now.to_i}@foo.com")
           @splash_page.load_page
           @splash_page.click_jobs_link
           @jobs_page.run_job RipleyJob::REFRESH_MAILING_LIST

--- a/spec/ripley/refresh_canvas_recent_manual_spec.rb
+++ b/spec/ripley/refresh_canvas_recent_manual_spec.rb
@@ -1,152 +1,149 @@
-unless ENV['STANDALONE']
+require_relative '../../util/spec_helper'
 
-  require_relative '../../util/spec_helper'
+# Prior to running, set Junction recent_refresh_cutoff_days as required, same as Teena's cutoff setting
 
-  # Prior to running, set Junction recent_refresh_cutoff_days as required, same as Teena's cutoff setting
+describe 'bCourses recent enrollment updates' do
 
-  describe 'bCourses recent enrollment updates' do
+  include Logging
 
-    include Logging
+  begin
 
-    begin
+    @test = RipleyTestConfig.new
+    @test.refresh_canvas_recent
+    @driver = Utils.launch_browser
+    @splash_page = Page::JunctionPages::SplashPage.new @driver
+    @cal_net = Page::CalNetPage.new @driver
+    @create_course_site = Page::JunctionPages::CanvasCreateCourseSitePage.new @driver
+    @canvas = Page::CanvasPage.new @driver
+    @canvas_api = CanvasAPIPage.new @driver
 
-      @test = RipleyTestConfig.new
-      @test.refresh_canvas_recent
-      @driver = Utils.launch_browser
-      @splash_page = Page::JunctionPages::SplashPage.new @driver
-      @cal_net = Page::CalNetPage.new @driver
-      @create_course_site = Page::JunctionPages::CanvasCreateCourseSitePage.new @driver
-      @canvas = Page::CanvasPage.new @driver
-      @canvas_api = CanvasAPIPage.new @driver
+    roles = ['Teacher', 'Lead TA', 'TA', 'Student', 'Waitlist Student']
+    sites_to_verify = []
 
-      roles = ['Teacher', 'Lead TA', 'TA', 'Student', 'Waitlist Student']
-      sites_to_verify = []
+    logger.debug "There are #{@test.course_sites.length} test courses"
+    @canvas.log_in(@cal_net, @test.admin.username, Utils.super_admin_password)
 
-      logger.debug "There are #{@test.course_sites.length} test courses"
-      @canvas.log_in(@cal_net, @test.admin.username, Utils.super_admin_password)
+    @test.course_sites.each do |site|
+      begin
+        section_ids = @canvas_api.get_course_site_sis_section_ids site.site_id
+        @test.get_existing_site_data(site, section_ids)
+        course = site.course
+        course.site_id = site.site_id
 
-      @test.course_sites.each do |site|
-        begin
-          section_ids = @canvas_api.get_course_site_sis_section_ids site.site_id
-          @test.get_existing_site_data(site, section_ids)
-          course = site.course
-          course.site_id = site.site_id
-
-          if site.site_id
-            @canvas.load_course_site site
-          else
-            # TODO create course site
-            # TODO @canvas.publish_course_site site
-          end
-          @canvas.set_course_sis_id course
-          @canvas.set_section_sis_ids course
-          @canvas.load_users_page course
-          @canvas.wait_for_enrollment_import(course, roles)
-
-          initial_users_with_sections = []
-          course.sections.each do |section|
-            initial_users_with_sections << @canvas.get_users_with_sections(course, section)
-          end
-          initial_users_with_sections.flatten!
-          initial_enrollment_data = initial_users_with_sections.map do |u|
-            {
-              sid: u[:user].sis_id,
-              section_id: u[:section].sis_id,
-              role: u[:user].role
-            }
-          end
-          sites_to_verify << { site: site, enrollment_data: initial_enrollment_data }
-
-          student_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'student' }
-          waitlisted_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Waitlist Student' }
-          ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'ta' }
-          lead_ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Lead TA' }
-          teacher_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'teacher' }
-
-          csv = File.join(Utils.initialize_test_output_dir, "enrollments-#{course.code}.csv")
-          CSV.open(csv, 'wb') { |heading| heading << %w(course_id user_id role section_id status) }
-
-          students_to_delete = student_enrollments[0..9].map &:dup
-          waitlists_to_delete = waitlisted_enrollments[0..9].map &:dup
-          tas_to_delete = ta_enrollments[0..0].map &:dup
-          lead_tas_to_delete = lead_ta_enrollments[0..1].map &:dup
-          teachers_to_delete = teacher_enrollments[0..0].map &:dup
-          students_to_convert = student_enrollments[10..19].map &:dup
-
-          deletes = [students_to_delete + students_to_convert + waitlists_to_delete + tas_to_delete + lead_tas_to_delete + teachers_to_delete]
-          deletes.flatten!
-          logger.debug "#{deletes.map { |h| {sid: h[:user].sis_id, role: h[:user].role} }}"
-          deletes.each { |h| h[:user].status = 'deleted' }
-          deletes.each do |delete|
-            user = delete[:user]
-            section = delete[:section]
-            Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
-          end
-
-          logger.debug "#{students_to_convert}"
-          students_to_convert.each do |h|
-            h[:user].role = 'Waitlist Student'
-            h[:user].status = 'active'
-          end
-          students_to_convert.each do |converts|
-            user = converts[:user]
-            section = converts[:section]
-            Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
-          end
-
-          # For one of the deletions, add a different user role manually to ensure that the manual role persists after an enrollment update
-          if lead_tas_to_delete[0] && course.sections.length == 1
-            teacher = lead_tas_to_delete[0].dup
-            teacher[:user].role = 'Teacher'
-            @canvas.add_users(course, [teacher[:user]])
-            initial_enrollment_data << {sid: teacher[:user].sis_id, role: teacher[:user].role.downcase, section_id: teacher[:section].sis_id}
-          end
-
-          @canvas.upload_sis_imports([csv])
-          sites_to_verify << site
-        rescue => e
-          Utils.log_error e
-          it("hit an error in the test for #{site[:course].code}") { fail }
+        if site.site_id
+          @canvas.load_course_site site
+        else
+          # TODO create course site
+          # TODO @canvas.publish_course_site site
         end
-      end
+        @canvas.set_course_sis_id course
+        @canvas.set_section_sis_ids course
+        @canvas.load_users_page course
+        @canvas.wait_for_enrollment_import(course, roles)
 
-      @canvas.log_out @cal_net
-      @canvas.load_homepage
-      RipleyUtils.set_last_sync_timestamps
-      @cal_net.prompt_for_action 'RUN EXPORT AND REFRESH SCRIPTS MANUALLY'
-      @cal_net.wait_for_manual_login 9000
-
-      #########################################
-      ############  MANUAL STEPS  #############
-      #########################################
-
-      # 1. Run job Export Term Enrollments
-      # 2. Run Junction data_loch_recent_refresh
-      # 3. Run Nessie RefreshSisedoSchemaIncremental
-      # 4. Run job Bcourses Refresh Incremental
-      # 5. Log in manually to resume tests
-
-      sites_to_verify.each do |site|
-        course = site[:site].course
-        @canvas.load_course_site course
-        updated_users_with_sections = @canvas.get_users_with_sections course
-        updated_enrollment_data = updated_users_with_sections.map do |u|
+        initial_users_with_sections = []
+        course.sections.each do |section|
+          initial_users_with_sections << @canvas.get_users_with_sections(course, section)
+        end
+        initial_users_with_sections.flatten!
+        initial_enrollment_data = initial_users_with_sections.map do |u|
           {
             sid: u[:user].sis_id,
             section_id: u[:section].sis_id,
             role: u[:user].role
           }
         end
-        logger.debug "Original site membership: #{site[:enrollment_data]}"
-        logger.debug "Updated site membership: #{updated_enrollment_data}"
-        logger.debug "Current less original: #{updated_enrollment_data - site[:enrollment_data]}"
-        logger.debug "Original less current: #{site[:enrollment_data] - updated_enrollment_data}"
-        it("updates the enrollment for site ID #{site[:course].site_id} with no unexpected memberships") do
-          expect(updated_enrollment_data - site[:enrollment_data]).to be_empty
+        sites_to_verify << { site: site, enrollment_data: initial_enrollment_data }
+
+        student_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'student' }
+        waitlisted_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Waitlist Student' }
+        ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'ta' }
+        lead_ta_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'Lead TA' }
+        teacher_enrollments = initial_users_with_sections.select { |h| h[:user].role == 'teacher' }
+
+        csv = File.join(Utils.initialize_test_output_dir, "enrollments-#{course.code}.csv")
+        CSV.open(csv, 'wb') { |heading| heading << %w(course_id user_id role section_id status) }
+
+        students_to_delete = student_enrollments[0..9].map &:dup
+        waitlists_to_delete = waitlisted_enrollments[0..9].map &:dup
+        tas_to_delete = ta_enrollments[0..0].map &:dup
+        lead_tas_to_delete = lead_ta_enrollments[0..1].map &:dup
+        teachers_to_delete = teacher_enrollments[0..0].map &:dup
+        students_to_convert = student_enrollments[10..19].map &:dup
+
+        deletes = [students_to_delete + students_to_convert + waitlists_to_delete + tas_to_delete + lead_tas_to_delete + teachers_to_delete]
+        deletes.flatten!
+        logger.debug "#{deletes.map { |h| { sid: h[:user].sis_id, role: h[:user].role } }}"
+        deletes.each { |h| h[:user].status = 'deleted' }
+        deletes.each do |delete|
+          user = delete[:user]
+          section = delete[:section]
+          Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
         end
-        it("updates the enrollment for site ID #{site[:course].site_id} with no missing memberships") do
-          expect(site[:enrollment_data] - updated_enrollment_data).to be_empty
+
+        logger.debug "#{students_to_convert}"
+        students_to_convert.each do |h|
+          h[:user].role = 'Waitlist Student'
+          h[:user].status = 'active'
         end
+        students_to_convert.each do |converts|
+          user = converts[:user]
+          section = converts[:section]
+          Utils.add_csv_row(csv, [course.sis_id, user.sis_id, user.role, section.sis_id, user.status])
+        end
+
+        # For one of the deletions, add a different user role manually to ensure that the manual role persists after an enrollment update
+        if lead_tas_to_delete[0] && course.sections.length == 1
+          teacher = lead_tas_to_delete[0].dup
+          teacher[:user].role = 'Teacher'
+          @canvas.add_users(course, [teacher[:user]])
+          initial_enrollment_data << { sid: teacher[:user].sis_id, role: teacher[:user].role.downcase, section_id: teacher[:section].sis_id }
+        end
+
+        @canvas.upload_sis_imports([csv])
+        sites_to_verify << site
+      rescue => e
+        Utils.log_error e
+        it("hit an error in the test for #{site[:course].code}") { fail }
+      end
+    end
+
+    @canvas.log_out @cal_net
+    @canvas.load_homepage
+    RipleyUtils.set_last_sync_timestamps
+    @cal_net.prompt_for_action 'RUN EXPORT AND REFRESH SCRIPTS MANUALLY'
+    @cal_net.wait_for_manual_login 9000
+
+    #########################################
+    ############  MANUAL STEPS  #############
+    #########################################
+
+    # 1. Run job Export Term Enrollments
+    # 2. Run Junction data_loch_recent_refresh
+    # 3. Run Nessie RefreshSisedoSchemaIncremental
+    # 4. Run job Bcourses Refresh Incremental
+    # 5. Log in manually to resume tests
+
+    sites_to_verify.each do |site|
+      course = site[:site].course
+      @canvas.load_course_site course
+      updated_users_with_sections = @canvas.get_users_with_sections course
+      updated_enrollment_data = updated_users_with_sections.map do |u|
+        {
+          sid: u[:user].sis_id,
+          section_id: u[:section].sis_id,
+          role: u[:user].role
+        }
+      end
+      logger.debug "Original site membership: #{site[:enrollment_data]}"
+      logger.debug "Updated site membership: #{updated_enrollment_data}"
+      logger.debug "Current less original: #{updated_enrollment_data - site[:enrollment_data]}"
+      logger.debug "Original less current: #{site[:enrollment_data] - updated_enrollment_data}"
+      it("updates the enrollment for site ID #{site[:course].site_id} with no unexpected memberships") do
+        expect(updated_enrollment_data - site[:enrollment_data]).to be_empty
+      end
+      it("updates the enrollment for site ID #{site[:course].site_id} with no missing memberships") do
+        expect(site[:enrollment_data] - updated_enrollment_data).to be_empty
       end
     end
   end

--- a/spec/ripley/refresh_canvas_recent_spec.rb
+++ b/spec/ripley/refresh_canvas_recent_spec.rb
@@ -1,162 +1,159 @@
-unless ENV['STANDALONE']
+require_relative '../../util/spec_helper'
 
-  require_relative '../../util/spec_helper'
+describe 'bCourses recent enrollment updates' do
 
-  describe 'bCourses recent enrollment updates' do
+  include Logging
 
-    include Logging
+  before(:all) do
+    @driver = Utils.launch_browser
+    @cal_net_page = Page::CalNetPage.new @driver
+    @canvas_page = Page::CanvasPage.new @driver
+    @splash_page = RipleySplashPage.new @driver
+    @create_course_site_page = RipleyCreateCourseSitePage.new @driver
+    @jobs_page = RipleyJobsPage.new @driver
 
-    before(:all) do
-      @driver = Utils.launch_browser
-      @cal_net_page = Page::CalNetPage.new @driver
-      @canvas_page = Page::CanvasPage.new @driver
-      @splash_page = RipleySplashPage.new @driver
-      @create_course_site_page = RipleyCreateCourseSitePage.new @driver
-      @jobs_page = RipleyJobsPage.new @driver
+    @test = RipleyTestConfig.new
+    site = @test.get_single_test_site
+    @test.set_incremental_refresh_users site
+    logger.info "Teachers: #{@test.teachers.map &:uid}"
+    logger.info "Students: #{@test.students.map &:uid}"
 
-      @test = RipleyTestConfig.new
-      site = @test.get_single_test_site
-      @test.set_incremental_refresh_users site
-      logger.info "Teachers: #{@test.teachers.map &:uid}"
-      logger.info "Students: #{@test.students.map &:uid}"
+    @canvas_page.log_in(@cal_net_page, @test.admin.username, Utils.super_admin_password)
+    if site.site_id
+      @canvas_page.load_course_site site
+    else
+      @create_course_site_page.provision_course_site site
+      @canvas_page.publish_course_site site
+    end
 
-      @canvas_page.log_in(@cal_net_page, @test.admin.username, Utils.super_admin_password)
-      if site.site_id
-        @canvas_page.load_course_site site
-      else
-        @create_course_site_page.provision_course_site site
-        @canvas_page.publish_course_site site
-      end
-
-      # Primary section updates
-      @primary_section = site.sections.find &:primary
-      @prim_stu0_enroll = SectionEnrollment.new user: @test.students[0],
-                                                term: site.course.term,
-                                                section_id: @primary_section.id,
-                                                status: 'E'
-      @prim_stu1_enroll = SectionEnrollment.new user: @test.students[1],
-                                                term: site.course.term,
-                                                section_id: @primary_section.id,
-                                                status: 'W'
-      RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[0], 'PI')
-      RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[1], 'APRX')
-      RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[2], 'ICNT')
-      RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[3], 'INVT')
-      RipleyUtils.insert_enrollment_update @prim_stu0_enroll
-      RipleyUtils.insert_enrollment_update @prim_stu1_enroll
-
-      # Secondary section updates
-      @secondary_sections = site.sections.select { |s| !s.primary }
-      @sec0_stu0_enroll = SectionEnrollment.new user: @test.students[0],
-                                                term: site.course.term,
-                                                section_id: @secondary_sections[0].id,
-                                                status: 'E'
-      @sec1_stu0_list = SectionEnrollment.new user: @test.students[0],
+    # Primary section updates
+    @primary_section = site.sections.find &:primary
+    @prim_stu0_enroll = SectionEnrollment.new user: @test.students[0],
                                               term: site.course.term,
-                                              section_id: @secondary_sections[1].id,
-                                              status: 'W'
-      @sec1_stu1_list = SectionEnrollment.new user: @test.students[1],
+                                              section_id: @primary_section.id,
+                                              status: 'E'
+    @prim_stu1_enroll = SectionEnrollment.new user: @test.students[1],
                                               term: site.course.term,
-                                              section_id: @secondary_sections[1].id,
+                                              section_id: @primary_section.id,
                                               status: 'W'
-      RipleyUtils.insert_instructor_update(site.course, @secondary_sections[0], @test.teachers[4], 'TNIC')
-      RipleyUtils.insert_enrollment_update @sec0_stu0_enroll
-      RipleyUtils.insert_enrollment_update @sec1_stu0_list
-      RipleyUtils.insert_enrollment_update @sec1_stu1_list
+    RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[0], 'PI')
+    RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[1], 'APRX')
+    RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[2], 'ICNT')
+    RipleyUtils.insert_instructor_update(site.course, @primary_section, @test.teachers[3], 'INVT')
+    RipleyUtils.insert_enrollment_update @prim_stu0_enroll
+    RipleyUtils.insert_enrollment_update @prim_stu1_enroll
 
-      # Run Ripley job
-      @splash_page.load_page
-      @splash_page.dev_auth @test.admin.uid
-      @splash_page.click_jobs_link
-      @jobs_page.run_job RipleyJob::REFRESH_INCREMENTAL
+    # Secondary section updates
+    @secondary_sections = site.sections.select { |s| !s.primary }
+    @sec0_stu0_enroll = SectionEnrollment.new user: @test.students[0],
+                                              term: site.course.term,
+                                              section_id: @secondary_sections[0].id,
+                                              status: 'E'
+    @sec1_stu0_list = SectionEnrollment.new user: @test.students[0],
+                                            term: site.course.term,
+                                            section_id: @secondary_sections[1].id,
+                                            status: 'W'
+    @sec1_stu1_list = SectionEnrollment.new user: @test.students[1],
+                                            term: site.course.term,
+                                            section_id: @secondary_sections[1].id,
+                                            status: 'W'
+    RipleyUtils.insert_instructor_update(site.course, @secondary_sections[0], @test.teachers[4], 'TNIC')
+    RipleyUtils.insert_enrollment_update @sec0_stu0_enroll
+    RipleyUtils.insert_enrollment_update @sec1_stu0_list
+    RipleyUtils.insert_enrollment_update @sec1_stu1_list
 
-      # Get resulting Canvas enrollments
-      @enrollments = @canvas_page.get_users_with_sections site.course
+    # Run Ripley job
+    @splash_page.load_page
+    @splash_page.dev_auth @test.admin.uid
+    @splash_page.click_jobs_link
+    @jobs_page.run_job RipleyJob::REFRESH_INCREMENTAL
+
+    # Get resulting Canvas enrollments
+    @enrollments = @canvas_page.get_users_with_sections site.course
+  end
+
+  context 'when a PI in a primary section' do
+    it 'adds a Teacher enrollment to the right section' do
+      teacher_0_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[0].uid }
+      expect(teacher_0_enroll[:section].label).to eql(@primary_section.label)
+      expect(teacher_0_enroll[:user].role).to eql('teacher')
     end
+  end
 
-    context 'when a PI in a primary section' do
-      it 'adds a Teacher enrollment to the right section' do
-        teacher_0_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[0].uid }
-        expect(teacher_0_enroll[:section].label).to eql(@primary_section.label)
-        expect(teacher_0_enroll[:user].role).to eql('teacher')
-      end
+  context 'when an APRX in a primary section' do
+    it 'adds a Lead TA enrollment to the right section' do
+      teacher_1_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[1].uid }
+      expect(teacher_1_enroll[:section].label).to eql(@primary_section.label)
+      expect(teacher_1_enroll[:user].role).to eql('Lead TA')
     end
+  end
 
-    context 'when an APRX in a primary section' do
-      it 'adds a Lead TA enrollment to the right section' do
-        teacher_1_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[1].uid }
-        expect(teacher_1_enroll[:section].label).to eql(@primary_section.label)
-        expect(teacher_1_enroll[:user].role).to eql('Lead TA')
-      end
+  context 'when an ICNT in a primary section' do
+    it 'adds a Teacher enrollment to the right section' do
+      teacher_2_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[2].uid }
+      expect(teacher_2_enroll[:section].label).to eql(@primary_section.label)
+      expect(teacher_2_enroll[:user].role).to eql('teacher')
     end
+  end
 
-    context 'when an ICNT in a primary section' do
-      it 'adds a Teacher enrollment to the right section' do
-        teacher_2_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[2].uid }
-        expect(teacher_2_enroll[:section].label).to eql(@primary_section.label)
-        expect(teacher_2_enroll[:user].role).to eql('teacher')
-      end
+  context 'when an INVT in a primary section' do
+    it 'adds a Teacher enrollment to the right section' do
+      teacher_3_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[3].uid }
+      expect(teacher_3_enroll[:section].label).to eql(@primary_section.label)
+      expect(teacher_3_enroll[:user].role).to eql('teacher')
     end
+  end
 
-    context 'when an INVT in a primary section' do
-      it 'adds a Teacher enrollment to the right section' do
-        teacher_3_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[3].uid }
-        expect(teacher_3_enroll[:section].label).to eql(@primary_section.label)
-        expect(teacher_3_enroll[:user].role).to eql('teacher')
-      end
+  context 'when a TNIC in a secondary section' do
+    it 'adds a TA enrollment to the right section' do
+      teacher_4_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[4].uid }
+      expect(teacher_4_enroll[:section].label).to eql(@secondary_sections[0].label)
+      expect(teacher_4_enroll[:user].role).to eql('ta')
     end
+  end
 
-    context 'when a TNIC in a secondary section' do
-      it 'adds a TA enrollment to the right section' do
-        teacher_4_enroll = @enrollments.find { |e| e[:user].uid == @test.teachers[4].uid }
-        expect(teacher_4_enroll[:section].label).to eql(@secondary_sections[0].label)
-        expect(teacher_4_enroll[:user].role).to eql('ta')
+  context 'when a student in a primary section' do
+    it 'adds a Student enrollment to the right section' do
+      prim_stu0 = @enrollments.find do |e|
+        (e[:user].uid == @test.students[0].uid) && (e[:section].label == @primary_section.label)
       end
+      expect(prim_stu0[:user].role).to eql('student')
     end
+  end
 
-    context 'when a student in a primary section' do
-      it 'adds a Student enrollment to the right section' do
-        prim_stu0 = @enrollments.find do |e|
-          (e[:user].uid == @test.students[0].uid) && (e[:section].label == @primary_section.label)
-        end
-        expect(prim_stu0[:user].role).to eql('student')
+  context 'when a student in a secondary section' do
+    it 'adds a Student enrollment to the right section' do
+      sec0_stu0 = @enrollments.find do |e|
+        (e[:user].uid == @test.students[0].uid) && (e[:section].label == @secondary_sections[0].label)
       end
+      expect(sec0_stu0[:user].role).to eql('student')
     end
+  end
 
-    context 'when a student in a secondary section' do
-      it 'adds a Student enrollment to the right section' do
-        sec0_stu0 = @enrollments.find do |e|
-          (e[:user].uid == @test.students[0].uid) && (e[:section].label == @secondary_sections[0].label)
-        end
-        expect(sec0_stu0[:user].role).to eql('student')
+  context 'when a wait listed student in a primary section' do
+    it 'adds a Waitlist Student enrollment to the right section' do
+      prim_stu1 = @enrollments.find do |e|
+        (e[:user].uid == @test.students[1].uid) && (e[:section].label == @primary_section.label)
       end
+      expect(prim_stu1[:user].role).to eql('Waitlist Student')
     end
+  end
 
-    context 'when a wait listed student in a primary section' do
-      it 'adds a Waitlist Student enrollment to the right section' do
-        prim_stu1 = @enrollments.find do |e|
-          (e[:user].uid == @test.students[1].uid) && (e[:section].label == @primary_section.label)
-        end
-        expect(prim_stu1[:user].role).to eql('Waitlist Student')
+  context 'when a wait listed student in a secondary section' do
+    it 'adds a Waitlist Student enrollment to the right section' do
+      sec1_stu1 = @enrollments.find do |e|
+        (e[:user].uid == @test.students[1].uid) && (e[:section].label == @secondary_sections[1].label)
       end
+      expect(sec1_stu1[:user].role).to eql('Waitlist Student')
     end
+  end
 
-    context 'when a wait listed student in a secondary section' do
-      it 'adds a Waitlist Student enrollment to the right section' do
-        sec1_stu1 = @enrollments.find do |e|
-          (e[:user].uid == @test.students[1].uid) && (e[:section].label == @secondary_sections[1].label)
-        end
-        expect(sec1_stu1[:user].role).to eql('Waitlist Student')
+  context 'when a wait listed student in a secondary section, enrolled in another section' do
+    it 'adds a Waitlist Student enrollment to the right section' do
+      sec1_stu0 = @enrollments.find do |e|
+        (e[:user].uid == @test.students[0].uid) && (e[:section].label == @secondary_sections[1].label)
       end
-    end
-
-    context 'when a wait listed student in a secondary section, enrolled in another section' do
-      it 'adds a Waitlist Student enrollment to the right section' do
-        sec1_stu0 = @enrollments.find do |e|
-          (e[:user].uid == @test.students[0].uid) && (e[:section].label == @secondary_sections[1].label)
-        end
-        expect(sec1_stu0[:user].role).to eql('Waitlist Student')
-      end
+      expect(sec1_stu0[:user].role).to eql('Waitlist Student')
     end
   end
 end

--- a/spec/ripley/user_provisioning_spec.rb
+++ b/spec/ripley/user_provisioning_spec.rb
@@ -23,30 +23,24 @@ describe 'User Provisioning' do
     @canvas = Page::CanvasPage.new @driver
     @user_prov_tool = RipleyUserProvisioningPage.new @driver
 
-    if standalone
-      @splash_page.basic_auth test.admin.uid
-    else
-      @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
-      RipleyTool::TOOLS.each { |t| @canvas.add_ripley_tool t }
-      @canvas.set_canvas_ids test_users
-    end
+    @canvas.log_in(@cal_net, test.admin.username, Utils.super_admin_password)
+    RipleyTool::TOOLS.each { |t| @canvas.add_ripley_tool t }
+    @canvas.set_canvas_ids test_users
   end
 
   after(:all) { Utils.quit_browser @driver }
 
-  unless standalone
-    context 'when the user is an authorized user' do
+  context 'when the user is an authorized user' do
 
-      it 'can be reached from a navigation link' do
-        @canvas.load_sub_account Utils.canvas_uc_berkeley_sub_account
-        @canvas.click_user_prov
-      end
+    it 'can be reached from a navigation link' do
+      @canvas.load_sub_account Utils.canvas_uc_berkeley_sub_account
+      @canvas.click_user_prov
     end
   end
 
   context 'when the user is an authorized user' do
 
-    before(:each) { standalone ? @user_prov_tool.load_standalone_tool : @user_prov_tool.load_embedded_tool }
+    before(:each) { @user_prov_tool.load_embedded_tool }
 
     it 'provisions users via line break separated UIDs' do
       uids = test_users.map(&:uid).join("\n")
@@ -80,15 +74,13 @@ describe 'User Provisioning' do
     end
   end
 
-  unless standalone
-    context 'when the user is not an authorized user' do
+  context 'when the user is not an authorized user' do
 
-      test_users.each do |user|
-        it "prevents the #{user.role} from reaching the tool" do
-          @canvas.masquerade_as user
-          @user_prov_tool.load_embedded_tool
-          @user_prov_tool.unauthorized_msg_element.when_visible Utils.short_wait
-        end
+    test_users.each do |user|
+      it "prevents the #{user.role} from reaching the tool" do
+        @canvas.masquerade_as user
+        @user_prov_tool.load_embedded_tool
+        @user_prov_tool.unauthorized_msg_element.when_visible Utils.short_wait
       end
     end
   end

--- a/spec/ripley/welcome_email_spec.rb
+++ b/spec/ripley/welcome_email_spec.rb
@@ -1,152 +1,149 @@
-unless ENV['STANDALONE']
+require_relative '../../util/spec_helper'
 
-  require_relative '../../util/spec_helper'
+describe 'bCourses welcome email', order: :defined do
 
-  describe 'bCourses welcome email', order: :defined do
+  include Logging
 
-    include Logging
+  before(:all) do
+    @test = RipleyTestConfig.new
+    @site = @test.get_welcome_email_site
+    @email = Email.new("Welcome Email #{@test.id}", "Teena welcomes you")
+    @site_members = [@test.manual_teacher, @test.students.first]
+
+    # Browser for instructor
+    @driver1 = Utils.launch_browser
+    @canvas1 = Page::CanvasPage.new @driver1
+    @cal_net1 = Page::CalNetPage.new @driver1
+    @mailing_list = RipleyMailingListPage.new @driver1
+    @canvas1.log_in(@cal_net1, @test.admin.username, Utils.super_admin_password)
+    @canvas1.set_canvas_ids @site.manual_members
+
+    # Browser for admin
+    @driver2 = Utils.launch_browser
+    @canvas2 = Page::CanvasPage.new @driver2
+    @cal_net2 = Page::CalNetPage.new @driver2
+    @ripley2 = RipleySplashPage.new @driver2
+    @mailing_lists = RipleyMailingListsPage.new @driver2
+    @canvas2.log_in(@cal_net2, @test.admin.username, Utils.super_admin_password)
+
+    @canvas2.create_generic_course_site(Utils.canvas_official_courses_sub_account, @site, @site_members, @test.id)
+    @canvas1.masquerade_as(@test.students[0], @site)
+    @canvas1.masquerade_as(@test.manual_teacher, @site)
+  end
+
+  after(:all) { Utils.quit_browser @driver1; Utils.quit_browser @driver2 }
+
+  context 'creation' do
 
     before(:all) do
-      @test = RipleyTestConfig.new
-      @site = @test.get_welcome_email_site
-      @email = Email.new("Welcome Email #{@test.id}", "Teena welcomes you")
-      @site_members = [@test.manual_teacher, @test.students.first]
-
-      # Browser for instructor
-      @driver1 = Utils.launch_browser
-      @canvas1 = Page::CanvasPage.new @driver1
-      @cal_net1 = Page::CalNetPage.new @driver1
-      @mailing_list = RipleyMailingListPage.new @driver1
-      @canvas1.log_in(@cal_net1, @test.admin.username, Utils.super_admin_password)
-      @canvas1.set_canvas_ids @site.manual_members
-
-      # Browser for admin
-      @driver2 = Utils.launch_browser
-      @canvas2 = Page::CanvasPage.new @driver2
-      @cal_net2 = Page::CalNetPage.new @driver2
-      @ripley2 = RipleySplashPage.new @driver2
-      @mailing_lists = RipleyMailingListsPage.new @driver2
-      @canvas2.log_in(@cal_net2, @test.admin.username, Utils.super_admin_password)
-
-      @canvas2.create_generic_course_site(Utils.canvas_official_courses_sub_account, @site, @site_members, @test.id)
-      @canvas1.masquerade_as(@test.students[0], @site)
-      @canvas1.masquerade_as(@test.manual_teacher, @site)
+      @mailing_list.load_embedded_tool @site
+      @mailing_list.create_list
     end
 
-    after(:all) { Utils.quit_browser @driver1; Utils.quit_browser @driver2 }
-
-    context 'creation' do
-
-      before(:all) do
-        @mailing_list.load_embedded_tool @site
-        @mailing_list.create_list
-      end
-
-      it 'includes a link to more information' do
-        title = 'IT - bCourses Mailing List - Welcome Email'
-        expect(@mailing_list.external_link_valid?(@mailing_list.welcome_email_link_element, title)).to be true
-      end
-
-      it('is not possible with an empty subject or body') do
-        @mailing_list.switch_to_canvas_iframe if @canvas1.canvas_iframe?
-        expect(@mailing_list.email_save_button_element.disabled?).to be true
-      end
-
-      it 'is possible with a subject and body' do
-        @mailing_list.enter_email_subject @email.subject
-        @mailing_list.enter_email_body @email.body
-        @mailing_list.click_save_email_button
-        expect(@mailing_list.email_subject).to eql(@email.subject)
-        expect(@mailing_list.email_body).to eql(@email.body)
-      end
-
-      it('sets the email to paused by default') { expect(@mailing_list.email_paused_msg?).to be true }
+    it 'includes a link to more information' do
+      title = 'IT - bCourses Mailing List - Welcome Email'
+      expect(@mailing_list.external_link_valid?(@mailing_list.welcome_email_link_element, title)).to be true
     end
 
-    context 'edits' do
-
-      it 'can be canceled' do
-        @mailing_list.click_edit_email_button
-        @mailing_list.enter_email_subject "#{@email.subject} - edited"
-        @mailing_list.enter_email_body "#{@email.body} - edited"
-        @mailing_list.click_cancel_edit_button
-        expect(@mailing_list.email_subject).to eql(@email.subject)
-        expect(@mailing_list.email_body).to eql(@email.body)
-      end
-
-      it 'can be saved' do
-        @mailing_list.click_edit_email_button
-        @mailing_list.enter_email_subject(@email.subject = "#{@email.subject} - edited")
-        @mailing_list.enter_email_body(@email.body = "#{@email.body} - edited")
-        @mailing_list.click_save_email_button
-        expect(@mailing_list.email_subject).to eql(@email.subject)
-        expect(@mailing_list.email_body).to eql(@email.body)
-      end
+    it('is not possible with an empty subject or body') do
+      @mailing_list.switch_to_canvas_iframe if @canvas1.canvas_iframe?
+      expect(@mailing_list.email_save_button_element.disabled?).to be true
     end
 
-    context 'when activated' do
-
-      before(:all) do
-        @mailing_list.click_activation_toggle
-        @mailing_list.email_activated_msg_element.when_visible 3
-        @mailing_lists.load_embedded_tool
-        @mailing_lists.search_for_list @site.site_id
-      end
-
-      it 'is sent to existing members of the site' do
-        # Update membership
-        @mailing_lists.click_update_memberships
-
-        # Verify new emails triggered
-        @mailing_list.load_embedded_tool @site
-        csv = @mailing_list.download_csv
-        expect(csv[:email_address].sort).to eql(@site_members.map(&:email).sort)
-      end
-
-      it 'is sent to new members of the site' do
-        # Add student, accept invite
-        @canvas2.add_users(@site, [@test.students[1]])
-        @site_members << @test.students[1]
-        @canvas2.masquerade_as(@test.students[1], @site)
-        @canvas2.stop_masquerading
-
-        # Update membership
-        RipleyUtils.clear_cache # TODO @ripley2
-        @mailing_lists.load_embedded_tool
-        @mailing_lists.search_for_list @site.site_id
-        @mailing_lists.click_update_memberships
-
-        # Verify new email triggered
-        @mailing_list.load_embedded_tool @site
-        csv = @mailing_list.download_csv
-        expect(csv[:email_address].sort).to eql(@site_members.map(&:email).sort)
-      end
+    it 'is possible with a subject and body' do
+      @mailing_list.enter_email_subject @email.subject
+      @mailing_list.enter_email_body @email.body
+      @mailing_list.click_save_email_button
+      expect(@mailing_list.email_subject).to eql(@email.subject)
+      expect(@mailing_list.email_body).to eql(@email.body)
     end
 
-    context 'when paused' do
+    it('sets the email to paused by default') { expect(@mailing_list.email_paused_msg?).to be true }
+  end
 
-      before(:all) do
-        @mailing_list.click_activation_toggle
-        @mailing_list.email_paused_msg_element.when_visible 3
-      end
+  context 'edits' do
 
-      it 'is not sent to new members of the site' do
-        # Add student, accept invite
-        @canvas2.add_users(@site, [@test.students[2]])
-        @canvas2.masquerade_as(@test.students[2], @site)
-        @canvas2.stop_masquerading
+    it 'can be canceled' do
+      @mailing_list.click_edit_email_button
+      @mailing_list.enter_email_subject "#{@email.subject} - edited"
+      @mailing_list.enter_email_body "#{@email.body} - edited"
+      @mailing_list.click_cancel_edit_button
+      expect(@mailing_list.email_subject).to eql(@email.subject)
+      expect(@mailing_list.email_body).to eql(@email.body)
+    end
 
-        # Update membership
-        RipleyUtils.clear_cache # TODO @ripley2
-        @mailing_lists.load_embedded_tool
-        @mailing_lists.search_for_list @site.site_id
-        @mailing_lists.click_update_memberships
+    it 'can be saved' do
+      @mailing_list.click_edit_email_button
+      @mailing_list.enter_email_subject(@email.subject = "#{@email.subject} - edited")
+      @mailing_list.enter_email_body(@email.body = "#{@email.body} - edited")
+      @mailing_list.click_save_email_button
+      expect(@mailing_list.email_subject).to eql(@email.subject)
+      expect(@mailing_list.email_body).to eql(@email.body)
+    end
+  end
 
-        # Verify no new email triggered
-        @mailing_list.load_embedded_tool @site
-        csv = @mailing_list.download_csv
-        expect(csv[:email_address].sort).to eql(@site_members.map(&:email).sort)
-      end
+  context 'when activated' do
+
+    before(:all) do
+      @mailing_list.click_activation_toggle
+      @mailing_list.email_activated_msg_element.when_visible 3
+      @mailing_lists.load_embedded_tool
+      @mailing_lists.search_for_list @site.site_id
+    end
+
+    it 'is sent to existing members of the site' do
+      # Update membership
+      @mailing_lists.click_update_memberships
+
+      # Verify new emails triggered
+      @mailing_list.load_embedded_tool @site
+      csv = @mailing_list.download_csv
+      expect(csv[:email_address].sort).to eql(@site_members.map(&:email).sort)
+    end
+
+    it 'is sent to new members of the site' do
+      # Add student, accept invite
+      @canvas2.add_users(@site, [@test.students[1]])
+      @site_members << @test.students[1]
+      @canvas2.masquerade_as(@test.students[1], @site)
+      @canvas2.stop_masquerading
+
+      # Update membership
+      RipleyUtils.clear_cache # TODO @ripley2
+      @mailing_lists.load_embedded_tool
+      @mailing_lists.search_for_list @site.site_id
+      @mailing_lists.click_update_memberships
+
+      # Verify new email triggered
+      @mailing_list.load_embedded_tool @site
+      csv = @mailing_list.download_csv
+      expect(csv[:email_address].sort).to eql(@site_members.map(&:email).sort)
+    end
+  end
+
+  context 'when paused' do
+
+    before(:all) do
+      @mailing_list.click_activation_toggle
+      @mailing_list.email_paused_msg_element.when_visible 3
+    end
+
+    it 'is not sent to new members of the site' do
+      # Add student, accept invite
+      @canvas2.add_users(@site, [@test.students[2]])
+      @canvas2.masquerade_as(@test.students[2], @site)
+      @canvas2.stop_masquerading
+
+      # Update membership
+      RipleyUtils.clear_cache # TODO @ripley2
+      @mailing_lists.load_embedded_tool
+      @mailing_lists.search_for_list @site.site_id
+      @mailing_lists.click_update_memberships
+
+      # Verify no new email triggered
+      @mailing_list.load_embedded_tool @site
+      csv = @mailing_list.download_csv
+      expect(csv[:email_address].sort).to eql(@site_members.map(&:email).sort)
     end
   end
 end

--- a/util/ripley_utils.rb
+++ b/util/ripley_utils.rb
@@ -451,7 +451,8 @@ class RipleyUtils < Utils
   def self.set_mailing_list_member_email(member, email_address)
     sql = "UPDATE canvas_site_mailing_list_members
               SET email_address = '#{email_address}'
-            WHERE CONCAT(first_name, ' ', last_name) = '#{member.full_name}';"
+            WHERE CONCAT(first_name, ' ', last_name) = '#{member.full_name}'
+              AND deleted_at IS NULL;"
     result = query_pg_db(db_credentials, sql)
     logger.warn "Command status: #{result.cmd_status}. Result status: #{result.result_status}"
   end
@@ -459,7 +460,8 @@ class RipleyUtils < Utils
   def self.get_mailing_list_member_email(member)
     sql = "SELECT email_address
              FROM canvas_site_mailing_list_members
-            WHERE CONCAT(first_name, ' ', last_name) = '#{member.full_name}';"
+            WHERE CONCAT(first_name, ' ', last_name) = '#{member.full_name}'
+              AND deleted_at IS NULL;"
     query_pg_db_field(db_credentials, sql, 'email_address').first
   end
 end


### PR DESCRIPTION
Almost all indent changes.  Ripley standalone is meaningless for testing LTI tools, and it adds too much complexity to already complex scripts.